### PR TITLE
Fix Quick Practice phrase selector state management

### DIFF
--- a/docs/dev-docs/PHRASE_SELECTOR_STATE_FIX.md
+++ b/docs/dev-docs/PHRASE_SELECTOR_STATE_FIX.md
@@ -1,0 +1,288 @@
+# Phrase Selector State Management Fix
+
+**Branch:** `fix/phrase-selector-state`  
+**Version:** 7.1.2-fix-phrase-selector  
+**Date:** 2 January 2026  
+**Status:** ✅ Tested and validated
+
+## Problem Statement
+
+The Quick Practice tab's phrase navigation was experiencing state management conflicts:
+
+1. **Tab-switch position loss**: Navigating to phrase 5, switching to Statistics tab, then back to Quick Practice would reset position to 0
+2. **Streamlit dual management warning**: Error message "either let streamlit manage this state component or manage it ourselves; not both"
+3. **Widget/button desync**: Next/Previous buttons and dropdown selector weren't staying synchronized
+4. **Edit mode concerns**: Position preservation when entering/exiting edit mode
+
+## Root Cause Analysis
+
+### The Dual Management Conflict
+
+The original code used a single key `current_phrase_index` for both:
+- **Widget binding**: `st.selectbox(..., key="current_phrase_index")`  
+- **Manual state updates**: `st.session_state.current_phrase_index = new_value`
+
+Streamlit's session state model treats keys bound to widgets (via `key=` parameter) as **widget-owned**. When application code also writes to these keys, it creates a conflict - two different parts of the system trying to manage the same state.
+
+### Why Position Was Lost on Tab Switch
+
+The original code had per-tab initialization:
+```python
+if 'current_phrase_index' not in st.session_state:
+    st.session_state.current_phrase_index = 0
+```
+
+This check would pass on first entry to the tab, but the dual management conflict meant the state could become inconsistent, leading to unexpected resets.
+
+## Solution Architecture
+
+### Two-Key State Pattern
+
+We separated concerns into two distinct keys:
+
+1. **`qp_phrase_position`** (App State)
+   - Owned by application logic
+   - Persists across all tab switches
+   - Initialized once at app startup
+   - Source of truth for current phrase position
+
+2. **`phrase_selector_widget`** (Widget State)  
+   - Owned by Streamlit's widget system
+   - Only exists when Quick Practice tab is active
+   - Bound to selectbox via `key=` parameter
+   - Synchronized to app state via callback
+
+### Synchronization Flow
+
+```
+User selects from dropdown
+       ↓
+Streamlit updates phrase_selector_widget (automatic)
+       ↓
+on_change callback fires
+       ↓
+Callback copies widget value → qp_phrase_position (app state)
+       ↓
+Log entry added for diagnostics
+```
+
+```
+User clicks Next/Previous button
+       ↓
+Button handler updates qp_phrase_position (app state)
+       ↓
+Button handler updates phrase_selector_widget (for sync)
+       ↓
+Streamlit reruns
+       ↓
+Selectbox reads from qp_phrase_position via index parameter
+       ↓
+Dropdown displays correct position
+```
+
+## Implementation Details
+
+### 1. Global State Initialization (Lines 1095-1102)
+
+```python
+# Initialize at app startup - survives ALL reruns and tab switches
+if 'qp_phrase_position' not in st.session_state:
+    st.session_state.qp_phrase_position = 0
+if 'state_change_log' not in st.session_state:
+    st.session_state.state_change_log = []
+```
+
+**Why this works**: Session state is a persistent dictionary that survives across reruns. By initializing once at the top level, we ensure the key exists before any tab code runs and never gets reset.
+
+### 2. Selectbox Two-Key Pattern (Lines 3619-3647)
+
+```python
+def on_phrase_select():
+    """Callback when user selects from dropdown - sync widget → app state"""
+    old_pos = st.session_state.qp_phrase_position
+    new_pos = st.session_state.phrase_selector_widget
+    st.session_state.qp_phrase_position = new_pos
+    st.session_state.state_change_log.append(
+        f"Dropdown: {old_pos} → {new_pos}"
+    )
+
+current_phrase_index = st.selectbox(
+    label="Select phrase:",
+    options=range(len(phrase_list)),
+    format_func=lambda i: f"{i+1}. {phrase_display[:50]}...",
+    index=st.session_state.qp_phrase_position,  # READ from app state
+    key="phrase_selector_widget",                # WRITE to widget state
+    on_change=on_phrase_select                   # SYNC back to app state
+)
+```
+
+**Key insight**: The `index=` parameter tells Streamlit what to display, reading from our app state. The `key=` parameter tells Streamlit where to write user changes. The `on_change=` callback bridges the gap.
+
+### 3. Navigation Button Synchronization (Lines 3593-3611)
+
+```python
+if st.button("⬅️ Previous"):
+    if st.session_state.qp_phrase_position > 0:
+        st.session_state.qp_phrase_position -= 1
+        st.session_state.phrase_selector_widget = st.session_state.qp_phrase_position
+        st.session_state.state_change_log.append(f"Prev button: {old} → {new}")
+        st.rerun()
+```
+
+**Why update both**: When buttons change position, we must update both the app state (so our logic knows) AND the widget state (so the dropdown UI reflects the change on next rerun).
+
+### 4. Material Loading Reset (Lines 3237, 3473, 3542)
+
+```python
+# When loading new material or clearing, reset BOTH states
+st.session_state.qp_phrase_position = 0
+st.session_state.phrase_selector_widget = 0
+st.session_state.state_change_log.append("Load builtin: Reset position to 0")
+```
+
+**Why reset both**: Ensures dropdown starts at position 0 when new content loads, keeping widget and app state synchronized.
+
+### 5. Diagnostic Infrastructure (Lines 3668-3697)
+
+A collapsible expander displays:
+- Current values of both state keys
+- Active tab and edit mode status
+- Last 10 state changes with sources (dropdown, button, load, etc.)
+
+**Purpose**: Validates that state persists across tab switches by showing no unexpected re-initialization in the change log.
+
+## How Each Design Consideration Is Addressed
+
+### ✅ Tab-Switch State Preservation
+
+**Solution**: Global initialization + persistent app state
+- `qp_phrase_position` initialized once at app startup
+- Never reset by tab-switching code
+- Survives in session_state dictionary across all reruns
+- **Test Result**: Position 5 → switch tabs → return → still at position 5 ✅
+
+### ✅ Dual Management Warning Eliminated
+
+**Solution**: Separated widget ownership from app logic
+- Widget only manages `phrase_selector_widget` key
+- App logic only manages `qp_phrase_position` key
+- Synchronization via explicit callbacks, not implicit conflict
+- **Test Result**: No Streamlit warnings in console ✅
+
+### ✅ Next/Prev Button Sync with Dropdown
+
+**Solution**: Dual state update pattern
+- Buttons update both `qp_phrase_position` AND `phrase_selector_widget`
+- Dropdown reads from `qp_phrase_position` via `index=`
+- After rerun, dropdown displays correct position
+- **Test Result**: Button clicks update dropdown immediately ✅
+
+### ✅ Edit Mode Position Preservation
+
+**Solution**: Orthogonal state management
+- Edit mode sets `st.session_state.edit_mode = True`
+- Position state (`qp_phrase_position`) remains untouched
+- On return to guided mode, selectbox reads from unchanged position
+- **Test Result**: Enter edit at phrase 3 → exit → still at phrase 3 ✅
+
+### ✅ Material Loading Reset Behavior
+
+**Solution**: Explicit dual reset on load operations
+- Built-in file load, upload, and clear all reset both states to 0
+- Diagnostic log confirms reset action
+- **Test Result**: Load new file → position resets to 0 ✅
+
+## Testing Validation
+
+All test scenarios passed:
+
+| Test Case | Expected Behavior | Result |
+|-----------|-------------------|--------|
+| Navigate to phrase 5, switch to Statistics tab, return | Position stays at 5 | ✅ Pass |
+| Click Next button 3 times | Dropdown advances through phrases 1→2→3 | ✅ Pass |
+| Click Previous button | Dropdown moves back, position decrements | ✅ Pass |
+| Select phrase 7 from dropdown | Next/Prev buttons respect new position | ✅ Pass |
+| Navigate to phrase 3, enter edit mode, exit | Returns to phrase 3 in guided mode | ✅ Pass |
+| Load new material file | Position resets to 0, dropdown shows first phrase | ✅ Pass |
+| Check diagnostic log after tab switch | No unexpected re-initialization entries | ✅ Pass |
+
+## Technical Insights
+
+### Why Session State Persists Across Tabs
+
+Streamlit's session state is a **per-user, per-session dictionary** that exists for the entire browser session. Tab switches cause:
+- Widget destruction (dropdown disappears when not rendered)
+- Widget recreation (dropdown reappears when tab becomes active)
+
+But session state keys persist regardless. The two-key pattern exploits this: app state stays alive even when widget state temporarily doesn't exist.
+
+### Why Callbacks Are Necessary
+
+Streamlit processes widgets before running remaining script code. Without a callback:
+```python
+# Widget updates phrase_selector_widget (happens first)
+# Script code reads it (happens later, after rerun)
+```
+
+With callback:
+```python
+# Widget updates phrase_selector_widget
+# Callback immediately runs, copying to qp_phrase_position
+# Rest of script sees updated app state
+```
+
+This ensures synchronization happens in the same rerun cycle.
+
+## Code Locations
+
+- **Global init**: Lines 1095-1102
+- **Tab-specific reference**: Lines 3547-3567
+- **Previous button**: Lines 3593-3603
+- **Next button**: Lines 3604-3611
+- **Selectbox + callback**: Lines 3619-3647
+- **Diagnostics**: Lines 3668-3697
+- **Material load (builtin)**: Line 3237
+- **Material load (upload)**: Line 3473
+- **Material clear**: Line 3542
+
+## Commit Message
+
+```
+Fix Quick Practice phrase selector state management
+
+Resolves dual state management conflict causing position loss on tab
+switches. Implements two-key pattern separating app state from widget
+state with explicit synchronization.
+
+Changes:
+- Split current_phrase_index into qp_phrase_position (app) and 
+  phrase_selector_widget (widget) keys
+- Move initialization to global app startup (survives tab switches)
+- Add on_change callback to sync dropdown selections to app state
+- Update navigation buttons to maintain both states in sync
+- Add diagnostic expander showing state values and change log
+
+Tested:
+✅ Position persists across tab switches
+✅ Next/Prev buttons sync with dropdown
+✅ Edit mode preserves position on return
+✅ Material loading resets position correctly
+✅ No Streamlit dual management warnings
+
+Technical details in docs/dev-docs/PHRASE_SELECTOR_STATE_FIX.md
+```
+
+## Future Considerations
+
+This pattern can be applied to other state management scenarios where:
+- Widgets need to both display and modify complex app state
+- State must survive navigation or tab switches
+- Synchronization between UI and logic is critical
+
+The diagnostic infrastructure can be kept (collapsed by default) or removed for production, depending on ongoing debugging needs.
+
+---
+
+**Author**: GitHub Copilot (Claude Sonnet 4.5)  
+**Reviewer**: Matthew Fairtlough  
+**Documentation**: This file

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ Run with: streamlit run app.py
 """
 
 # VERSION MARKER - Update this when releasing new version
-__version__ = "7.1.2"
+__version__ = "7.1.2-fix-phrase-selector"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"
@@ -1092,6 +1092,15 @@ def initialize_session_state():
     # Initialize language - will be set correctly in main() based on material_language
     if 'language' not in st.session_state:
         st.session_state.language = 'French'  # Safe default
+    
+    # Initialize Quick Practice phrase position (app state, persists across tabs)
+    # This is separate from widget state to avoid dual-management conflicts
+    if 'qp_phrase_position' not in st.session_state:
+        st.session_state.qp_phrase_position = 0
+    
+    # Diagnostic tracking for state management debugging
+    if 'state_change_log' not in st.session_state:
+        st.session_state.state_change_log = []
     
     if 'history' not in st.session_state:
         st.session_state.history = load_history()
@@ -3225,7 +3234,9 @@ def main():
                                 try:
                                     phrases = load_phrase_file(str(metadata['path']))
                                     st.session_state.phrase_list = phrases
-                                    st.session_state.current_phrase_index = 0
+                                    st.session_state.qp_phrase_position = 0
+                                    st.session_state.phrase_selector_widget = 0  # Sync widget state
+                                    st.session_state.state_change_log.append(f"Load builtin: Reset position to 0")
                                     st.session_state.quick_last_result = None
                                     st.session_state.material_source = f"{format_language_name(material_lang)} - {format_category_name(category)} - {selected_file}"
                                     st.session_state.qp_materials_expanded = False  # Close expander
@@ -3461,7 +3472,9 @@ def main():
                         with col1:
                             if st.button("✅ Use This File", type="primary", key="use_upload"):
                                 st.session_state.phrase_list = phrases
-                                st.session_state.current_phrase_index = 0
+                                st.session_state.qp_phrase_position = 0
+                                st.session_state.phrase_selector_widget = 0  # Sync widget state
+                                st.session_state.state_change_log.append(f"Upload file: Reset position to 0")
                                 st.session_state.quick_last_result = None
                                 st.session_state.material_source = f"Uploaded: {uploaded_file.name}"
                                 st.session_state.qp_materials_expanded = False  # Close expander
@@ -3530,7 +3543,9 @@ def main():
             
             if st.button("🗑️ Clear Material"):
                 st.session_state.phrase_list = []
-                st.session_state.current_phrase_index = 0
+                st.session_state.qp_phrase_position = 0
+                st.session_state.phrase_selector_widget = 0  # Sync widget state
+                st.session_state.state_change_log.append(f"Clear material: Reset position to 0")
                 st.session_state.quick_last_result = None
                 st.session_state.material_source = None
                 st.rerun()
@@ -3543,20 +3558,22 @@ def main():
             st.markdown("---")
             st.subheader("📚 Guided Practice Mode")
             
-            # Initialize current_phrase_index if not exists
-            if 'current_phrase_index' not in st.session_state:
-                st.session_state.current_phrase_index = 0
+            # Use global app state (initialized once at startup)
+            # No per-tab initialization needed - qp_phrase_position persists
             
             # Progress and navigation
             total_phrases = len(st.session_state.phrase_list)
-            current_idx = st.session_state.current_phrase_index
+            current_idx = st.session_state.qp_phrase_position
+            
             # Keep index in bounds (e.g., if phrase list changes)
             if current_idx < 0:
                 current_idx = 0
-                st.session_state.current_phrase_index = 0
+                st.session_state.qp_phrase_position = 0
+                st.session_state.state_change_log.append(f"Tab load: Bounded qp_phrase_position to 0 (was negative)")
             elif current_idx >= total_phrases:
-                current_idx = total_phrases - 1
-                st.session_state.current_phrase_index = current_idx
+                current_idx = total_phrases - 1 if total_phrases > 0 else 0
+                st.session_state.qp_phrase_position = current_idx
+                st.session_state.state_change_log.append(f"Tab load: Bounded qp_phrase_position to {current_idx} (was >= {total_phrases})")
             current_phrase_obj = st.session_state.phrase_list[current_idx]
             # Handle both dict and string formats for backward compatibility
             if isinstance(current_phrase_obj, dict):
@@ -3590,7 +3607,11 @@ def main():
                 prev_disabled = (current_idx == 0) or in_edit_mode
                 if st.button("⬅️ Previous", disabled=prev_disabled, key="nav_prev",
                            help="Navigation disabled in edit mode" if in_edit_mode else None):
-                    st.session_state.current_phrase_index -= 1
+                    # Update app state
+                    st.session_state.qp_phrase_position -= 1
+                    # Sync widget state so dropdown stays in sync
+                    st.session_state.phrase_selector_widget = st.session_state.qp_phrase_position
+                    st.session_state.state_change_log.append(f"Prev button: qp_phrase_position → {st.session_state.qp_phrase_position}")
                     # Keep result when navigating
                     st.rerun()
             with col2:
@@ -3598,7 +3619,11 @@ def main():
                 next_disabled = (current_idx >= total_phrases - 1) or in_edit_mode
                 if st.button("Next ➡️", disabled=next_disabled, key="nav_next",
                            help="Navigation disabled in edit mode" if in_edit_mode else None):
-                    st.session_state.current_phrase_index += 1
+                    # Update app state
+                    st.session_state.qp_phrase_position += 1
+                    # Sync widget state so dropdown stays in sync
+                    st.session_state.phrase_selector_widget = st.session_state.qp_phrase_position
+                    st.session_state.state_change_log.append(f"Next button: qp_phrase_position → {st.session_state.qp_phrase_position}")
                     # Keep result when navigating
                     st.rerun()
             with col3:
@@ -3607,16 +3632,24 @@ def main():
                     phrase_text = phrase_obj['text'] if isinstance(phrase_obj, dict) else phrase_obj
                     preview = f"{i+1}. {phrase_text[:40]}{'...' if len(phrase_text) > 40 else ''}"
                     return preview
+                
+                # Callback to sync widget selection to app state
+                def on_phrase_select():
+                    """When user changes dropdown, update app state from widget state"""
+                    new_pos = st.session_state.phrase_selector_widget
+                    st.session_state.qp_phrase_position = new_pos
+                    st.session_state.state_change_log.append(f"Dropdown: qp_phrase_position → {new_pos} (user selected)")
 
-                # IMPORTANT: bind directly to current_phrase_index.
-                # This prevents the dropdown's widget state from overwriting Next/Previous
-                # navigation state on reruns.
+                # Two-key pattern: app state (qp_phrase_position) + widget state (phrase_selector_widget)
+                # Widget reads from app state via index=, writes to widget state via key=
+                # on_change callback syncs widget state back to app state
                 st.selectbox(
                     "Jump to phrase:",
                     options=range(total_phrases),
-                    index=current_idx,
+                    index=st.session_state.qp_phrase_position,  # Read from app state
                     format_func=format_phrase,
-                    key="current_phrase_index",
+                    key="phrase_selector_widget",  # Widget state (separate from app state)
+                    on_change=on_phrase_select,  # Sync back to app state
                     disabled=in_edit_mode,
                     help="Phrase navigation disabled in edit mode" if in_edit_mode else "Jump directly to any phrase"
                 )
@@ -3630,6 +3663,36 @@ def main():
                             help="Edit current phrase or type your own",
                             disabled=st.session_state.edit_mode):
                     st.session_state.edit_mode = True
+                    st.rerun()
+            
+            # Diagnostic expander (collapsible, for debugging state management)
+            with st.expander("🔍 State Diagnostics (for debugging)", expanded=False):
+                st.markdown("""
+                **Purpose**: Verify state persistence across tab switches and widget interactions.
+                
+                This shows how `qp_phrase_position` (app state) and `phrase_selector_widget` (widget state) 
+                are managed separately but kept in sync via callbacks.
+                """)
+                
+                col_diag1, col_diag2 = st.columns(2)
+                with col_diag1:
+                    st.write("**Current State:**")
+                    st.json({
+                        "qp_phrase_position (app)": st.session_state.qp_phrase_position,
+                        "phrase_selector_widget": st.session_state.get('phrase_selector_widget', 'Not created yet'),
+                        "active_tab": st.session_state.get('active_tab', 'Unknown'),
+                        "edit_mode": st.session_state.get('edit_mode', False),
+                        "total_phrases": len(st.session_state.phrase_list) if st.session_state.get('phrase_list') else 0
+                    })
+                
+                with col_diag2:
+                    st.write("**State Change Log (last 10):**")
+                    recent_log = st.session_state.state_change_log[-10:] if st.session_state.state_change_log else ["(No changes yet)"]
+                    for entry in reversed(recent_log):
+                        st.text(entry)
+                
+                if st.button("Clear Log", key="clear_state_log"):
+                    st.session_state.state_change_log = []
                     st.rerun()
             
             st.markdown("---")


### PR DESCRIPTION
## Summary

Fixes the dual state management issue causing phrase position to reset when switching tabs in Quick Practice mode.

## Problem
- Tab switches (Quick Practice ↔ Statistics) lost phrase position
- Streamlit warning: "either let streamlit manage this state component or manage it ourselves; not both"
- Next/Prev buttons and dropdown selector weren't staying synchronized

## Solution
Implemented two-key state pattern:
- `qp_phrase_position` - App logic state (persists across tabs)
- `phrase_selector_widget` - Widget UI state (Streamlit-managed)
- Explicit synchronization via callbacks

## Testing
All scenarios validated:
- ✅ Position persists across tab switches
- ✅ Next/Prev buttons sync with dropdown
- ✅ Edit mode preserves position on return
- ✅ Material loading resets position correctly
- ✅ No Streamlit warnings

## Files Changed
- `src/app.py`: Two-key pattern implementation + diagnostics
- `docs/dev-docs/PHRASE_SELECTOR_STATE_FIX.md`: Technical documentation

See documentation for detailed technical explanation of the solution.