### PR TITLE
fix: login language persistence + widget warning

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -72,16 +72,28 @@ def _load_settings():
     return _config_load_settings(session_state=st.session_state, db_module=app_mysql)
 
 
-def _resolve_and_lock_source_language():
+def _resolve_and_lock_languages():
     """
-    Resolve source language from login-form selection, lock it in session state.
+    Resolve source AND target language from login-form selection, lock in session state.
     Called after every successful login path (regular, guest, cookie re-attach).
+
     Source language is session-only — not read from or written to the database.
+    Target language (material_language) is persisted so the sidebar selectbox
+    picks it up on the first post-login render.
     """
+    # ── Source language ──────────────────────────────────────────────────────
     _login_source = st.session_state.get('_login_source_lang')
     _chosen_source = _login_source or 'English'
     st.session_state['source_language'] = _chosen_source
     st.session_state.setdefault('settings', {})['source_language'] = _chosen_source
+
+    # ── Target language ──────────────────────────────────────────────────────
+    _login_target = st.session_state.get('_login_target_lang')
+    if _login_target and _login_target in LANGUAGE_CONFIG:
+        target_code = LANGUAGE_CONFIG[_login_target]['code']
+        st.session_state['material_language'] = target_code
+        st.session_state['language'] = MATERIAL_TO_TRAINING.get(target_code, _login_target)
+        st.session_state['target_language'] = target_code
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +282,7 @@ def show_login_page():
 
                             # Reload settings from database (using new tracked connection)
                             st.session_state.settings = _load_settings()
-                            _resolve_and_lock_source_language()
+                            _resolve_and_lock_languages()
                             st.success(f"✅ Welcome back, {user['username']}!")
                             st.rerun()
                         else:
@@ -367,7 +379,7 @@ def show_login_page():
 
                 # Reload settings from database (will have defaults for new guest)
                 st.session_state.settings = _load_settings()
-                _resolve_and_lock_source_language()
+                _resolve_and_lock_languages()
                 st.success(f"✅ Welcome, Guest! Enjoy exploring Miolingo!")
                 st.rerun()
             else:
@@ -399,7 +411,7 @@ def check_authentication():
                 st.session_state['user'] = context.user
                 st.session_state['session_id'] = context.session_id
                 st.session_state.settings = _load_settings()
-                _resolve_and_lock_source_language()
+                _resolve_and_lock_languages()
 
     # Check if authenticated
     if not st.session_state['authenticated']:

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -161,23 +161,25 @@ def render_settings_panel():
             _source_code = get_language_code(st.session_state.get("source_language", "English"))
             _target_options = [m for m in available_materials if m != _source_code]
 
-            current_idx = 0
-            if 'material_language' in st.session_state:
-                try:
-                    current_idx = _target_options.index(st.session_state.material_language)
-                except ValueError:
-                    pass
-            elif 'material_language' in st.session_state.settings:
-                try:
-                    current_idx = _target_options.index(st.session_state.settings['material_language'])
-                except ValueError:
-                    pass
+            # Ensure material_language is set to a valid option BEFORE the
+            # widget renders.  The selectbox with key= reads its value from
+            # session state — we must NOT also pass index= or Streamlit warns
+            # about conflicting defaults.
+            if 'material_language' not in st.session_state:
+                # First render — pick from saved settings or first available
+                _saved = st.session_state.settings.get('material_language')
+                st.session_state.material_language = (
+                    _saved if _saved in _target_options
+                    else _target_options[0] if _target_options else 'fr'
+                )
+            elif st.session_state.material_language not in _target_options:
+                # Current value was filtered out (e.g. source language changed)
+                st.session_state.material_language = _target_options[0] if _target_options else 'fr'
 
             previous_material_language = st.session_state.get('material_language', None)
             st.selectbox(
                 "Target Language",
                 _target_options,
-                index=current_idx,
                 format_func=format_language_name,
                 help="Language being learned (IPA + practice target)",
                 key="material_language"


### PR DESCRIPTION
## Summary
- **Login language persistence**: Renamed `_resolve_and_lock_source_language()` → `_resolve_and_lock_languages()` to persist both source AND target language from login page selections. Fixes issue where DB settings (e.g. Portuguese) overrode login page choices after form submit.
- **Widget warning fix**: Sidebar `material_language` selectbox no longer passes `index=` — value is managed solely via session state before widget renders. Eliminates the recurring "created with default value but also set via Session State API" warning.
- Works correctly with cookie re-attach (respects previous session's language choice).

## Test plan
- [x] Syntax check modified files
- [x] Server starts without errors
- [x] Cookie re-attach preserves previous language selection
- [x] No widget state warning in console or server logs
- [x] Manual: logout, select non-default languages, login → verify selections persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)