### PR TITLE
fix: positional algorithm crash after removal

### DIFF
--- a/src/scoring/comparison.py
+++ b/src/scoring/comparison.py
@@ -116,7 +116,5 @@ def compare_phonemes(user_phonemes: str, correct_phonemes: str,
         similarity: float (0.0 to 1.0)
         distance: int (only for edit_distance, None otherwise)
     """
-    if algorithm == "edit_distance":
-        return compare_phonemes_edit_distance(user_phonemes, correct_phonemes)
-    else:
-        raise ValueError(f"Unknown algorithm: {algorithm}")
+    # "positional" was removed; fall back to edit_distance for any unknown value
+    return compare_phonemes_edit_distance(user_phonemes, correct_phonemes)


### PR DESCRIPTION
## Summary
- `compare_phonemes()` raised `ValueError: Unknown algorithm: positional` after the positional implementation was deleted in the code quality sweep — but the "positional" option is still selectable in user settings.
- Fix: remove the raise and fall back to `edit_distance` for any unrecognised algorithm value.

## Root cause
The code quality sweep deleted `compare_phonemes_positional()` correctly (it was dead code with no callers from new code), but missed that the `positional` string is still a valid saved user setting. Any user with this setting saved would crash on scoring.

## Test plan
- [x] Syntax check
- [ ] Manual: set Scoring Algorithm to "positional" in sidebar, record audio — should score without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)