### PR TITLE
Bump version to 7.1.7-claude-dev-phase4

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.1.7-claude-dev-phase4] - 2026-04-05
+
+### Changed
+
+- Version bump
+
+
 ## [7.1.6-claude-dev-phase2] - 2026-04-05
 
 ### Changed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.1.6-claude-dev-phase2"
+__version__ = "7.1.7-claude-dev-phase4"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Summary

- Version bumped `7.1.6-claude-dev-phase2` → `7.1.7-claude-dev-phase4`
- Tag `v7.1.7-claude-dev-phase4` pushed
- Marks merge of Phase 4: UI layer extraction into `src/ui/` package

## Note for future phases

Going forward, the version bump + tag will be included in the phase PR itself, not as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)