### PR TITLE
fix: bootstrap connection generator bug + debug log SSH guard

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.1.11-claude-dev] - 2026-04-06
+
+### Fixed
+
+- **Bootstrap connection generator bug**: `get_connection()` pre-auth path called
+  `pool.get_bootstrap_connection()` without `with`, storing a `_GeneratorContextManager`
+  in session state instead of a real MySQL connection. Every subsequent `.cursor()` call
+  failed. Fixed by adding `ConnectionPool.get_direct_connection()` which returns a real
+  connection object, reusing existing tunnels when available.
+- **`write_debug_log` crash on missing SSH secrets**: On environments without `[ssh]` in
+  `st.secrets` (e.g. Streamlit Cloud), `write_debug_log()` raised `KeyError` inside its
+  own error handler, creating log noise. Added a guard that returns early when SSH secrets
+  are absent, plus a `None` check on the connection.
+- Added `tests/test_connection.py` covering both fixes.
+
+
 ## [7.1.10-claude-dev] - 2026-04-06
 
 ### Fixed

--- a/src/app_mysql.py
+++ b/src/app_mysql.py
@@ -319,11 +319,11 @@ def get_connection() -> mysql.connector.MySQLConnection:
     # Pre-auth: Use single bootstrap connection (untracked, temporary)
     # Post-auth: Switch to tracked connection from pool (permanent until logout)
     if not st.session_state.get('authenticated', False):
-        # Not authenticated - use bootstrap connection (unlimited, not tracked)
+        # Not authenticated - use direct connection (not tracked, not a context manager)
         # Store it for reuse until login, then it will be closed during handover
         if 'db_connection' not in st.session_state:
             print("⚠️ Creating bootstrap connection for unauthenticated user (temporary, not tracked)")
-            conn = pool.get_bootstrap_connection()
+            conn = pool.get_direct_connection()
             st.session_state.db_connection = conn
         else:
             conn = st.session_state.db_connection
@@ -339,7 +339,7 @@ def get_connection() -> mysql.connector.MySQLConnection:
                     conn.close()
                 except:
                     pass
-                conn = pool.get_bootstrap_connection()
+                conn = pool.get_direct_connection()
                 st.session_state.db_connection = conn
         return conn
     
@@ -1323,6 +1323,10 @@ def write_debug_log(
     """
     conn = None
     try:
+        # Guard: if SSH secrets not available, skip silently
+        if 'ssh' not in st.secrets:
+            return  # graceful no-op on environments without SSH tunnel
+
         # Detect environment
         try:
             # Check if running on Streamlit Cloud
@@ -1331,11 +1335,13 @@ def write_debug_log(
             environment = 'deployed' if 'streamlit' in hostname.lower() else 'local'
         except:
             environment = 'unknown'
-        
+
         # Extract partial session ID for correlation (privacy)
         session_id_partial = session_id[:8] if session_id else None
-        
+
         conn = get_connection()
+        if conn is None:
+            return  # no connection available pre-auth
         cursor = conn.cursor()
         
         # Insert log entry

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.1.10-claude-dev"
+__version__ = "7.1.11-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/connection_pool.py
+++ b/src/connection_pool.py
@@ -317,14 +317,61 @@ class ConnectionPool:
         tunnel.start()
         return tunnel
     
+    def get_direct_connection(self):
+        """
+        Return a real MySQL connection object (not a context manager) using
+        an available tracked tunnel from the pool, or creating one if needed.
+        For pre-auth ephemeral use where storing in session state is required.
+        Caller is responsible for closing when done.
+        """
+        # Reuse first available healthy tunnel
+        for tunnel_info in self.tunnel_pool.values():
+            if tunnel_info.status == 'active' and self._is_tunnel_healthy(tunnel_info):
+                conn = mysql.connector.connect(
+                    host='127.0.0.1',
+                    port=tunnel_info.local_port,
+                    database=self.secrets['mysql']['database'],
+                    user=self.secrets['mysql']['user'],
+                    password=self.secrets['mysql']['password'],
+                    connect_timeout=10,
+                    use_pure=True,
+                )
+                return conn
+
+        # No existing tunnel — create a temporary one via bootstrap
+        tunnel = self.create_ssh_tunnel()
+        conn = mysql.connector.connect(
+            host='127.0.0.1',
+            port=tunnel.local_bind_port,
+            database=self.secrets['mysql']['database'],
+            user=self.secrets['mysql']['user'],
+            password=self.secrets['mysql']['password'],
+            connect_timeout=10,
+            use_pure=True,
+        )
+        # Store tunnel in pool so it can be reused (avoid proliferation)
+        tunnel_id = f"bootstrap_{self._next_tunnel_index}"
+        self._next_tunnel_index += 1
+        self.tunnel_pool[tunnel_id] = TunnelInfo(
+            tunnel_id=tunnel_id,
+            tunnel_obj=tunnel,
+            pid=self.get_tunnel_pid(tunnel),
+            local_port=tunnel.local_bind_port,
+            created_at=datetime.now(),
+            last_used=datetime.now(),
+            status='active',
+            connection_count=0,
+        )
+        return conn
+
     @contextmanager
     def get_bootstrap_connection(self):
         """
         Context manager for TRULY EPHEMERAL MySQL connection.
         Creates temporary tunnel → connection → automatically closes both.
-        
+
         CRITICAL: Prevents tunnel proliferation (125 SSH tunnel limit).
-        
+
         Usage:
             with pool.get_bootstrap_connection() as conn:
                 cursor = conn.cursor()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,130 @@
+"""
+Tests for connection pool and debug log fixes.
+
+Bug 1: get_connection() pre-auth path must not store a generator (context manager).
+Bug 2: write_debug_log() must return gracefully when 'ssh' not in secrets.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+from contextlib import contextmanager
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+class TestGetDirectConnection:
+    """ConnectionPool.get_direct_connection() returns a real connection, not a generator."""
+
+    def test_returns_real_connection_not_generator(self):
+        """get_direct_connection() must return a mysql connection, not a _GeneratorContextManager."""
+        from connection_pool import ConnectionPool
+
+        pool = ConnectionPool({
+            'ssh': {'host': 'h', 'port': 22, 'username': 'u', 'key_path': '/dev/null'},
+            'mysql': {'host': '127.0.0.1', 'port': 3306, 'database': 'db', 'user': 'u', 'password': 'p'},
+        })
+
+        fake_conn = MagicMock()
+        fake_tunnel = MagicMock()
+        fake_tunnel.local_bind_port = 13306
+
+        with patch.object(pool, 'create_ssh_tunnel', return_value=fake_tunnel), \
+             patch.object(pool, 'get_tunnel_pid', return_value=123), \
+             patch('connection_pool.mysql.connector.connect', return_value=fake_conn):
+            conn = pool.get_direct_connection()
+
+        # Must be the real connection object, not a generator/context manager
+        assert conn is fake_conn
+        assert not hasattr(conn, '__enter__') or not hasattr(conn, '__exit__') or isinstance(conn, MagicMock)
+
+    def test_reuses_existing_healthy_tunnel(self):
+        """get_direct_connection() should prefer an existing healthy tunnel."""
+        from connection_pool import ConnectionPool, TunnelInfo
+        from datetime import datetime
+
+        pool = ConnectionPool({
+            'ssh': {'host': 'h', 'port': 22, 'username': 'u', 'key_path': '/dev/null'},
+            'mysql': {'host': '127.0.0.1', 'port': 3306, 'database': 'db', 'user': 'u', 'password': 'p'},
+        })
+
+        fake_tunnel = MagicMock()
+        fake_tunnel.is_active = True
+        fake_tunnel.local_bind_port = 13306
+
+        pool.tunnel_pool['tunnel_0'] = TunnelInfo(
+            tunnel_id='tunnel_0',
+            tunnel_obj=fake_tunnel,
+            pid=100,
+            local_port=13306,
+            created_at=datetime.now(),
+            last_used=datetime.now(),
+            status='active',
+            connection_count=1,
+        )
+
+        fake_conn = MagicMock()
+        with patch('connection_pool.mysql.connector.connect', return_value=fake_conn):
+            conn = pool.get_direct_connection()
+
+        assert conn is fake_conn
+
+
+class TestBootstrapConnectionIsContextManager:
+    """get_bootstrap_connection() must remain a context manager (not broken by our changes)."""
+
+    def test_is_context_manager(self):
+        from connection_pool import ConnectionPool
+
+        pool = ConnectionPool({
+            'ssh': {'host': 'h', 'port': 22, 'username': 'u', 'key_path': '/dev/null'},
+            'mysql': {'host': '127.0.0.1', 'port': 3306, 'database': 'db', 'user': 'u', 'password': 'p'},
+        })
+
+        result = pool.get_bootstrap_connection()
+        # Must be a context manager (generator-based)
+        assert hasattr(result, '__enter__') and hasattr(result, '__exit__')
+
+
+class TestWriteDebugLogSSHGuard:
+    """write_debug_log() must return gracefully when 'ssh' not in st.secrets."""
+
+    def test_returns_when_ssh_missing(self):
+        """write_debug_log should no-op when SSH secrets are absent."""
+        mock_secrets = MagicMock()
+        mock_secrets.__contains__ = lambda self, key: key != 'ssh'
+
+        with patch('app_mysql.st') as mock_st:
+            mock_st.secrets = mock_secrets
+            mock_st.session_state = {}
+
+            # Import after patching
+            import app_mysql
+            # Should return without error (no connection attempt)
+            app_mysql.write_debug_log(
+                event_type='test',
+                message='test message',
+            )
+            # If we get here without exception, the guard works
+
+    def test_proceeds_when_ssh_present(self):
+        """write_debug_log should attempt connection when SSH secrets exist."""
+        mock_secrets = MagicMock()
+        mock_secrets.__contains__ = lambda self, key: True
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch('app_mysql.st') as mock_st, \
+             patch('app_mysql.get_connection', return_value=mock_conn):
+            mock_st.secrets = mock_secrets
+            mock_st.session_state = {'authenticated': True, 'user': {'user_id': 1}}
+
+            import app_mysql
+            app_mysql.write_debug_log(
+                event_type='test',
+                message='test message',
+            )
+            # Should have attempted to use connection
+            mock_conn.cursor.assert_called()


### PR DESCRIPTION
## Summary
- **Bug 1**: `get_connection()` pre-auth path stored a `_GeneratorContextManager` (from `pool.get_bootstrap_connection()` called without `with`) in session state. Every subsequent `.cursor()` call failed. Added `ConnectionPool.get_direct_connection()` returning a real connection object, reusing existing tunnels.
- **Bug 2**: `write_debug_log()` crashed with `KeyError` when SSH secrets were absent (Streamlit Cloud). Added early-return guard.
- Version bump to `7.1.11-claude-dev`

## Test plan
- [x] `tests/test_connection.py` — 5 new tests covering both fixes
- [x] Full suite: 89 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)