### PR TITLE
fix: restore PT narrative order in unified story scenes (v7.3.6)

### DIFF
--- a/language_materials/unified/phrasebook/asking-for-help.json
+++ b/language_materials/unified/phrasebook/asking-for-help.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/basics.json
+++ b/language_materials/unified/phrasebook/basics.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/conversation.json
+++ b/language_materials/unified/phrasebook/conversation.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/courtesy-basics.json
+++ b/language_materials/unified/phrasebook/courtesy-basics.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/directions.json
+++ b/language_materials/unified/phrasebook/directions.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/exclamations.json
+++ b/language_materials/unified/phrasebook/exclamations.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/farewells.json
+++ b/language_materials/unified/phrasebook/farewells.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/feelings-emotions.json
+++ b/language_materials/unified/phrasebook/feelings-emotions.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/greetings.json
+++ b/language_materials/unified/phrasebook/greetings.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/introductions.json
+++ b/language_materials/unified/phrasebook/introductions.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/restaurant.json
+++ b/language_materials/unified/phrasebook/restaurant.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrasebook/shopping.json
+++ b/language_materials/unified/phrasebook/shopping.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrases/common-phrases-001.json
+++ b/language_materials/unified/phrases/common-phrases-001.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrases/common-phrases-003.json
+++ b/language_materials/unified/phrases/common-phrases-003.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrases/common-phrases-004.json
+++ b/language_materials/unified/phrases/common-phrases-004.json
@@ -12,7 +12,7 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/phrases/common-phrases-005.json
+++ b/language_materials/unified/phrases/common-phrases-005.json
@@ -11,7 +11,7 @@
             "it",
             "nl"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [

--- a/language_materials/unified/stories/scene-01.json
+++ b/language_materials/unified/stories/scene-01.json
@@ -24,12 +24,105 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-01-001",
+            "text": {
+                "fr": "Le soleil se lève doucement sur Paris.",
+                "en": "The sun rises gently over Paris.",
+                "de": "Die Sonne geht langsam über Berlin auf.",
+                "it": "Il sole sorge lentamente su Roma.",
+                "es": "El sol se levanta suavemente sobre Madrid.",
+                "nl": "De zon komt langzaam op over Amsterdam.",
+                "pt": "O sol nasce suavemente sobre São Paulo.",
+                "en_pt": "The sun rises gently over São Paulo."
+            },
+            "ipa": {
+                "fr": "lə- sɔlˈɛj sə- lˈɛv dusmˈɑ̃ syʁ paʁˈi",
+                "de": "[diː ˈzɔnə ɡeːt ˈlaŋzam ˈyːbɐ bɛɐ̯ˈliːn aʊ̯f]",
+                "it": "[ˌil sˈoːle sˈoːrdʒe lˌentamˈente sˌʊ rˈɔːma]",
+                "es": "[el sol se leˈβanta swaβeˈmente ˈsoβɾe maˈðɾið]",
+                "nl": "[də zˈɔn kˈɔmt lˈɑŋzaːm ɔp ˈoːvər ˈɑmstərdˌɑm]",
+                "pt": "[ʊ sˈɔl nˈasy sˌuavemˈeɪŋtʃy sˈobry sɐ̃ʊ̃ pˈaʊlʊ]",
+                "en": "[ðə sˈʌn ɹˈaɪzɪz dʒˈɛntli ˌəʊvə pˈaɹɪs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-002",
+            "text": {
+                "fr": "Les rues du Marais commencent à s'animer.",
+                "en": "The streets of the Marais begin to come alive.",
+                "de": "Die Straßen von Kreuzberg beginnen sich zu beleben.",
+                "it": "Le strade di Trastevere cominciano a prendere vita.",
+                "es": "Las calles de Malasaña empiezan a animarse.",
+                "nl": "De straten van De Pijp beginnen te bruisen.",
+                "pt": "As ruas da Vila Madalena começam a ganhar vida.",
+                "en_pt": "The streets of Vila Madalena begin to come alive."
+            },
+            "ipa": {
+                "fr": "le- ʁˈy dy- maʁˈɛ kɔmˈɑ̃st a sanimˈe",
+                "de": "[diː ˈʃtʁaːsn̩ fɔn ˈkʁɔɪ̯t͡sˌbɛʁk bəˈɡɪnən zɪç t͡su bəˈleːbn̩]",
+                "it": "[lˌe strˈaːde dˌɪ trastˈevere komˈintʃano ˌa prˈendere vˈiːta]",
+                "es": "[las ˈkaʎes ðe malaˈsaɲa emˈpjɛθan a aˈni.maɾse]",
+                "nl": "[də strˈaːtən vɑn də pˈɛɪ pəɣˈɪnən tə brˈœyzən]",
+                "pt": "[az xˈuæz da vˈilæ mˌadalˈenæ kˌomˈɛsɐ̃ʊ̃ a ɡɐ̃ɲˈar vˈidæ]",
+                "en": "[ðə stɹˈiːts ɒvðə mˈaɹaɪz bɪɡˈɪn tə kˈʌm ɐlˈaɪv]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-003",
+            "text": {
+                "fr": "Sophie Moreau entre dans son café préféré, un petit endroit chaleureux au coin de la rue des Rosiers.",
+                "en": "Sophie Moreau enters her favorite café, a small cozy place on the corner of Rue des Rosiers.",
+                "de": "Sophie Müller betritt ihr Lieblingscafé, eine gemütliche kleine Ecke an der Ecke der Wiener Straße.",
+                "it": "Sophie Romano entra nel suo caffè preferito, un piccolo posto accogliente all'angolo della strada.",
+                "es": "Sophie Moreno entra en su cafetería favorita, un lugar acogedor en la esquina.",
+                "nl": "Sophie de Vries loopt haar favoriete café binnen, een knus plekje op de hoek van de Albert Cuypstraat.",
+                "pt": "Sophie Moreira entra em seu café preferido, um lugar acolhedor na esquina da rua Aspicuelta.",
+                "en_pt": "Sophie Moreira enters her favorite café, a cozy place on the corner of Aspicuelta street."
+            },
+            "ipa": {
+                "fr": "sɔfˈi mɔʁˈo ɑ̃tʁ dɑ̃ sɔ̃ kafˈe pʁefeʁˈe œ̃ pətˈit ɑ̃dʁwˈa ʃaløʁˈøz o kwˈɛ̃ də- la- ʁˈy de- ʁozjˈe",
+                "de": "[ˈzoːfi ˈmʏlɐ bəˈtʁɪt iːɐ ˈliːblɪŋskaˌfeː ˈaɪ̯nə ɡəˈmyːtlɪçə ˈklaɪ̯nə ˈɛkə an dɐ ˈɛkə dɐ ˈviːnɐ ˈʃtʁaːsə]",
+                "it": "[sˈopje romˈaːno ˈentra nˌɛl sˌʊo kaffˈɛ prˌeferˈiːto\n ˌʊn pˈikːolo pˈosto ˌakːoʎˈɛnte allˈaŋɡolo dˌɛlla strˈaːda]",
+                "es": "[ˈsofi moˈɾeno ˈentɾa en su kafeˈteɾja faβoˈɾita un luˈɣaɾ akoˈxeðoɾ en la esˈkina]",
+                "nl": "[sɔphˈi də vrˈis lˈoːpt haːr fˌaːvoːrˈitə kaːfˈeː bˈɪnən\n ən knˈɵs plˈɛkjə ɔp də hˈuk vɑn də ˈɑlbɛrt kˈyɪpstrˌaːt]",
+                "pt": "[sˌofˈiy mˌoɾˈeɪɾæ ˈeɪŋtræ ˈeɪŋ seʊ kafˈɛ prˌefeɾˈidʊ\n ũŋ luɡˈaɾ ˌakoljedˈor na ˌeskˈinæ da xˈuæ ˌaspikuˈɛʊtæ]",
+                "en": "[sˈəʊfi mˈɔːɹaʊ ˈɛntəz hɜː fˈeɪvəɹɪt kafˈeɪ ɐ smˈɔːl kˈəʊzi plˈeɪs ɒnðə kˈɔːnəɹ ɒv ɹˈuː dˈɛs ɹˈəʊsiəz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-004",
             "text": {
                 "fr": "Bonjour Sophie, ça va?",
                 "en": "Hello Sophie, how are you?",
@@ -60,10 +153,25 @@
             }
         },
         {
-            "id": "scene-01-002",
+            "id": "scene-01-005",
+            "text": {
+                "pt": "pergunta Marco, o garçom que a conhece bem.",
+                "en": "asks Marco, the waiter who knows her well."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ mˈaɾəkʊ\n ʊ ɡaɾəsˈoŋ ky a kˌoɲˈɛsy bˈeɪŋ]",
+                "en": "[ˈasks mˈɑːkəʊ ðə wˈeɪtə hˌuː nˈəʊz hɜː wˈɛl]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-006",
             "text": {
                 "fr": "Oui, bien merci. Et toi?",
-                "en": "Yes, well, thank you. And you?",
+                "en": "Yes, well thank you. And you?",
                 "de": "Ja, gut danke. Und dir?",
                 "it": "Sì, bene grazie. E tu?",
                 "es": "Sí, bien gracias. ¿Y tú?",
@@ -91,216 +199,7 @@
             }
         },
         {
-            "id": "scene-01-003",
-            "text": {
-                "fr": "Ça va. Qu'est-ce que tu prends ce matin?",
-                "en": "Good. What are you having this morning?",
-                "de": "Mir geht's gut. Was wirst du heute Morgen nehmen?",
-                "it": "Bene. Cosa prendi stamattina?",
-                "es": "Bien. ¿Qué vas a tomar esta mañana?",
-                "nl": "Goed. Wat neem je vanochtend?"
-            },
-            "ipa": {
-                "fr": "sa vˈa kɛskˌə ty pʁˈɑ̃ sə- matˈɛ̃",
-                "de": "[miːɐ̯ ˈɡeːts ɡuːt vas vɪʁst duː ˈhoːtə ˈmɔʁɡn̩ ˈneːmən]",
-                "it": "[bˈɛːne\n kˈɔːza prˈɛndɪ stˌamatːˈiːna]",
-                "es": "[ˈβjen ke βas a toˈmaɾ ˈesta ˈmaɲana]",
-                "nl": "[ɣˈut\n ʋɑt nˈeːm jə vɑnˈɔxtənt]",
-                "en": "[ɡˈʊd wˌɒt ɑː juː hˌavɪŋ ðɪs mˈɔːnɪŋ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-004",
-            "text": {
-                "fr": "Un café et un croissant, s'il vous plaît.",
-                "en": "A coffee and a stroopwafel, please.",
-                "de": "Einen Kaffee und ein Brötchen, bitte.",
-                "it": "Un caffè e un cornetto, per favore.",
-                "es": "Un café y un churro, por favor.",
-                "nl": "Een koffie en een stroopwafel, alsjeblieft.",
-                "pt": "Um café e um pão na chapa, por favor.",
-                "en_pt": "A coffee and a grilled bread, please."
-            },
-            "ipa": {
-                "fr": "œ̃ kafˈe e œ̃ kʁwasˈɑ̃ sil vu plˈɛ",
-                "de": "[ˈaɪ̯nən ˈkaf.eː ʊnt aɪ̯n ˈbrœtçən ˈbɪtə]",
-                "it": "[ˌʊn kaffˈɛ ˌe ˌʊn kornˈetːo\n pˌɛr favˈoːre]",
-                "es": "[un kaˈfe i un ˈtʃuro poɾ faˈβoɾ]",
-                "nl": "[ən kɔfˈi ɛn ən strˌoːpʋaːfˈɛl\n ˌɑlʃɛblˈift]",
-                "pt": "[ũŋ kafˈɛ i ũŋ pˈɐ̃ʊ̃ na ʃˈapæ\n por favˈor]",
-                "en": "[ɐ kˈɒfɪ and ɐ stɹˈuːpweɪfəl plˈiːz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-005",
-            "text": {
-                "fr": "Bonjour Lucas!",
-                "en": "Hello Lucas!",
-                "de": "Hallo Lucas!",
-                "it": "Ciao Lucas!",
-                "es": "¡Hola Lucas!",
-                "nl": "Hallo Lucas!"
-            },
-            "ipa": {
-                "fr": "bɔ̃ʒˈuʁ lykˈa",
-                "de": "[ˈhalo ˈluːkas]",
-                "it": "[tʃˈaʊ lˈuːkas]",
-                "es": "[ˈola ˈlukas]",
-                "nl": "[hˈɑloː lˈykɑs]",
-                "en": "[həlˈəʊ lˈuːkəz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-006",
-            "text": {
-                "fr": "Salut! Tu as bien dormi?",
-                "en": "Hi! Did you sleep well?",
-                "de": "Hallo! Hast du gut geschlafen?",
-                "it": "Ciao! Hai dormito bene?",
-                "es": "¡Hola! ¿Dormiste bien?",
-                "nl": "Hoi! Heb je lekker geslapen?",
-                "pt": "Você dormiu bem?",
-                "en_pt": "Did you sleep well?"
-            },
-            "ipa": {
-                "fr": "salˈy ty a bjˈɛ̃ dɔʁmˈi",
-                "de": "[ˈhalo hast duː ɡuːt ɡəˈʃlaːfn̩]",
-                "it": "[tʃˈaʊ\n ˌaj dormˈiːto bˈɛːne]",
-                "es": "[ˈola ˈdoɾmiste βjen]",
-                "nl": "[hˈoːi\n hɛp jə lˈɛkər ɣəslˈaːpən]",
-                "pt": "[vosˌe doɾəmˈiʊ bˈeɪŋ]",
-                "en": "[hˈaɪ dˈɪd juː slˈiːp wˈɛl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-01-007",
-            "text": {
-                "fr": "Non, pas très bien. J'ai fait des rêves étranges.",
-                "en": "No, not really. I had strange dreams.",
-                "de": "Nein, nicht besonders. Ich hatte merkwürdige Träume.",
-                "it": "No, non molto bene. Ho fatto dei sogni strani.",
-                "es": "No, no muy bien. He tenido sueños raros.",
-                "nl": "Nee, niet echt. Ik had vreemde dromen.",
-                "pt": "Tive sonhos estranhos.",
-                "en_pt": "I had strange dreams."
-            },
-            "ipa": {
-                "fr": "nˈɔ̃ pa tʁɛ bjˈɛ̃ ʒe fˈɛ de- ʁˈɛvz etʁˈɑ̃ʒ",
-                "de": "[naɪ̯n nɪçt bəˈzɔndɐs ɪç ˈhatə ˈmɛʁkvyːɐ̯dɪɡə ˈtʁɔɪ̯mə]",
-                "it": "[nˈɔ\n nˌon mˈolto bˈɛːne\n ˌo fˈatːo dˌɛj sˈoɲʲɪ strˈaːnɪ]",
-                "es": "[no no mwi ˈβjen e teˈniðo ˈsweɲos ˈraɾos]",
-                "nl": "[nˈeː\n nˌit ˈɛxt\n ɪk hˈɑt vrˈeːmdə drˈoːmən]",
-                "pt": "[tʃˌivy sˈoɲʊz ˌestrˈɐ̃ɲʊs]",
-                "en": "[nˈəʊ nˌɒt ɹˈiəlɪ aɪ hɐd stɹˈeɪndʒ dɹˈiːmz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-008",
-            "text": {
-                "fr": "Un café au lait et un pain au chocolat, s'il vous plaît.",
-                "en": "A latte and a chocolate pastry, please.",
-                "de": "Einen Milchkaffee und ein Schokoladenbrötchen, bitte.",
-                "it": "Un caffelatte e un cornetto al cioccolato, per favore.",
-                "es": "Un café con leche y una tostada de chocolate, por favor.",
-                "nl": "Een koffie verkeerd en een chocoladebroodje, alsjeblieft.",
-                "pt": "Um café com leite e um pão de queijo, por favor.",
-                "en_pt": "A coffee with milk and a cheese bread, please."
-            },
-            "ipa": {
-                "fr": "œ̃ kafˈe o lˈɛt e œ̃ pˈɛ̃ o ʃɔkɔlˈa sil vu plˈɛ",
-                "de": "[ˈaɪ̯nən ˈmɪlçkaf.eː ʊnt aɪ̯n ʃokoˈlaːdənˈbrœtçən ˈbɪtə]",
-                "it": "[ˌʊn kˌaffelˈatːe ˌe ˌʊn kornˈetːo ˌal tʃˌɔkːolˈaːto\n pˌɛr favˈoːre]",
-                "es": "[un kaˈfe kon ˈletʃe i ˈuna tosˈtaða ðe tʃokoˈlate poɾ faˈβoɾ]",
-                "nl": "[ən kɔfˈi vərkˈɪːrd ɛn ən ʃˈoːkoːlˌaːdɛbrˌoːtjə\n ˌɑlʃɛblˈift]",
-                "pt": "[ũŋ kafˈɛ koŋ lˈeɪtʃj i ũŋ pˈɐ̃ʊ̃ dʒy kˈeɪʒʊ\n por favˈor]",
-                "en": "[ɐ lˈɑːteɪ and ɐ tʃˈɒklət pˈeɪstɹi plˈiːz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-009",
-            "text": {
-                "fr": "Voilà pour vous. Bon appétit!",
-                "en": "Here you go, enjoy your meal!",
-                "de": "Hier bitte, guten Appetit!",
-                "it": "Ecco a voi. Buon appetito!",
-                "es": "Aquí tienes. ¡Buen provecho!",
-                "nl": "Alsjeblieft, eet smakelijk!",
-                "pt": "Bom apetite!",
-                "en_pt": "Enjoy your meal!"
-            },
-            "ipa": {
-                "fr": "vwalˌa puʁ vˈu bˈɔ̃n apetˈi",
-                "de": "[hiːɐ̯ ˈbɪtə ˈɡuːtn̩ aˈpeːtɪt]",
-                "it": "[ˈɛkːo ˌa vˈɔɪ\n bʊˌon ˌapːetˈiːto]",
-                "es": "[aˈki ˈtjenes ˈbwen pɾoˈβetʃo]",
-                "nl": "[ˌɑlʃɛblˈift\n ˈeːt smˈaːkələk]",
-                "pt": "[bˈoŋ ˌapetʃˈitʃy]",
-                "en": "[hˈiə juː ɡˈəʊ ɛndʒˈɔɪ jɔː mˈiːl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-010",
             "text": {
                 "fr": "Merci,",
                 "en": "Thank you,",
@@ -331,24 +230,70 @@
             }
         },
         {
-            "id": "scene-01-011",
+            "id": "scene-01-008",
             "text": {
-                "fr": "Tu veux du sucre dans ton café?",
-                "en": "Do you want sugar in your coffee?",
-                "de": "Willst du Zucker in deinem Kaffee?",
-                "it": "Vuoi dello zucchero nel tuo caffè?",
-                "es": "¿Quieres azúcar en tu café?",
-                "nl": "Wil je suiker in je koffie?",
-                "pt": "Você quer açúcar no seu café?"
+                "pt": "responde Sophie com um sorriso cansado.",
+                "en": "Sophie responds with a tired smile."
             },
             "ipa": {
-                "fr": "ty vˈø dy- sˈykʁ dɑ̃ tɔ̃ kafˈe",
-                "de": "[vɪlst duː ˈtsʊkɐ ɪn ˈdaɪ̯nəm ˈkaf.eː]",
-                "it": "[vʊˈɔːɪ dˌɛllo dzˈukːero nˌɛl tˌʊo kaffˈɛ]",
-                "es": "[ˈkjeɾes aˈsuθaɾ en tu kaˈfe]",
-                "nl": "[ʋɪl jə sˈœykər ɪn jə kɔfˈi]",
-                "pt": "[vosˌe kˈɛɾ ˌasˈukar nʊ seʊ kafˈɛ]",
-                "en": "[dˈuː juː wˈɒnt ʃˈʊɡəɹ ɪn jɔː kˈɒfɪ]"
+                "pt": "[xˌespˈoŋdʒy sˌofˈiy koŋ ũŋ sˌoxˈizʊ kˌɐ̃ŋsˈadʊ]",
+                "en": "[sˈəʊfi ɹɪspˈɒndz wɪð ɐ tˈaɪəd smˈaɪl]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-009",
+            "text": {
+                "pt": "Tudo certo.",
+                "en": "All good."
+            },
+            "ipa": {
+                "pt": "[tˈudʊ sˈɛɾətʊ]",
+                "en": "[ˈɔːl ɡˈʊd]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-010",
+            "text": {
+                "pt": "O que você vai querer hoje?",
+                "en": "What will you have today?"
+            },
+            "ipa": {
+                "pt": "[ʊ ky vosˌe vaɪ keɾˈeɾ ˈoʒy]",
+                "en": "[wˌɒt wɪl juː hav tədˈeɪ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-011",
+            "text": {
+                "fr": "Un café et un croissant, s'il vous plaît.",
+                "en": "A coffee and a croissant, please.",
+                "de": "Einen Kaffee und ein Brötchen, bitte.",
+                "it": "Un caffè e un cornetto, per favore.",
+                "es": "Un café y un churro, por favor.",
+                "nl": "Een koffie en een stroopwafel, alsjeblieft.",
+                "pt": "Um café e um pão na chapa, por favor.",
+                "en_pt": "A coffee and a grilled bread, please."
+            },
+            "ipa": {
+                "fr": "œ̃ kafˈe e œ̃ kʁwasˈɑ̃ sil vu plˈɛ",
+                "de": "[ˈaɪ̯nən ˈkaf.eː ʊnt aɪ̯n ˈbrœtçən ˈbɪtə]",
+                "it": "[ˌʊn kaffˈɛ ˌe ˌʊn kornˈetːo\n pˌɛr favˈoːre]",
+                "es": "[un kaˈfe i un ˈtʃuro poɾ faˈβoɾ]",
+                "nl": "[ən kɔfˈi ɛn ən strˌoːpʋaːfˈɛl\n ˌɑlʃɛblˈift]",
+                "pt": "[ũŋ kafˈɛ i ũŋ pˈɐ̃ʊ̃ na ʃˈapæ\n por favˈor]",
+                "en": "[ɐ kˈɒfɪ and ɐ kwˈɑːsɑ̃ plˈiːz]"
             },
             "provenance": {
                 "fr": "original",
@@ -363,23 +308,22 @@
         {
             "id": "scene-01-012",
             "text": {
-                "fr": "Non merci, je le prends noir.",
-                "en": "No thank you, I take it black.",
-                "de": "Nein danke, ich nehme ihn schwarz.",
-                "it": "No grazie, lo prendo nero.",
-                "es": "No gracias, lo tomo negro.",
-                "nl": "Nee bedankt, ik drink het zwart.",
-                "pt": "Não obrigada, eu tomo sem açúcar.",
-                "en_pt": "No thank you, I take it without sugar."
+                "fr": "Sophie s'assoit près de la fenêtre.",
+                "en": "Sophie sits near the window.",
+                "de": "Sophie setzt sich ans Fenster.",
+                "it": "Sophie si siede vicino alla finestra.",
+                "es": "Sophie se sienta cerca de la ventana.",
+                "nl": "Sophie gaat bij het raam zitten.",
+                "pt": "Sophie senta perto da janela."
             },
             "ipa": {
-                "fr": "nɔ̃ mɛʁsˈi ʒə- lə- pʁˈɑ̃ nwˈaʁ",
-                "de": "[naɪ̯n daŋkə ɪç ˈneːmə iːn ʃvaʁts]",
-                "it": "[nˈɔ ɡrˈatsje\n lˌo prˈɛndo nˈeːro]",
-                "es": "[no ˈɣɾaθjas lo ˈtomo ˈneɣɾo]",
-                "nl": "[nˈeː bədˈɑŋkt\n ɪk drˈɪŋk hət zʋˈɑrt]",
-                "pt": "[nˌɐ̃ʊ̃ ˌobriɡˈadæ\n eʊ tˈomʊ sˈeɪŋ ˌasˈukar]",
-                "en": "[nˈəʊ θˈaŋk juː aɪ tˈeɪk ɪt blˈak]"
+                "fr": "sɔfˈi saswˈa pʁɛ də- la- fənˈɛtʁ",
+                "de": "[ˈzoːfi zɛt͡st zɪç ans ˈfɛnstɐ]",
+                "it": "[sˈopje sˌɪ sjˈeːde vitʃˈiːno ˌalla finˈɛstra]",
+                "es": "[ˈsofi se ˈsjenta ˈθeɾka ðe la βenˈtana]",
+                "nl": "[sɔphˈi ɣˈaːt bɛɪ hət rˈaːm zˈɪtən]",
+                "pt": "[sˌofˈiy sˈeɪŋtæ pˈɛɾətʊ da ʒˌænˈɛlæ]",
+                "en": "[sˈəʊfi sˈɪts nˌiə ðə wˈɪndəʊ]"
             },
             "provenance": {
                 "fr": "original",
@@ -394,369 +338,14 @@
         {
             "id": "scene-01-013",
             "text": {
-                "fr": "Il fait beau aujourd'hui,",
-                "en": "It's nice weather today,",
-                "de": "Es ist schönes Wetter heute,",
-                "it": "Fa bel tempo oggi,",
-                "es": "Hace buen tiempo hoy,",
-                "nl": "Het is mooi weer vandaag,"
-            },
-            "ipa": {
-                "fr": "il fˈɛ bˈo oʒuʁdyˈi",
-                "de": "[ɛs ɪst ˈʃøːnəs ˈvɛtɐ ˈhoːtə]",
-                "it": "[fˌa bˈɛl tˈɛmpo ˈɔdʒːɪ]",
-                "es": "[ˈaθe βwen ˈtjempo oj]",
-                "nl": "[hət ɪs mˈoːj ʋˈɪːr vɑndˈaːx]",
-                "en": "[ɪts nˈaɪs wˈɛðə tədˈeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-014",
-            "text": {
-                "fr": "Oui, c'est une belle journée.",
-                "en": "Yes, it's a beautiful day.",
-                "de": "Ja, es ist ein schöner Tag.",
-                "it": "Sì, è una giornata bellissima.",
-                "es": "Sí, es un día precioso.",
-                "nl": "Ja, het is een prachtige dag.",
-                "pt": "Sim, é um dia lindo.",
-                "en_pt": "Yes, it's a lovely day."
-            },
-            "ipa": {
-                "fr": "wˈi sɛt yn bˈɛl ʒuʁnˈe",
-                "de": "[ja ɛs ɪst aɪ̯n ˈʃøːnɐ taːk]",
-                "it": "[sˈi\n ˌɛ ˌʊna dʒornˈaːta bellˈissima]",
-                "es": "[si es un ˈdi.a pɾeˈθjoso]",
-                "nl": "[jˈaː\n hət ɪs ən prˈɑxtəɣə dˈɑx]",
-                "pt": "[sˈiŋ\n ɛ ũŋ dʒˈiæ lˈiŋdʊ]",
-                "en": "[jˈɛs ɪts ɐ bjˈuːtɪfəl dˈeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-015",
-            "text": {
-                "fr": "Tu sais, Lucas, la vie est si monotone ici.",
-                "en": "You know, Lucas, life is so monotonous here.",
-                "de": "Weißt du, Lucas, das Leben ist so eintönig hier.",
-                "it": "Sai, Lucas, la vita è così monotona qui.",
-                "es": "Sabes, Lucas, la vida es tan monótona aquí.",
-                "nl": "Weet je, Lucas, het leven is zo eentonig hier.",
-                "pt": "Sabe Lucas, a vida é tão monótona aqui.",
-                "en_pt": "You know Lucas, life is so monotonous here."
-            },
-            "ipa": {
-                "fr": "ty sˈɛ lykˈa la- vˈi ɛ sˈi mɔnɔtˈɔn isˈi",
-                "de": "[vaɪ̯st duː ˈluːkas das ˈleːbn̩ ɪst zo aɪ̯nˈtøːnɪç hiːɐ]",
-                "it": "[sˈaɪ\n lˈuːkas\n lˌa vˈiːta ˌɛ kozˈi mˌonotˈoːna kwˈi]",
-                "es": "[ˈsaβes ˈlukas la ˈβiða es tan monoˈtona aˈki]",
-                "nl": "[ʋˈeːt jə\n lˈykɑs\n hət lˈeːvən ɪ soː eːntˈoːnəx hˈir]",
-                "pt": "[sˈaby lˈukæs\n a vˈidæ ɛ tˈɐ̃ʊ̃ mˌonˈɔtonæ akˈi]",
-                "en": "[juː nˈəʊ lˈuːkəz lˈaɪf ɪz sˌəʊ mənˈɒtənəs hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-016",
-            "text": {
-                "fr": "Je suis d'accord avec toi. Chaque jour est pareil.",
-                "en": "I agree with you. Every day is the same.",
-                "de": "Ich stimme dir zu. Jeder Tag ist gleich.",
-                "it": "Sono d'accordo con te. Ogni giorno è uguale.",
-                "es": "Estoy de acuerdo contigo. Cada día es igual.",
-                "nl": "Ik ben het met je eens. Elke dag is hetzelfde.",
-                "pt": "Todo dia é igual.",
-                "en_pt": "Every day is the same."
-            },
-            "ipa": {
-                "fr": "ʒə- syˌi dakˈɔʁ avˌɛk twˈa ʃak ʒˈuʁ ɛ paʁˈɛj",
-                "de": "[ɪç ˈʃtɪmə diːɐ̯ t͡suː ˈjeːdɐ taːk ɪst ɡlaɪç]",
-                "it": "[sˌono dakːˈɔːrdo kˌon tˈe\n ˈoɲʲɪ dʒˈoːrno ˌɛ ʊɡwˈaːle]",
-                "es": "[esˈtoj ðe aˈkweɾðo konˈtiɣo ˈkaða ˈdi.a es iˈɣwal]",
-                "nl": "[ɪk bɛn hət mɛt jə ˈeːns\n ˈɛlkə dˈɑx ɪs hˈɛtzɛlvdə]",
-                "pt": "[tˈodʊ dʒˈiæ ɛ iɡwˈaʊ]",
-                "en": "[aɪ ɐɡɹˈiː wɪð juː ˈɛvɹɪ dˈeɪ ɪz ðə sˈeɪm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-017",
-            "text": {
-                "fr": "On devrait partir en voyage,",
-                "en": "We should go on a trip,",
-                "de": "Wir sollten verreisen,",
-                "it": "Dovremmo fare un viaggio,",
-                "es": "Deberíamos irnos de viaje,",
-                "nl": "We zouden op reis moeten gaan,"
-            },
-            "ipa": {
-                "fr": "ɔ̃ dəvʁˈɛ paʁtˈiʁ ɑ̃ vwajˈaʒ",
-                "de": "[viːɐ̯ ˈzɔltn̩ fɛɐ̯ˈʁaɪ̯zn̩]",
-                "it": "[dovrˈɛmmo fˌare ˌʊn vjˈadʒːo]",
-                "es": "[ðeβeˈɾjamos ˈiɾnos ðe ˈβjaxe]",
-                "nl": "[ʋə zˌʌʊdən ɔp rˈɛɪs mˈutən ɣˈaːn]",
-                "en": "[wiː ʃˌʊd ɡˌəʊ ˌɒn ɐ tɹˈɪp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-018",
-            "text": {
-                "fr": "Tu as raison! Pourquoi pas?",
-                "en": "You're right! Why not?",
-                "de": "Du hast recht! Warum nicht?",
-                "it": "Hai ragione! Perché no?",
-                "es": "¡Tienes razón! ¿Por qué no?",
-                "nl": "Je hebt gelijk! Waarom niet?",
-                "pt": "Você tem razão!",
-                "en_pt": "You're right!"
-            },
-            "ipa": {
-                "fr": "ty a ʁɛzˈɔ̃ puʁkwˌa pˈa",
-                "de": "[duː hast ʁɛçt vaˈʁʏm nɪçt]",
-                "it": "[ˌaj radʒˈoːne\n perkˌe nˈɔ]",
-                "es": "[ˈtjenes raˈθon poɾ ˈke no]",
-                "nl": "[jə hɛpt ɣəlˈɛɪk\n ʋˈaːrɔm nˈit]",
-                "pt": "[vosˌe teɪŋ xazˈɐ̃ʊ̃]",
-                "en": "[jɔː ɹˈaɪt wˌaɪ nˈɒt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-019",
-            "text": {
-                "fr": "Le soleil se lève doucement sur Paris.",
-                "en": "The sun is slowly rising over Amsterdam.",
-                "de": "Die Sonne geht langsam über Berlin auf.",
-                "it": "Il sole sorge lentamente su Roma.",
-                "es": "El sol se levanta suavemente sobre Madrid.",
-                "nl": "De zon komt langzaam op over Amsterdam.",
-                "pt": "O sol nasce suavemente sobre São Paulo.",
-                "en_pt": "The sun rises gently over São Paulo."
-            },
-            "ipa": {
-                "fr": "lə- sɔlˈɛj sə- lˈɛv dusmˈɑ̃ syʁ paʁˈi",
-                "de": "[diː ˈzɔnə ɡeːt ˈlaŋzam ˈyːbɐ bɛɐ̯ˈliːn aʊ̯f]",
-                "it": "[ˌil sˈoːle sˈoːrdʒe lˌentamˈente sˌʊ rˈɔːma]",
-                "es": "[el sol se leˈβanta swaβeˈmente ˈsoβɾe maˈðɾið]",
-                "nl": "[də zˈɔn kˈɔmt lˈɑŋzaːm ɔp ˈoːvər ˈɑmstərdˌɑm]",
-                "pt": "[ʊ sˈɔl nˈasy sˌuavemˈeɪŋtʃy sˈobry sɐ̃ʊ̃ pˈaʊlʊ]",
-                "en": "[ðə sˈʌn ɪz slˈəʊli ɹˈaɪzɪŋ ˌəʊvəɹ ˈamstədˌam]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-020",
-            "text": {
-                "fr": "Les rues du Marais commencent à s'animer.",
-                "en": "The streets of De Pijp are starting to bustle.",
-                "de": "Die Straßen von Kreuzberg beginnen sich zu beleben.",
-                "it": "Le strade di Trastevere cominciano a prendere vita.",
-                "es": "Las calles de Malasaña empiezan a animarse.",
-                "nl": "De straten van De Pijp beginnen te bruisen.",
-                "pt": "As ruas da Vila Madalena começam a ganhar vida.",
-                "en_pt": "The streets of Vila Madalena begin to come alive."
-            },
-            "ipa": {
-                "fr": "le- ʁˈy dy- maʁˈɛ kɔmˈɑ̃st a sanimˈe",
-                "de": "[diː ˈʃtʁaːsn̩ fɔn ˈkʁɔɪ̯t͡sˌbɛʁk bəˈɡɪnən zɪç t͡su bəˈleːbn̩]",
-                "it": "[lˌe strˈaːde dˌɪ trastˈevere komˈintʃano ˌa prˈendere vˈiːta]",
-                "es": "[las ˈkaʎes ðe malaˈsaɲa emˈpjɛθan a aˈni.maɾse]",
-                "nl": "[də strˈaːtən vɑn də pˈɛɪ pəɣˈɪnən tə brˈœyzən]",
-                "pt": "[az xˈuæz da vˈilæ mˌadalˈenæ kˌomˈɛsɐ̃ʊ̃ a ɡɐ̃ɲˈar vˈidæ]",
-                "en": "[ðə stɹˈiːts ɒv də pˈeɪp ɑː stˈɑːtɪŋ tə bˈʌsəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-021",
-            "text": {
-                "fr": "Sophie Moreau entre dans son café préféré, un petit endroit chaleureux au coin de la rue des Rosiers.",
-                "en": "Sophie de Vries enters her favorite cafe, a cozy spot on the corner of Albert Cuyp Street.",
-                "de": "Sophie Müller betritt ihr Lieblingscafé, eine gemütliche kleine Ecke an der Ecke der Wiener Straße.",
-                "it": "Sophie Romano entra nel suo caffè preferito, un piccolo posto accogliente all'angolo della strada.",
-                "es": "Sophie Moreno entra en su cafetería favorita, un lugar acogedor en la esquina.",
-                "nl": "Sophie de Vries loopt haar favoriete café binnen, een knus plekje op de hoek van de Albert Cuypstraat.",
-                "pt": "Sophie Moreira entra em seu café preferido, um lugar acolhedor na esquina da rua Aspicuelta.",
-                "en_pt": "Sophie Moreira enters her favorite café, a cozy place on the corner of Aspicuelta street."
-            },
-            "ipa": {
-                "fr": "sɔfˈi mɔʁˈo ɑ̃tʁ dɑ̃ sɔ̃ kafˈe pʁefeʁˈe œ̃ pətˈit ɑ̃dʁwˈa ʃaløʁˈøz o kwˈɛ̃ də- la- ʁˈy de- ʁozjˈe",
-                "de": "[ˈzoːfi ˈmʏlɐ bəˈtʁɪt iːɐ ˈliːblɪŋskaˌfeː ˈaɪ̯nə ɡəˈmyːtlɪçə ˈklaɪ̯nə ˈɛkə an dɐ ˈɛkə dɐ ˈviːnɐ ˈʃtʁaːsə]",
-                "it": "[sˈopje romˈaːno ˈentra nˌɛl sˌʊo kaffˈɛ prˌeferˈiːto\n ˌʊn pˈikːolo pˈosto ˌakːoʎˈɛnte allˈaŋɡolo dˌɛlla strˈaːda]",
-                "es": "[ˈsofi moˈɾeno ˈentɾa en su kafeˈteɾja faβoˈɾita un luˈɣaɾ akoˈxeðoɾ en la esˈkina]",
-                "nl": "[sɔphˈi də vrˈis lˈoːpt haːr fˌaːvoːrˈitə kaːfˈeː bˈɪnən\n ən knˈɵs plˈɛkjə ɔp də hˈuk vɑn də ˈɑlbɛrt kˈyɪpstrˌaːt]",
-                "pt": "[sˌofˈiy mˌoɾˈeɪɾæ ˈeɪŋtræ ˈeɪŋ seʊ kafˈɛ prˌefeɾˈidʊ\n ũŋ luɡˈaɾ ˌakoljedˈor na ˌeskˈinæ da xˈuæ ˌaspikuˈɛʊtæ]",
-                "en": "[sˈəʊfi də vˈiːɹˈaɪz ˈɛntəz hɜː fˈeɪvəɹɪt kˈafeɪ ɐ kˈəʊzi spˈɒt ɒnðə kˈɔːnəɹ ɒv ˈalbət kˈaɪp stɹˈiːt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-022",
-            "text": {
-                "fr": "demande Marc, le serveur qui la connaît bien.",
-                "en": "asks Marc, the waiter who knows her well.",
-                "de": "fragt Marc, der Kellner, der sie gut kennt.",
-                "it": "chiede Marco, il barista che la conosce bene.",
-                "es": "¿Qué deseas?, pregunta Marc, el camarero que la conoce bien.",
-                "nl": "vraagt Marc, de ober die haar goed kent."
-            },
-            "ipa": {
-                "fr": "dəmˈɑ̃d mˈaʁk lə- sɛʁvˈœʁ ki la- kɔnˈɛ bjˈɛ̃",
-                "de": "[fʁaːkt maʁk dɐ ˈkɛlnɐ dɐ ziː ɡuːt kɛnt]",
-                "it": "[kjˈeːde mˈaːrko\n ˌil barˈista kˌe lˌa konˈoːʃe bˈɛːne]",
-                "es": "[ke deˈse.as pɾeˈɣunta maɾk el kamaˈɾeɾo ke la koˈnoθe βjen]",
-                "nl": "[vrˈaːxt mˈɑrk\n də ˈoːbər di haːr ɣˈut kˈɛnt]",
-                "en": "[ˈasks mˈɑːk ðə wˈeɪtə hˌuː nˈəʊz hɜː wˈɛl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-023",
-            "text": {
-                "fr": "répond Sophie avec un sourire fatigué.",
-                "en": "replies Sophie with a tired smile.",
-                "de": "antwortet Sophie mit einem müden Lächeln.",
-                "it": "risponde Sophie con un sorriso stanco.",
-                "es": "responde Sophie con una sonrisa cansada.",
-                "nl": "antwoordt Sophie met een vermoeide glimlach."
-            },
-            "ipa": {
-                "fr": "ʁepˈɔ̃ sɔfˈi avˌɛk œ̃ suʁˈiʁ fatiɡˈe",
-                "de": "[ˈantvoːɐ̯tət ˈzoːfi mɪt ˈaɪ̯nəm ˈmyːdn̩ ˈlɛçl̩n]",
-                "it": "[rispˈonde sˈopje kˌon ˌʊn sorɾˈiːzo stˈanko]",
-                "es": "[resˈponde ˈsofi kon ˈuna sonˈrisa kanˈsaða]",
-                "nl": "[ˈɑntʋɔːrt sɔphˈi mɛt ən vərmˈujdə ɣlˈɪmlɑx]",
-                "en": "[ɹɪplˈaɪz sˈəʊfi wɪð ɐ tˈaɪəd smˈaɪl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-024",
-            "text": {
-                "fr": "Sophie s'assoit près de la fenêtre.",
-                "en": "Sophie sits by the window.",
-                "de": "Sophie setzt sich ans Fenster.",
-                "it": "Sophie si siede vicino alla finestra.",
-                "es": "Sophie se sienta cerca de la ventana.",
-                "nl": "Sophie gaat bij het raam zitten.",
-                "pt": "Sophie senta perto da janela.",
-                "en_pt": "Sophie sits near the window."
-            },
-            "ipa": {
-                "fr": "sɔfˈi saswˈa pʁɛ də- la- fənˈɛtʁ",
-                "de": "[ˈzoːfi zɛt͡st zɪç ans ˈfɛnstɐ]",
-                "it": "[sˈopje sˌɪ sjˈeːde vitʃˈiːno ˌalla finˈɛstra]",
-                "es": "[ˈsofi se ˈsjenta ˈθeɾka ðe la βenˈtana]",
-                "nl": "[sɔphˈi ɣˈaːt bɛɪ hət rˈaːm zˈɪtən]",
-                "pt": "[sˌofˈiy sˈeɪŋtæ pˈɛɾətʊ da ʒˌænˈɛlæ]",
-                "en": "[sˈəʊfi sˈɪts baɪ ðə wˈɪndəʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-025",
-            "text": {
                 "fr": "Elle regarde les gens qui passent dans la rue.",
-                "en": "She watches the people passing by on the street.",
+                "en": "She watches people passing in the street.",
                 "de": "Sie beobachtet die Leute, die vorbeigehen.",
                 "it": "Osserva le persone che passano per strada.",
                 "es": "Ella mira a las personas que pasan por la calle.",
                 "nl": "Ze kijkt naar de mensen die voorbij lopen op straat.",
-                "pt": "Ela observa as pessoas que passam na rua."
+                "pt": "Ela observa as pessoas que passam na rua.",
+                "en_pt": "She watches the people passing by on the street."
             },
             "ipa": {
                 "fr": "ɛl ʁəɡˈaʁd le- ʒˈɑ̃ ki pˈas dɑ̃ la- ʁˈy",
@@ -765,7 +354,7 @@
                 "es": "[ˈeʎa ˈmiɾa a las peɾˈsonas ke ˈpasan poɾ la ˈkaʎe]",
                 "nl": "[zə kˈɛɪkt naːr də mˈɛnsən di vˈɔːrbˌɛɪ lˈoːpən ɔp strˈaːt]",
                 "pt": "[ˌɛlæ ˌobsˈɛɾəvæ as pˌesˈoæs ky pˈasɐ̃ʊ̃ na xˈuæ]",
-                "en": "[ʃiː wˈɒtʃɪz ðə pˈiːpəl pˈasɪŋ baɪ ɒnðə stɹˈiːt]"
+                "en": "[ʃiː wˈɒtʃɪz pˈiːpəl pˈasɪŋ ɪnðə stɹˈiːt]"
             },
             "provenance": {
                 "fr": "original",
@@ -778,10 +367,10 @@
             }
         },
         {
-            "id": "scene-01-026",
+            "id": "scene-01-014",
             "text": {
                 "fr": "Quelques minutes plus tard, Lucas Dubois arrive, son sac à dos sur l'épaule.",
-                "en": "A few minutes later, Lucas van der Berg arrives, with his backpack over his shoulder.",
+                "en": "A few minutes later, Lucas Dubois arrives, his backpack on his shoulder.",
                 "de": "Wenige Minuten später kommt Lucas Schmidt mit seinem Rucksack über der Schulter.",
                 "it": "Pochi minuti dopo, arriva Lucas Conti, con lo zaino in spalla.",
                 "es": "Unos minutos después, Lucas Ruiz llega con su mochila al hombro.",
@@ -796,7 +385,7 @@
                 "es": "[ˈunos ˈminutos desˈpwes ˈlukas ˈrwiθ ˈʎeɣa kon su moˈʧila al ˈombɾo]",
                 "nl": "[ən pˈaːr mˈinytən lˈaːtər kˈɔmt lˈykɑs vɑn dˈɛr bˈɛrx ˈaːn\n mɛt zɛɪn rˈɵɣzɑk ˈoːvər zɛɪn sxˈʌʊdər]",
                 "pt": "[aʊɡˈũŋz mˌinˈutʊz depˈoɪs\n lˈukæz dˌuˈaɾətʃy ʃˈeɡæ\n sˌuæ mˌoʃˈilæ nas kˈɔstæs]",
-                "en": "[ɐ fjˈuː mˈɪnɪts lˈeɪtə lˈuːkəz vˈandɜː bˈɜːɡ ɐɹˈaɪvz wɪð hɪz bˈakpak ˌəʊvə hɪz ʃˈəʊldə]"
+                "en": "[ɐ fjˈuː mˈɪnɪts lˈeɪtə lˈuːkəz djˈuːbwɑːɹ ɐɹˈaɪvz hɪz bˈakpak ˌɒn hɪz ʃˈəʊldə]"
             },
             "provenance": {
                 "fr": "original",
@@ -809,7 +398,130 @@
             }
         },
         {
-            "id": "scene-01-027",
+            "id": "scene-01-015",
+            "text": {
+                "pt": "Bom dia Lucas!",
+                "en": "Good morning Lucas!"
+            },
+            "ipa": {
+                "pt": "[bˈoŋ dʒˈiæ lˈukæs]",
+                "en": "[ɡˈʊd mˈɔːnɪŋ lˈuːkəz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-016",
+            "text": {
+                "fr": "dit Sophie spontanément.",
+                "en": "says Sophie spontanément.",
+                "de": "sagt Sophie spontan.",
+                "it": "dice Sophie spontaneamente.",
+                "es": "dice Sophie espontáneamente.",
+                "nl": "zegt Sophie spontaan.",
+                "pt": "diz Sophie.",
+                "en_pt": "says Sophie."
+            },
+            "ipa": {
+                "fr": "dˈi sɔfˈi spɔ̃tanemˈɑ̃",
+                "de": "[zaːkt ˈzoːfi ʃpɔnˈtaːn]",
+                "it": "[dˈiːtʃe sˈopje spˌontanˌɛamˈente]",
+                "es": "[ˈdiθe ˈsofi esponˈtanea.mente]",
+                "nl": "[zˈɛxt sɔphˈi spɔntˈaːn]",
+                "pt": "[dʒˈis sˌofˈiy]",
+                "en": "[sˈɛz sˈəʊfi spˌɒntɐnˈeɪmənt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-017",
+            "text": {
+                "fr": "Salut! Tu as bien dormi?",
+                "en": "Hi! Did you sleep well?",
+                "de": "Hallo! Hast du gut geschlafen?",
+                "it": "Ciao! Hai dormito bene?",
+                "es": "¡Hola! ¿Dormiste bien?",
+                "nl": "Hoi! Heb je lekker geslapen?",
+                "pt": "Você dormiu bem?",
+                "en_pt": "Did you sleep well?"
+            },
+            "ipa": {
+                "fr": "salˈy ty a bjˈɛ̃ dɔʁmˈi",
+                "de": "[ˈhalo hast duː ɡuːt ɡəˈʃlaːfn̩]",
+                "it": "[tʃˈaʊ\n ˌaj dormˈiːto bˈɛːne]",
+                "es": "[ˈola ˈdoɾmiste βjen]",
+                "nl": "[hˈoːi\n hɛp jə lˈɛkər ɣəslˈaːpən]",
+                "pt": "[vosˌe doɾəmˈiʊ bˈeɪŋ]",
+                "en": "[hˈaɪ dˈɪd juː slˈiːp wˈɛl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-018",
+            "text": {
+                "pt": "Não, não muito bem.",
+                "en": "No, not very well."
+            },
+            "ipa": {
+                "pt": "[nˈɐ̃ʊ̃\n nˌɐ̃ʊ̃ mwˈiŋtʊ bˈeɪŋ]",
+                "en": "[nˈəʊ nˌɒt vˈɛɹɪ wˈɛl]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-019",
+            "text": {
+                "fr": "Non, pas très bien. J'ai fait des rêves étranges.",
+                "en": "No, not very well. I had strange dreams.",
+                "de": "Nein, nicht besonders. Ich hatte merkwürdige Träume.",
+                "it": "No, non molto bene. Ho fatto dei sogni strani.",
+                "es": "No, no muy bien. He tenido sueños raros.",
+                "nl": "Nee, niet echt. Ik had vreemde dromen.",
+                "pt": "Tive sonhos estranhos.",
+                "en_pt": "I had strange dreams."
+            },
+            "ipa": {
+                "fr": "nˈɔ̃ pa tʁɛ bjˈɛ̃ ʒe fˈɛ de- ʁˈɛvz etʁˈɑ̃ʒ",
+                "de": "[naɪ̯n nɪçt bəˈzɔndɐs ɪç ˈhatə ˈmɛʁkvyːɐ̯dɪɡə ˈtʁɔɪ̯mə]",
+                "it": "[nˈɔ\n nˌon mˈolto bˈɛːne\n ˌo fˈatːo dˌɛj sˈoɲʲɪ strˈaːnɪ]",
+                "es": "[no no mwi ˈβjen e teˈniðo ˈsweɲos ˈraɾos]",
+                "nl": "[nˈeː\n nˌit ˈɛxt\n ɪk hˈɑt vrˈeːmdə drˈoːmən]",
+                "pt": "[tʃˌivy sˈoɲʊz ˌestrˈɐ̃ɲʊs]",
+                "en": "[nˈəʊ nˌɒt vˈɛɹɪ wˈɛl aɪ hɐd stɹˈeɪndʒ dɹˈiːmz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-020",
             "text": {
                 "fr": "Lucas commande au comptoir.",
                 "en": "Lucas orders at the counter.",
@@ -839,25 +551,25 @@
             }
         },
         {
-            "id": "scene-01-028",
+            "id": "scene-01-021",
             "text": {
-                "fr": "Il vient s'asseoir en face de Sophie.",
-                "en": "He sits down opposite Sophie.",
-                "de": "Er setzt sich gegenüber von Sophie.",
-                "it": "Poi viene a sedersi di fronte a Sophie.",
-                "es": "Luego se sienta frente a Sophie.",
-                "nl": "Hij gaat tegenover Sophie zitten.",
-                "pt": "Ele vem sentar na frente de Sophie.",
-                "en_pt": "He comes to sit across from Sophie."
+                "fr": "Un café au lait et un pain au chocolat, s'il vous plaît.",
+                "en": "A coffee with milk and a chocolate croissant, please.",
+                "de": "Einen Milchkaffee und ein Schokoladenbrötchen, bitte.",
+                "it": "Un caffelatte e un cornetto al cioccolato, per favore.",
+                "es": "Un café con leche y una tostada de chocolate, por favor.",
+                "nl": "Een koffie verkeerd en een chocoladebroodje, alsjeblieft.",
+                "pt": "Um café com leite e um pão de queijo, por favor.",
+                "en_pt": "A coffee with milk and a cheese bread, please."
             },
             "ipa": {
-                "fr": "il vjˈɛ̃ saswˈaʁ ɑ̃ fˈas də- sɔfˈi",
-                "de": "[ɛɐ̯ ˈzɛt͡st zɪç ɡəˈɡn̩ʏbɐ fɔn ˈzoːfi]",
-                "it": "[pˈɔːɪ vjˈɛːne ˌa sedˈeːrsɪ dˌɪ frˈonte ˌa sˈopje]",
-                "es": "[ˈlweɣo se ˈsjenta ˈfɾente a ˈsofi]",
-                "nl": "[hɛɪ ɣˈaː tˈeːɣənˌoːvər sɔphˈi zˈɪtən]",
-                "pt": "[ˌely vˈeɪŋ seɪŋtˈar na frˈeɪŋtʃy dʒy sˌofˈiy]",
-                "en": "[hiː sˈɪts dˌaʊn ˈɒpəsˌɪt sˈəʊfi]"
+                "fr": "œ̃ kafˈe o lˈɛt e œ̃ pˈɛ̃ o ʃɔkɔlˈa sil vu plˈɛ",
+                "de": "[ˈaɪ̯nən ˈmɪlçkaf.eː ʊnt aɪ̯n ʃokoˈlaːdənˈbrœtçən ˈbɪtə]",
+                "it": "[ˌʊn kˌaffelˈatːe ˌe ˌʊn kornˈetːo ˌal tʃˌɔkːolˈaːto\n pˌɛr favˈoːre]",
+                "es": "[un kaˈfe kon ˈletʃe i ˈuna tosˈtaða ðe tʃokoˈlate poɾ faˈβoɾ]",
+                "nl": "[ən kɔfˈi vərkˈɪːrd ɛn ən ʃˈoːkoːlˌaːdɛbrˌoːtjə\n ˌɑlʃɛblˈift]",
+                "pt": "[ũŋ kafˈɛ koŋ lˈeɪtʃj i ũŋ pˈɐ̃ʊ̃ dʒy kˈeɪʒʊ\n por favˈor]",
+                "en": "[ɐ kˈɒfɪ wɪð mˈɪlk and ɐ tʃˈɒklət kwˈɑːsɑ̃ plˈiːz]"
             },
             "provenance": {
                 "fr": "original",
@@ -870,7 +582,37 @@
             }
         },
         {
-            "id": "scene-01-029",
+            "id": "scene-01-022",
+            "text": {
+                "fr": "Il vient s'asseoir en face de Sophie.",
+                "en": "He comes to sit across from Sophie.",
+                "de": "Er setzt sich gegenüber von Sophie.",
+                "it": "Poi viene a sedersi di fronte a Sophie.",
+                "es": "Luego se sienta frente a Sophie.",
+                "nl": "Hij gaat tegenover Sophie zitten.",
+                "pt": "Ele vem sentar na frente de Sophie."
+            },
+            "ipa": {
+                "fr": "il vjˈɛ̃ saswˈaʁ ɑ̃ fˈas də- sɔfˈi",
+                "de": "[ɛɐ̯ ˈzɛt͡st zɪç ɡəˈɡn̩ʏbɐ fɔn ˈzoːfi]",
+                "it": "[pˈɔːɪ vjˈɛːne ˌa sedˈeːrsɪ dˌɪ frˈonte ˌa sˈopje]",
+                "es": "[ˈlweɣo se ˈsjenta ˈfɾente a ˈsofi]",
+                "nl": "[hɛɪ ɣˈaː tˈeːɣənˌoːvər sɔphˈi zˈɪtən]",
+                "pt": "[ˌely vˈeɪŋ seɪŋtˈar na frˈeɪŋtʃy dʒy sˌofˈiy]",
+                "en": "[hiː kˈʌmz tə sˈɪt əkɹˌɒs fɹɒm sˈəʊfi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-023",
             "text": {
                 "fr": "Marc apporte leurs commandes.",
                 "en": "Marc brings their orders.",
@@ -901,7 +643,68 @@
             }
         },
         {
-            "id": "scene-01-030",
+            "id": "scene-01-024",
+            "text": {
+                "pt": "Aqui está para vocês.",
+                "en": "Here you are."
+            },
+            "ipa": {
+                "pt": "[akˈi estˌa pˌaɾæ vosˈes]",
+                "en": "[hˈiə juː ɑː]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-025",
+            "text": {
+                "fr": "Voilà pour vous. Bon appétit!",
+                "en": "Here you are. Enjoy your meal!",
+                "de": "Hier bitte, guten Appetit!",
+                "it": "Ecco a voi. Buon appetito!",
+                "es": "Aquí tienes. ¡Buen provecho!",
+                "nl": "Alsjeblieft, eet smakelijk!",
+                "pt": "Bom apetite!",
+                "en_pt": "Enjoy your meal!"
+            },
+            "ipa": {
+                "fr": "vwalˌa puʁ vˈu bˈɔ̃n apetˈi",
+                "de": "[hiːɐ̯ ˈbɪtə ˈɡuːtn̩ aˈpeːtɪt]",
+                "it": "[ˈɛkːo ˌa vˈɔɪ\n bʊˌon ˌapːetˈiːto]",
+                "es": "[aˈki ˈtjenes ˈbwen pɾoˈβetʃo]",
+                "nl": "[ˌɑlʃɛblˈift\n ˈeːt smˈaːkələk]",
+                "pt": "[bˈoŋ ˌapetʃˈitʃy]",
+                "en": "[hˈiə juː ɑː ɛndʒˈɔɪ jɔː mˈiːl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-026",
+            "text": {
+                "pt": "Obrigado, dizem eles juntos.",
+                "en": "Thank you, they say together."
+            },
+            "ipa": {
+                "pt": "[ˌobriɡˈadʊ\n dʒˈizeɪŋ ˌelyz ʒˈũŋtʊs]",
+                "en": "[θˈaŋk juː ðeɪ sˈeɪ təɡˈɛðə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-027",
             "text": {
                 "fr": "Lucas regarde Sophie attentivement.",
                 "en": "Lucas looks at Sophie attentively.",
@@ -931,10 +734,71 @@
             }
         },
         {
-            "id": "scene-01-031",
+            "id": "scene-01-028",
+            "text": {
+                "fr": "Tu veux du sucre dans ton café?",
+                "en": "Do you want sugar in your coffee?",
+                "de": "Willst du Zucker in deinem Kaffee?",
+                "it": "Vuoi dello zucchero nel tuo caffè?",
+                "es": "¿Quieres azúcar en tu café?",
+                "nl": "Wil je suiker in je koffie?",
+                "pt": "Você quer açúcar no seu café?"
+            },
+            "ipa": {
+                "fr": "ty vˈø dy- sˈykʁ dɑ̃ tɔ̃ kafˈe",
+                "de": "[vɪlst duː ˈtsʊkɐ ɪn ˈdaɪ̯nəm ˈkaf.eː]",
+                "it": "[vʊˈɔːɪ dˌɛllo dzˈukːero nˌɛl tˌʊo kaffˈɛ]",
+                "es": "[ˈkjeɾes aˈsuθaɾ en tu kaˈfe]",
+                "nl": "[ʋɪl jə sˈœykər ɪn jə kɔfˈi]",
+                "pt": "[vosˌe kˈɛɾ ˌasˈukar nʊ seʊ kafˈɛ]",
+                "en": "[dˈuː juː wˈɒnt ʃˈʊɡəɹ ɪn jɔː kˈɒfɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-029",
+            "text": {
+                "fr": "Non merci, je le prends noir.",
+                "en": "No thanks, I take it black.",
+                "de": "Nein danke, ich nehme ihn schwarz.",
+                "it": "No grazie, lo prendo nero.",
+                "es": "No gracias, lo tomo negro.",
+                "nl": "Nee bedankt, ik drink het zwart.",
+                "pt": "Não obrigada, eu tomo sem açúcar.",
+                "en_pt": "No thank you, I take it without sugar."
+            },
+            "ipa": {
+                "fr": "nɔ̃ mɛʁsˈi ʒə- lə- pʁˈɑ̃ nwˈaʁ",
+                "de": "[naɪ̯n daŋkə ɪç ˈneːmə iːn ʃvaʁts]",
+                "it": "[nˈɔ ɡrˈatsje\n lˌo prˈɛndo nˈeːro]",
+                "es": "[no ˈɣɾaθjas lo ˈtomo ˈneɣɾo]",
+                "nl": "[nˈeː bədˈɑŋkt\n ɪk drˈɪŋk hət zʋˈɑrt]",
+                "pt": "[nˌɐ̃ʊ̃ ˌobriɡˈadæ\n eʊ tˈomʊ sˈeɪŋ ˌasˈukar]",
+                "en": "[nˈəʊ θˈaŋks aɪ tˈeɪk ɪt blˈak]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-030",
             "text": {
                 "fr": "remarque Lucas en regardant par la fenêtre.",
-                "en": "Lucas remarks as he looks outside.",
+                "en": "Lucas notes, looking out the window.",
                 "de": "bemerkt Lucas, während er aus dem Fenster schaut.",
                 "it": "osserva Lucas guardando fuori dalla finestra.",
                 "es": "comenta Lucas mirando por la ventana.",
@@ -949,7 +813,38 @@
                 "es": "[koˈmenta ˈlukas miˈɾando poɾ la βenˈtana]",
                 "nl": "[mˈɛrkt lˈykɑs ɔp tˈɛrʋɛɪl hɛɪ naːr bˈœytən kˈɛɪkt]",
                 "pt": "[estˌa ũŋ dʒˈiæ bˌonˈitw ˈoʒy\n ˌobsˈɛɾəvæ lˈukæz ˌoljˈɐ̃ŋdʊ pˈelæ ʒˌænˈɛlæ]",
-                "en": "[lˈuːkəz ɹɪmˈɑːks az hiː lˈʊks aʊtsˈaɪd]"
+                "en": "[lˈuːkəz nˈəʊts lˈʊkɪŋ ˈaʊt ðə wˈɪndəʊ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-031",
+            "text": {
+                "fr": "Oui, c'est une belle journée.",
+                "en": "Yes, it's a beautiful day.",
+                "de": "Ja, es ist ein schöner Tag.",
+                "it": "Sì, è una giornata bellissima.",
+                "es": "Sí, es un día precioso.",
+                "nl": "Ja, het is een prachtige dag.",
+                "pt": "Sim, é um dia lindo.",
+                "en_pt": "Yes, it's a lovely day."
+            },
+            "ipa": {
+                "fr": "wˈi sɛt yn bˈɛl ʒuʁnˈe",
+                "de": "[ja ɛs ɪst aɪ̯n ˈʃøːnɐ taːk]",
+                "it": "[sˈi\n ˌɛ ˌʊna dʒornˈaːta bellˈissima]",
+                "es": "[si es un ˈdi.a pɾeˈθjoso]",
+                "nl": "[jˈaː\n hət ɪs ən prˈɑxtəɣə dˈɑx]",
+                "pt": "[sˈiŋ\n ɛ ũŋ dʒˈiæ lˈiŋdʊ]",
+                "en": "[jˈɛs ɪts ɐ bjˈuːtɪfəl dˈeɪ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1024,23 +919,23 @@
         {
             "id": "scene-01-034",
             "text": {
-                "fr": "dit Sophie spontanément.",
-                "en": "Sophie says spontaneously.",
-                "de": "sagt Sophie spontan.",
-                "it": "dice Sophie spontaneamente.",
-                "es": "dice Sophie espontáneamente.",
-                "nl": "zegt Sophie spontaan.",
-                "pt": "diz Sophie.",
-                "en_pt": "says Sophie."
+                "fr": "Tu sais, Lucas, la vie est si monotone ici.",
+                "en": "You know, Lucas, life is so monotonous here.",
+                "de": "Weißt du, Lucas, das Leben ist so eintönig hier.",
+                "it": "Sai, Lucas, la vita è così monotona qui.",
+                "es": "Sabes, Lucas, la vida es tan monótona aquí.",
+                "nl": "Weet je, Lucas, het leven is zo eentonig hier.",
+                "pt": "Sabe Lucas, a vida é tão monótona aqui.",
+                "en_pt": "You know Lucas, life is so monotonous here."
             },
             "ipa": {
-                "fr": "dˈi sɔfˈi spɔ̃tanemˈɑ̃",
-                "de": "[zaːkt ˈzoːfi ʃpɔnˈtaːn]",
-                "it": "[dˈiːtʃe sˈopje spˌontanˌɛamˈente]",
-                "es": "[ˈdiθe ˈsofi esponˈtanea.mente]",
-                "nl": "[zˈɛxt sɔphˈi spɔntˈaːn]",
-                "pt": "[dʒˈis sˌofˈiy]",
-                "en": "[sˈəʊfi sˈɛz spɒntˈeɪniəsli]"
+                "fr": "ty sˈɛ lykˈa la- vˈi ɛ sˈi mɔnɔtˈɔn isˈi",
+                "de": "[vaɪ̯st duː ˈluːkas das ˈleːbn̩ ɪst zo aɪ̯nˈtøːnɪç hiːɐ]",
+                "it": "[sˈaɪ\n lˈuːkas\n lˌa vˈiːta ˌɛ kozˈi mˌonotˈoːna kwˈi]",
+                "es": "[ˈsaβes ˈlukas la ˈβiða es tan monoˈtona aˈki]",
+                "nl": "[ʋˈeːt jə\n lˈykɑs\n hət lˈeːvən ɪ soː eːntˈoːnəx hˈir]",
+                "pt": "[sˈaby lˈukæs\n a vˈidæ ɛ tˈɐ̃ʊ̃ mˌonˈɔtonæ akˈi]",
+                "en": "[juː nˈəʊ lˈuːkəz lˈaɪf ɪz sˌəʊ mənˈɒtənəs hˈiə]"
             },
             "provenance": {
                 "fr": "original",
@@ -1055,157 +950,6 @@
         {
             "id": "scene-01-035",
             "text": {
-                "fr": "Lucas la regarde avec surprise, puis un sourire apparaît sur son visage.",
-                "en": "Lucas looks at her surprised, then a smile appears on his face.",
-                "de": "Lucas sieht sie überrascht an, dann erscheint ein Lächeln auf seinem Gesicht.",
-                "it": "Lucas la guarda sorpreso, poi appare un sorriso sul suo viso.",
-                "es": "Lucas la mira sorprendido, luego sonríe.",
-                "nl": "Lucas kijkt haar verrast aan, dan verschijnt er een glimlach op zijn gezicht.",
-                "pt": "Lucas a olha com surpresa, então um sorriso aparece em seu rosto.",
-                "en_pt": "Lucas looks at her with surprise, then a smile appears on his face."
-            },
-            "ipa": {
-                "fr": "lykˈa la- ʁəɡˈaʁd avˌɛk syʁpʁˈiz pyˈiz œ̃ suʁˈiʁ apaʁˈɛ syʁ sɔ̃ vizˈaʒ",
-                "de": "[ˈluːkas ziːt ziː ˈyːbɐˈʁaʃt an dan ɛɐ̯ˈʃaɪ̯nt aɪ̯n ˈlɛçl̩n aʊ̯f ˈzaɪ̯nəm ɡəˈzɪçt]",
-                "it": "[lˈuːkas lˌa ɡwˈaːrda sorprˈeːzo\n pˈɔːɪ apːˈaːre ˌʊn sorɾˈiːzo sˌʊl sˌʊo vˈiːzo]",
-                "es": "[ˈlukas la ˈmiɾa soɾpɾenˈðiðo ˈlweɣo sonˈrje]",
-                "nl": "[lˈykɑs kˈɛɪkt haːr vərrˈɑst ˈaːn\n dˈɑn vərsxˈɛɪnt ər ən ɣlˈɪmlɑx ɔp zɛɪn ɣəzˈɪxt]",
-                "pt": "[lˈukæz a ˈɔljæ koŋ sˌuɾəprˈezæ\n eɪŋtˈɐ̃ʊ̃ ũŋ sˌoxˈizw ˌapaɾˈɛsj ˈeɪŋ seʊ xˈostʊ]",
-                "en": "[lˈuːkəz lˈʊks at hɜː səpɹˈaɪzd ðˈɛn ɐ smˈaɪl ɐpˈiəz ˌɒn hɪz fˈeɪs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-036",
-            "text": {
-                "pt": "pergunta Marco, o garçom que a conhece bem.",
-                "en": "asks Marco, the waiter who knows her well."
-            },
-            "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ mˈaɾəkʊ\n ʊ ɡaɾəsˈoŋ ky a kˌoɲˈɛsy bˈeɪŋ]",
-                "en": "[ˈasks mˈɑːkəʊ ðə wˈeɪtə hˌuː nˈəʊz hɜː wˈɛl]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-037",
-            "text": {
-                "pt": "responde Sophie com um sorriso cansado.",
-                "en": "Sophie responds with a tired smile."
-            },
-            "ipa": {
-                "pt": "[xˌespˈoŋdʒy sˌofˈiy koŋ ũŋ sˌoxˈizʊ kˌɐ̃ŋsˈadʊ]",
-                "en": "[sˈəʊfi ɹɪspˈɒndz wɪð ɐ tˈaɪəd smˈaɪl]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-038",
-            "text": {
-                "pt": "Tudo certo.",
-                "en": "All good."
-            },
-            "ipa": {
-                "pt": "[tˈudʊ sˈɛɾətʊ]",
-                "en": "[ˈɔːl ɡˈʊd]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-039",
-            "text": {
-                "pt": "O que você vai querer hoje?",
-                "en": "What will you have today?"
-            },
-            "ipa": {
-                "pt": "[ʊ ky vosˌe vaɪ keɾˈeɾ ˈoʒy]",
-                "en": "[wˌɒt wɪl juː hav tədˈeɪ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-040",
-            "text": {
-                "pt": "Bom dia Lucas!",
-                "en": "Good morning Lucas!"
-            },
-            "ipa": {
-                "pt": "[bˈoŋ dʒˈiæ lˈukæs]",
-                "en": "[ɡˈʊd mˈɔːnɪŋ lˈuːkəz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-041",
-            "text": {
-                "pt": "Não, não muito bem.",
-                "en": "No, not very well."
-            },
-            "ipa": {
-                "pt": "[nˈɐ̃ʊ̃\n nˌɐ̃ʊ̃ mwˈiŋtʊ bˈeɪŋ]",
-                "en": "[nˈəʊ nˌɒt vˈɛɹɪ wˈɛl]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-042",
-            "text": {
-                "pt": "Aqui está para vocês.",
-                "en": "Here you are."
-            },
-            "ipa": {
-                "pt": "[akˈi estˌa pˌaɾæ vosˈes]",
-                "en": "[hˈiə juː ɑː]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-043",
-            "text": {
-                "pt": "Obrigado, dizem eles juntos.",
-                "en": "Thank you, they say together."
-            },
-            "ipa": {
-                "pt": "[ˌobriɡˈadʊ\n dʒˈizeɪŋ ˌelyz ʒˈũŋtʊs]",
-                "en": "[θˈaŋk juː ðeɪ sˈeɪ təɡˈɛðə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-01-044",
-            "text": {
                 "pt": "Concordo com você.",
                 "en": "I agree with you."
             },
@@ -1219,7 +963,38 @@
             }
         },
         {
-            "id": "scene-01-045",
+            "id": "scene-01-036",
+            "text": {
+                "fr": "Je suis d'accord avec toi. Chaque jour est pareil.",
+                "en": "I agree with you. Every day is the same.",
+                "de": "Ich stimme dir zu. Jeder Tag ist gleich.",
+                "it": "Sono d'accordo con te. Ogni giorno è uguale.",
+                "es": "Estoy de acuerdo contigo. Cada día es igual.",
+                "nl": "Ik ben het met je eens. Elke dag is hetzelfde.",
+                "pt": "Todo dia é igual.",
+                "en_pt": "Every day is the same."
+            },
+            "ipa": {
+                "fr": "ʒə- syˌi dakˈɔʁ avˌɛk twˈa ʃak ʒˈuʁ ɛ paʁˈɛj",
+                "de": "[ɪç ˈʃtɪmə diːɐ̯ t͡suː ˈjeːdɐ taːk ɪst ɡlaɪç]",
+                "it": "[sˌono dakːˈɔːrdo kˌon tˈe\n ˈoɲʲɪ dʒˈoːrno ˌɛ ʊɡwˈaːle]",
+                "es": "[esˈtoj ðe aˈkweɾðo konˈtiɣo ˈkaða ˈdi.a es iˈɣwal]",
+                "nl": "[ɪk bɛn hət mɛt jə ˈeːns\n ˈɛlkə dˈɑx ɪs hˈɛtzɛlvdə]",
+                "pt": "[tˈodʊ dʒˈiæ ɛ iɡwˈaʊ]",
+                "en": "[aɪ ɐɡɹˈiː wɪð juː ˈɛvɹɪ dˈeɪ ɪz ðə sˈeɪm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-037",
             "text": {
                 "pt": "A gente deveria viajar, diz Sophie espontaneamente.",
                 "en": "We should travel, Sophie says spontaneously."
@@ -1234,7 +1009,68 @@
             }
         },
         {
-            "id": "scene-01-046",
+            "id": "scene-01-038",
+            "text": {
+                "fr": "Lucas la regarde avec surprise, puis un sourire apparaît sur son visage.",
+                "en": "Lucas looks at her with surprise, then a smile appears on his face.",
+                "de": "Lucas sieht sie überrascht an, dann erscheint ein Lächeln auf seinem Gesicht.",
+                "it": "Lucas la guarda sorpreso, poi appare un sorriso sul suo viso.",
+                "es": "Lucas la mira sorprendido, luego sonríe.",
+                "nl": "Lucas kijkt haar verrast aan, dan verschijnt er een glimlach op zijn gezicht.",
+                "pt": "Lucas a olha com surpresa, então um sorriso aparece em seu rosto."
+            },
+            "ipa": {
+                "fr": "lykˈa la- ʁəɡˈaʁd avˌɛk syʁpʁˈiz pyˈiz œ̃ suʁˈiʁ apaʁˈɛ syʁ sɔ̃ vizˈaʒ",
+                "de": "[ˈluːkas ziːt ziː ˈyːbɐˈʁaʃt an dan ɛɐ̯ˈʃaɪ̯nt aɪ̯n ˈlɛçl̩n aʊ̯f ˈzaɪ̯nəm ɡəˈzɪçt]",
+                "it": "[lˈuːkas lˌa ɡwˈaːrda sorprˈeːzo\n pˈɔːɪ apːˈaːre ˌʊn sorɾˈiːzo sˌʊl sˌʊo vˈiːzo]",
+                "es": "[ˈlukas la ˈmiɾa soɾpɾenˈðiðo ˈlweɣo sonˈrje]",
+                "nl": "[lˈykɑs kˈɛɪkt haːr vərrˈɑst ˈaːn\n dˈɑn vərsxˈɛɪnt ər ən ɣlˈɪmlɑx ɔp zɛɪn ɣəzˈɪxt]",
+                "pt": "[lˈukæz a ˈɔljæ koŋ sˌuɾəprˈezæ\n eɪŋtˈɐ̃ʊ̃ ũŋ sˌoxˈizw ˌapaɾˈɛsj ˈeɪŋ seʊ xˈostʊ]",
+                "en": "[lˈuːkəz lˈʊks at hɜː wɪð səpɹˈaɪz ðˈɛn ɐ smˈaɪl ɐpˈiəz ˌɒn hɪz fˈeɪs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-039",
+            "text": {
+                "fr": "Tu as raison! Pourquoi pas?",
+                "en": "You're right! Why not?",
+                "de": "Du hast recht! Warum nicht?",
+                "it": "Hai ragione! Perché no?",
+                "es": "¡Tienes razón! ¿Por qué no?",
+                "nl": "Je hebt gelijk! Waarom niet?",
+                "pt": "Você tem razão!",
+                "en_pt": "You're right!"
+            },
+            "ipa": {
+                "fr": "ty a ʁɛzˈɔ̃ puʁkwˌa pˈa",
+                "de": "[duː hast ʁɛçt vaˈʁʏm nɪçt]",
+                "it": "[ˌaj radʒˈoːne\n perkˌe nˈɔ]",
+                "es": "[ˈtjenes raˈθon poɾ ˈke no]",
+                "nl": "[jə hɛpt ɣəlˈɛɪk\n ʋˈaːrɔm nˈit]",
+                "pt": "[vosˌe teɪŋ xazˈɐ̃ʊ̃]",
+                "en": "[jɔː ɹˈaɪt wˌaɪ nˈɒt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-040",
             "text": {
                 "pt": "Por que não?",
                 "en": "Why not?"
@@ -1245,6 +1081,168 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-041",
+            "text": {
+                "fr": "Ça va. Qu'est-ce que tu prends ce matin?",
+                "en": "I'm fine. What are you having this morning?",
+                "de": "Mir geht's gut. Was wirst du heute Morgen nehmen?",
+                "it": "Bene. Cosa prendi stamattina?",
+                "es": "Bien. ¿Qué vas a tomar esta mañana?",
+                "nl": "Goed. Wat neem je vanochtend?"
+            },
+            "ipa": {
+                "fr": "sa vˈa kɛskˌə ty pʁˈɑ̃ sə- matˈɛ̃",
+                "de": "[miːɐ̯ ˈɡeːts ɡuːt vas vɪʁst duː ˈhoːtə ˈmɔʁɡn̩ ˈneːmən]",
+                "it": "[bˈɛːne\n kˈɔːza prˈɛndɪ stˌamatːˈiːna]",
+                "es": "[ˈβjen ke βas a toˈmaɾ ˈesta ˈmaɲana]",
+                "nl": "[ɣˈut\n ʋɑt nˈeːm jə vɑnˈɔxtənt]",
+                "en": "[aɪm fˈaɪn wˌɒt ɑː juː hˌavɪŋ ðɪs mˈɔːnɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-042",
+            "text": {
+                "fr": "Bonjour Lucas!",
+                "en": "Hello Lucas!",
+                "de": "Hallo Lucas!",
+                "it": "Ciao Lucas!",
+                "es": "¡Hola Lucas!",
+                "nl": "Hallo Lucas!"
+            },
+            "ipa": {
+                "fr": "bɔ̃ʒˈuʁ lykˈa",
+                "de": "[ˈhalo ˈluːkas]",
+                "it": "[tʃˈaʊ lˈuːkas]",
+                "es": "[ˈola ˈlukas]",
+                "nl": "[hˈɑloː lˈykɑs]",
+                "en": "[həlˈəʊ lˈuːkəz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-043",
+            "text": {
+                "fr": "Il fait beau aujourd'hui,",
+                "en": "It's nice today,",
+                "de": "Es ist schönes Wetter heute,",
+                "it": "Fa bel tempo oggi,",
+                "es": "Hace buen tiempo hoy,",
+                "nl": "Het is mooi weer vandaag,"
+            },
+            "ipa": {
+                "fr": "il fˈɛ bˈo oʒuʁdyˈi",
+                "de": "[ɛs ɪst ˈʃøːnəs ˈvɛtɐ ˈhoːtə]",
+                "it": "[fˌa bˈɛl tˈɛmpo ˈɔdʒːɪ]",
+                "es": "[ˈaθe βwen ˈtjempo oj]",
+                "nl": "[hət ɪs mˈoːj ʋˈɪːr vɑndˈaːx]",
+                "en": "[ɪts nˈaɪs tədˈeɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-044",
+            "text": {
+                "fr": "On devrait partir en voyage,",
+                "en": "We should go on a trip,",
+                "de": "Wir sollten verreisen,",
+                "it": "Dovremmo fare un viaggio,",
+                "es": "Deberíamos irnos de viaje,",
+                "nl": "We zouden op reis moeten gaan,"
+            },
+            "ipa": {
+                "fr": "ɔ̃ dəvʁˈɛ paʁtˈiʁ ɑ̃ vwajˈaʒ",
+                "de": "[viːɐ̯ ˈzɔltn̩ fɛɐ̯ˈʁaɪ̯zn̩]",
+                "it": "[dovrˈɛmmo fˌare ˌʊn vjˈadʒːo]",
+                "es": "[ðeβeˈɾjamos ˈiɾnos ðe ˈβjaxe]",
+                "nl": "[ʋə zˌʌʊdən ɔp rˈɛɪs mˈutən ɣˈaːn]",
+                "en": "[wiː ʃˌʊd ɡˌəʊ ˌɒn ɐ tɹˈɪp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-045",
+            "text": {
+                "fr": "demande Marc, le serveur qui la connaît bien.",
+                "en": "asks Marc, le serveur qui la connaît bien.",
+                "de": "fragt Marc, der Kellner, der sie gut kennt.",
+                "it": "chiede Marco, il barista che la conosce bene.",
+                "es": "¿Qué deseas?, pregunta Marc, el camarero que la conoce bien.",
+                "nl": "vraagt Marc, de ober die haar goed kent."
+            },
+            "ipa": {
+                "fr": "dəmˈɑ̃d mˈaʁk lə- sɛʁvˈœʁ ki la- kɔnˈɛ bjˈɛ̃",
+                "de": "[fʁaːkt maʁk dɐ ˈkɛlnɐ dɐ ziː ɡuːt kɛnt]",
+                "it": "[kjˈeːde mˈaːrko\n ˌil barˈista kˌe lˌa konˈoːʃe bˈɛːne]",
+                "es": "[ke deˈse.as pɾeˈɣunta maɾk el kamaˈɾeɾo ke la koˈnoθe βjen]",
+                "nl": "[vrˈaːxt mˈɑrk\n də ˈoːbər di haːr ɣˈut kˈɛnt]",
+                "en": "[ˈasks mˈɑːk lə sɜːvˈɜː kwˈi lˌa kənˈeɪt baɪˈɛn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-01-046",
+            "text": {
+                "fr": "répond Sophie avec un sourire fatigué.",
+                "en": "replies Sophie avec un sourire fatigué.",
+                "de": "antwortet Sophie mit einem müden Lächeln.",
+                "it": "risponde Sophie con un sorriso stanco.",
+                "es": "responde Sophie con una sonrisa cansada.",
+                "nl": "antwoordt Sophie met een vermoeide glimlach."
+            },
+            "ipa": {
+                "fr": "ʁepˈɔ̃ sɔfˈi avˌɛk œ̃ suʁˈiʁ fatiɡˈe",
+                "de": "[ˈantvoːɐ̯tət ˈzoːfi mɪt ˈaɪ̯nəm ˈmyːdn̩ ˈlɛçl̩n]",
+                "it": "[rispˈonde sˈopje kˌon ˌʊn sorɾˈiːzo stˈanko]",
+                "es": "[resˈponde ˈsofi kon ˈuna sonˈrisa kanˈsaða]",
+                "nl": "[ˈɑntʋɔːrt sɔphˈi mɛt ən vərmˈujdə ɣlˈɪmlɑx]",
+                "en": "[ɹɪplˈaɪz sˈəʊfi ˈavɛk ˈʌn sˈaʊəɹaɪə fˌatɪɡəɹˈeɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-02.json
+++ b/language_materials/unified/stories/scene-02.json
@@ -24,27 +24,30 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-02-001",
             "text": {
-                "fr": "Bonjour,",
-                "en": "Hello,",
-                "de": "Hallo,",
-                "it": "Ciao,",
-                "es": "Hola,",
-                "nl": "Hoi,"
+                "fr": "L'après-midi, Sophie et Lucas se promènent dans les rues du Marais.",
+                "en": "In the afternoon, Sophie and Lucas walk through the streets of the Marais.",
+                "de": "Am Nachmittag spazieren Sophie und Lucas durch die Straßen von Kreuzberg.",
+                "it": "Nel pomeriggio, Sophie e Lucas passeggiano per le strade di Trastevere.",
+                "es": "Por la tarde, Sophie y Lucas pasean por las calles de Malasaña.",
+                "nl": "'s Middags wandelen Sophie en Lucas door de straten van De Pijp.",
+                "pt": "À tarde, Sophie e Lucas passeiam pelas ruas da Vila Madalena.",
+                "en_pt": "In the afternoon, Sophie and Lucas walk through the streets of Vila Madalena."
             },
             "ipa": {
-                "fr": "bɔ̃ʒˈuʁ",
-                "de": "[ˈhalo]",
-                "it": "[tʃˈaʊ]",
-                "es": "[ˈola]",
-                "nl": "[hˈoːi]",
-                "en": "[həlˈəʊ]"
+                "fr": "lapʁˌɛmidˈi sɔfˈi e lykˈa sə- pʁɔmˈɛn dɑ̃ le- ʁˈy dy- maʁˈɛ",
+                "de": "[am ˈnaːxmitaːk ˈʃpaːt͡siːʁən ˈzɔfiː ʊnt ˈluːkas dʊʁç diː ˈʃtʁaːsən fɔn ˈkʁɔɪ̯tsbɛʁk]",
+                "it": "[nˌɛl pˌomerˈidʒːo\n sˈopje ˌe lˈuːkas passˈɛdʒːano pˌɛr lˌe strˈaːde dˌɪ trastˈevere]",
+                "es": "[poɾ la ˈtarðe ˈsofi i ˈlukas paˈsean poɾ las ˈkaʎes ðe malaˈsaɲa]",
+                "nl": "[s mˈɪdɑxs ʋˈɑndələn sɔphˈi ɛn lˈykɑs doːr də strˈaːtən vɑn də pˈɛɪp]",
+                "pt": "[ˌaː tˈaɾədʒy\n sˌofˈij i lˈukæs pˌasˈeɪɐ̃ʊ̃ pˈelæz xˈuæz da vˈilæ mˌadalˈenæ]",
+                "en": "[ɪnðɪ ˌaftənˈuːn sˈəʊfi and lˈuːkəz wˈɔːk θɹuː ðə stɹˈiːts ɒvðə mˈaɹaɪz]"
             },
             "provenance": {
                 "fr": "original",
@@ -52,11 +55,57 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-02-002",
+            "text": {
+                "fr": "Ils entrent dans une petite épicerie.",
+                "en": "They enter a small grocery store.",
+                "de": "Sie gehen in einen kleinen Lebensmittelladen.",
+                "it": "Entrano in un piccolo negozio di alimentari.",
+                "es": "Entran en una pequeña tienda de alimentación.",
+                "nl": "Ze gaan een kleine kruidenierswinkel binnen.",
+                "pt": "Eles entram em uma pequena mercearia."
+            },
+            "ipa": {
+                "fr": "ilz ˈɑ̃tʁ dɑ̃z yn pətˈit episʁˈi",
+                "de": "[ziː ˈɡeːən ˈaɪ̯nən ˈklaɪ̯nən ˈleːbənsˌmɪtəllaːdn̩]",
+                "it": "[ˈentrano ˌin ˌʊn pˈikːolo neɡˈɔtsio dˌɪ ˌalimentˈaːrɪ]",
+                "es": "[ˈentɾan en ˈuna peˈkeɲa ˈtjenda ðe alimenˈtaθjon]",
+                "nl": "[zə ɣˈaːn ən klˈɛɪnə krˌœydənˌirsʋɪŋkˈɛl bˈɪnən]",
+                "pt": "[ˌelyz ˈeɪŋtrɐ̃ʊ̃ ˈeɪŋ ˌumæ pˌekˈenæ mˌeɾəseaɾˈiæ]",
+                "en": "[ðeɪ ˈɛntəɹ ɐ smˈɔːl ɡɹˈəʊsəɹɪ stˈɔː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-003",
+            "text": {
+                "pt": "Bom dia, diz a comerciante.",
+                "en": "Good morning, says the shopkeeper."
+            },
+            "ipa": {
+                "pt": "[bˈoŋ dʒˈiæ\n dʒˈiz a kˌomeɾəsiˈɐ̃ŋtʃy]",
+                "en": "[ɡˈʊd mˈɔːnɪŋ sˈɛz ðə ʃˈɒpkiːpə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-004",
             "text": {
                 "fr": "Qu'est-ce que je peux faire pour vous?",
                 "en": "What can I do for you?",
@@ -86,7 +135,7 @@
             }
         },
         {
-            "id": "scene-02-003",
+            "id": "scene-02-005",
             "text": {
                 "fr": "Nous avons besoin de pain,",
                 "en": "We need bread,",
@@ -117,7 +166,7 @@
             }
         },
         {
-            "id": "scene-02-004",
+            "id": "scene-02-006",
             "text": {
                 "fr": "Le pain est là-bas, près de l'entrée.",
                 "en": "The bread is over there, near the entrance.",
@@ -147,7 +196,37 @@
             }
         },
         {
-            "id": "scene-02-005",
+            "id": "scene-02-007",
+            "text": {
+                "fr": "Lucas examine les fromages sur le comptoir.",
+                "en": "Lucas examines the cheeses on the counter.",
+                "de": "Lucas betrachtet die Käse auf dem Tresen.",
+                "it": "Lucas esamina i formaggi sul bancone.",
+                "es": "Lucas examina los quesos sobre el mostrador.",
+                "nl": "Lucas bekijkt de kazen op de toonbank.",
+                "pt": "Lucas examina os queijos no balcão."
+            },
+            "ipa": {
+                "fr": "lykˈaz ɛɡzamˈin le- fʁɔmˈaʒ syʁ lə- kɔ̃twˈaʁ",
+                "de": "[ˈluːkas bəˈtʁaxtət diː ˈkɛːzə aʊ̯f deːm ˈtʁeːzn̩]",
+                "it": "[lˈuːkas ezˈamina ˌɪ formˈadʒːɪ sˌʊl bankˈoːne]",
+                "es": "[ˈlukas eksaˈmina los ˈkesos ˈsoβɾe el mosˈtɾaðoɾ]",
+                "nl": "[lˈykɑs bəkˈɛɪk tə kˈaːzən ɔp də tˈoːnbɑŋk]",
+                "pt": "[lˈukæz ˌezæmˈinæ ʊs kˈeɪʒʊz nʊ baʊkˈɐ̃ʊ̃]",
+                "en": "[lˈuːkəz ɛɡzˈamɪnz ðə tʃˈiːzɪz ɒnðə kˈaʊntə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-008",
             "text": {
                 "fr": "Le fromage est frais?",
                 "en": "Is the cheese fresh?",
@@ -177,7 +256,22 @@
             }
         },
         {
-            "id": "scene-02-006",
+            "id": "scene-02-009",
+            "text": {
+                "pt": "Sim, está muito bom.",
+                "en": "Yes, it's very good."
+            },
+            "ipa": {
+                "pt": "[sˈiŋ\n estˌa mwˈiŋtʊ bˈoŋ]",
+                "en": "[jˈɛs ɪts vˈɛɹɪ ɡˈʊd]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-010",
             "text": {
                 "fr": "Oui, il est très bon. Je l'ai reçu ce matin.",
                 "en": "Yes, it's very good. I received it this morning.",
@@ -208,7 +302,22 @@
             }
         },
         {
-            "id": "scene-02-007",
+            "id": "scene-02-011",
+            "text": {
+                "pt": "Perfeito.",
+                "en": "Perfect."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəfˈeɪtʊ]",
+                "en": "[pˈɜːfɛkt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-012",
             "text": {
                 "fr": "Parfait. Et combien coûtent les tomates?",
                 "en": "Perfect. And how much are the tomatoes?",
@@ -239,7 +348,7 @@
             }
         },
         {
-            "id": "scene-02-008",
+            "id": "scene-02-013",
             "text": {
                 "fr": "Trois euros le kilo.",
                 "en": "Three euros per kilo.",
@@ -270,521 +379,7 @@
             }
         },
         {
-            "id": "scene-02-009",
-            "text": {
-                "fr": "C'est trop cher pour moi.",
-                "en": "That's too expensive for me.",
-                "de": "Das ist mir zu teuer.",
-                "it": "È troppo caro per me.",
-                "es": "Es demasiado caro para mí.",
-                "nl": "Dat is te duur voor mij.",
-                "pt": "Está muito caro para mim."
-            },
-            "ipa": {
-                "fr": "sɛ tʁo ʃˈɛʁ puʁ mwˈa",
-                "de": "[das ɪst miːɐ̯ tsuː ˈtɔɪ̯ɐ]",
-                "it": "[ˌɛ trˈɔpːo kˈaːro pˌɛr mˈe]",
-                "es": "[es deˈmasjaðo ˈkaɾo paɾa ˈmi]",
-                "nl": "[dɑt ɪs tə dˈyr vɔːr mˈɛɪ]",
-                "pt": "[estˌa mwˈiŋtʊ kˈaɾʊ pˌaɾæ mˈiŋ]",
-                "en": "[ðats tˈuː ɛkspˈɛnsɪv fɔː mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-010",
-            "text": {
-                "fr": "Regardez,",
-                "en": "Look,",
-                "de": "Schau mal,",
-                "it": "Guarda,",
-                "es": "Mira,",
-                "nl": "Kijk,"
-            },
-            "ipa": {
-                "fr": "ʁəɡaʁdˈe",
-                "de": "[ʃaʊ̯ mal]",
-                "it": "[ɡwˈaːrda]",
-                "es": "[ˈmiɾa]",
-                "nl": "[kˈɛɪk]",
-                "en": "[lˈʊk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-011",
-            "text": {
-                "fr": "j'ai des tomates d'hier. Deux euros le kilo.",
-                "en": "I have yesterday's tomatoes. Two euros per kilo.",
-                "de": "ich habe noch Tomaten von gestern. Zwei Euro pro Kilo.",
-                "it": "ho dei pomodori di ieri. Due euro al chilo.",
-                "es": "tengo tomates de ayer. Dos euros el kilo.",
-                "nl": "ik heb tomaten van gisteren. Twee euro per kilo."
-            },
-            "ipa": {
-                "fr": "ʒe de- tɔmˈat djˈɛʁ dˈøz øʁˈo lə- kilˈo",
-                "de": "[ɪç ˈhaːbə nɔx toˈmaːtn̩ fɔn ˈɡɛstɐn. tsvaɪ̯ ˈʔøːʁo pʁoː ˈkiːlo]",
-                "it": "[ˌo dˌɛj pˌomodˈoːrɪ dˌɪ jˈɛːrɪ\n dˈuːe ˈɛʊro ˌal kˈiːlo]",
-                "es": "[ˈteŋɡo toˈmates ðe aˈʝeɾ dos ˈewɾos el ˈkilo]",
-                "nl": "[ɪk hɛp toːmˈaːtən vɑn ɣˈɪstərən\n tʋˈeː ˈøːroː pˈɛr kˈiloː]",
-                "en": "[aɪ hav jˈɛstədˌeɪz təmˈɑːtəʊz tˈuː jˈʊəɹəʊz pɜː kˈiːləʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-012",
-            "text": {
-                "fr": "D'accord, nous prenons un kilo.",
-                "en": "Okay, we'll take a kilo.",
-                "de": "Okay, wir nehmen ein Kilo.",
-                "it": "Va bene, prendiamo un chilo.",
-                "es": "Vale, llevamos un kilo.",
-                "nl": "Oké, we nemen een kilo.",
-                "pt": "Tá bom, a gente leva um quilo.",
-                "en_pt": "Okay, we'll take one kilo."
-            },
-            "ipa": {
-                "fr": "dakˈɔʁ nu pʁənˈɔ̃z œ̃ kilˈo",
-                "de": "[oˈkaɪ̯, viːɐ̯ ˈneːmən aɪ̯n ˈkiːlo]",
-                "it": "[vˈa bˈɛːne\n prendjˈaːmo ˌʊn kˈiːlo]",
-                "es": "[ˈβale ʎeˈβamos un ˈkilo]",
-                "nl": "[oːkˈeː\n ʋə nˈeːmən ən kˈiloː]",
-                "pt": "[tˈa bˈoŋ\n a ʒˈeɪŋtʃy lˈɛvæ ũŋ kˈilʊ]",
-                "en": "[əʊkˈeɪ wiːl tˈeɪk ɐ kˈiːləʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-013",
-            "text": {
-                "fr": "Où est la boulangerie?",
-                "en": "Where is the bakery?",
-                "de": "Wo ist die Bäckerei?",
-                "it": "Dove è la panetteria?",
-                "es": "¿Dónde está la churrería?",
-                "nl": "Waar is de bakkerij?",
-                "pt": "Lucas pergunta: Onde fica a padaria?",
-                "en_pt": "Lucas asks: Where is the bakery?"
-            },
-            "ipa": {
-                "fr": "u ɛ la- bulɑ̃ʒʁˈi",
-                "de": "[voː ɪst diː ˈbɛkəʁaɪ̯]",
-                "it": "[dˈoːve ˌɛ lˌa pˌanetːerˈiːa]",
-                "es": "[ˈdonde esˈta la tʃuˈreɾia]",
-                "nl": "[ʋˈaːr ɪs də bˌɑkərˈɛɪ]",
-                "pt": "[lˈukæs pˌeɾəɡˈũŋtæ\n ˌoŋdʒy fˈikæ a pˌadaɾˈiæ]",
-                "en": "[wˌeəɹ ɪz ðə bˈeɪkəɹɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-02-014",
-            "text": {
-                "fr": "Elle est au coin de la rue, après l'église.",
-                "en": "It's around the corner, past the church.",
-                "de": "Sie ist an der Ecke, nach der Kirche.",
-                "it": "È all'angolo della strada, dopo la chiesa.",
-                "es": "Está en la esquina de la calle, después de la iglesia.",
-                "nl": "Die is om de hoek, voorbij de kerk.",
-                "pt": "É na esquina, depois da igreja.",
-                "en_pt": "It's on the corner, past the church."
-            },
-            "ipa": {
-                "fr": "ɛl ɛt o kwˈɛ̃ də- la- ʁˈy apʁˌɛ leɡlˈiz",
-                "de": "[ziː ɪst an deːɐ̯ ˈʔɛkə, naːx deːɐ̯ ˈkɪʁçə]",
-                "it": "[ˌɛ allˈaŋɡolo dˌɛlla strˈaːda\n dˈoːpo lˌa kjˈɛːza]",
-                "es": "[esˈta en la esˈkiɲa ðe la ˈkaʎe deˈspwes ðe la iˈɣlesja]",
-                "nl": "[di ɪs ɔm də hˈuk\n vˈɔːrbˌɛɪ də kˈɛrk]",
-                "pt": "[ɛ na ˌeskˈinæ\n depˈoɪz da ˌiɡrˈeʒæ]",
-                "en": "[ɪts ɐɹˈaʊnd ðə kˈɔːnə pˈast ðə tʃˈɜːtʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-015",
-            "text": {
-                "fr": "J'aime ce quartier.",
-                "en": "I love this neighborhood.",
-                "de": "Ich mag diesen Kiez.",
-                "it": "Mi piace questo quartiere.",
-                "es": "Me gusta mucho este barrio.",
-                "nl": "Ik hou van deze buurt.",
-                "pt": "Eu adoro esse bairro."
-            },
-            "ipa": {
-                "fr": "ʒˈɛm sə- kaʁtjˈe",
-                "de": "[ɪç maːk ˈdiːzn̩ ˈkiːts]",
-                "it": "[mˌɪ pjˈaːtʃe kwˌɛsto kwˌartiˈɛːre]",
-                "es": "[me ˈɣusta ˈmutʃo ˈeste ˈβarjo]",
-                "nl": "[ɪk hˈʌʊ vɑn dˌeːzə bˈyrt]",
-                "pt": "[eʊ ˌadˈɔɾw ˌesi bˈaɪxʊ]",
-                "en": "[aɪ lˈʌv ðɪs nˈeɪbəhˌʊd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-016",
-            "text": {
-                "fr": "Moi aussi, c'est très joli",
-                "en": "Me too, it's very pretty",
-                "de": "Ich auch, er ist wirklich hübsch.",
-                "it": "Anche a me, è molto bello",
-                "es": "A mí también, es muy bonito.",
-                "nl": "Ik ook, het is heel mooi",
-                "pt": "Eu também, é muito bonito.",
-                "en_pt": "Me too, it's very beautiful."
-            },
-            "ipa": {
-                "fr": "mwˌa osˈi sɛ tʁɛ ʒɔlˈi",
-                "de": "[ɪç aʊ̯x, ɛɐ̯ ɪst ˈvɪʁklɪç ˈhʏpʃ]",
-                "it": "[ˈanke ˌa mˈe\n ˌɛ mˈolto bˈɛllo]",
-                "es": "[a ˈmi tamˈbjɛn es ˈmwi βoˈnito]",
-                "nl": "[ɪk ˈoːk\n hət ɪs hˈeːl mˈoːj]",
-                "pt": "[eʊ tɐ̃mbˈeɪŋ\n ɛ mwˈiŋtʊ bˌonˈitʊ]",
-                "en": "[mˌiː tˈuː ɪts vˈɛɹɪ pɹˈɪti]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-017",
-            "text": {
-                "fr": "Les vieux bâtiments ont du charme.",
-                "en": "The old buildings have charm.",
-                "de": "Die alten Gebäude haben Charme.",
-                "it": "I vecchi edifici hanno il loro fascino.",
-                "es": "Los edificios antiguos tienen su encanto.",
-                "nl": "De oude gebouwen hebben charme.",
-                "pt": "Os prédios antigos têm charme."
-            },
-            "ipa": {
-                "fr": "le- vjˈø batimˈɑ̃z ˈɔ̃ dy- ʃˈaʁm",
-                "de": "[diː ˈʔaltən ɡəˈbɔɪ̯də ˈhaːbn̩ ˈʃaʁm]",
-                "it": "[ˌɪ vˈekːɪ ˌedifˈiːtʃɪ ˌanno ˌil lˌɔro fˈaʃino]",
-                "es": "[los eðiˈfiθjos anˈtiɣwos ˈtjɛnen su enˈtʃanto]",
-                "nl": "[də ˈʌʊdə ɣəbˈʌʊən hˌɛbən ʃˈɑrmə]",
-                "pt": "[ʊs prˈɛdʒjʊz ˌɐ̃ŋtʃˈiɡʊs teɪŋ ʃˈaɾəmy]",
-                "en": "[ðɪ ˈəʊld bˈɪldɪŋz hav tʃˈɑːm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-018",
-            "text": {
-                "fr": "On achète du vin?",
-                "en": "Shall we buy some wine?",
-                "de": "Kaufen wir Wein?",
-                "it": "Compriamo del vino?",
-                "es": "¿Compramos vino?",
-                "nl": "Zullen we wijn kopen?",
-                "pt": "A gente compra vinho?",
-                "en_pt": "Should we buy wine?"
-            },
-            "ipa": {
-                "fr": "ɔ̃n aʃˈɛt dy- vˈɛ̃",
-                "de": "[ˈkaʊ̯fn̩ viːɐ̯ ˈvaɪ̯n]",
-                "it": "[kˌompriˈaːmo dˌɛl vˈiːno]",
-                "es": "[komˈpɾamos ˈβino]",
-                "nl": "[zˌɵlən ʋə ʋˈɛɪn kˈoːpən]",
-                "pt": "[a ʒˈeɪŋtʃy kˈompræ vˈiɲʊ]",
-                "en": "[ʃˌal wiː bˈaɪ sˌʌm wˈaɪn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-019",
-            "text": {
-                "fr": "Bonne idée! On peut prendre une bouteille pour ce soir.",
-                "en": "Good idea! We can take a bottle for tonight.",
-                "de": "Gute Idee! Wir können eine Flasche für heute Abend nehmen.",
-                "it": "Buona idea! Possiamo prendere una bottiglia per stasera.",
-                "es": "¡Buena idea! Podemos llevar una botella para esta noche.",
-                "nl": "Goed idee! We kunnen een fles voor vanavond nemen.",
-                "pt": "Podemos pegar uma garrafa para hoje à noite.",
-                "en_pt": "We can get a bottle for tonight."
-            },
-            "ipa": {
-                "fr": "bˈɔn idˈe ɔ̃ pˈø pʁˈɑ̃dʁ yn butˈɛj puʁ sə- swˈaʁ",
-                "de": "[ˈɡuːtə ʔiˈdeː! viːɐ̯ ˈkœnən ˈaɪ̯nə ˈflaʃə fʏɐ̯ ˈhoɪ̯tə ˈʔaːbnt ˈneːmən]",
-                "it": "[bʊˌona idˈɛːa\n possjˈaːmo prˈendere ˌʊna botːˈiːʎa pˌɛr stazˈeːra]",
-                "es": "[ˈbwena iˈðea poˈðemos ʎeˈβaɾ una boˈteʎa paɾa ˈesta ˈnotʃe]",
-                "nl": "[ɣˈut idˈeː\n ʋə kˌɵnən ən flˈɛs vɔːr vɑnˈaːvɔnt nˈeːmən]",
-                "pt": "[podˌemʊs peɡˈaɾ ˌumæ ɡˌaxˈafæ pˌaɾæ ˈoʒj ˌaː nˈoɪtʃy]",
-                "en": "[ɡˈʊd aɪdˈiə wiː kan tˈeɪk ɐ bˈɒtəl fɔː tənˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-020",
-            "text": {
-                "fr": "Quel vin tu préfères?",
-                "en": "Which wine do you prefer?",
-                "de": "Welchen Wein bevorzugst du?",
-                "it": "Quale vino preferisci?",
-                "es": "¿Qué vino prefieres?",
-                "nl": "Welke wijn heb je liever?",
-                "pt": "Que vinho você prefere?",
-                "en_pt": "What wine do you prefer?"
-            },
-            "ipa": {
-                "fr": "kɛl vˈɛ̃ ty pʁefˈɛʁ",
-                "de": "[ˈvɛlçn̩ ˈvaɪ̯n bəˈfɔɐ̯t͡sʊkst duː]",
-                "it": "[kwˈaːle vˈiːno prˌeferˈiːʃɪ]",
-                "es": "[ke ˈβino pɾeˈfjeɾes]",
-                "nl": "[ʋˈɛlkə ʋˈɛɪn hɛp jə lˈivər]",
-                "pt": "[ky vˈiɲʊ vosˌe prˌefˈɛɾy]",
-                "en": "[wˌɪtʃ wˈaɪn dˈuː juː pɹɪfˈɜː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-021",
-            "text": {
-                "fr": "Le rouge, toujours le rouge.",
-                "en": "The red, always the red.",
-                "de": "Rotwein, immer Rotwein.",
-                "it": "Il rosso, sempre il rosso.",
-                "es": "El tinto, siempre el tinto.",
-                "nl": "De rode, altijd de rode.",
-                "pt": "Tinto, sempre tinto.",
-                "en_pt": "Red, always red."
-            },
-            "ipa": {
-                "fr": "lə- ʁˈuʒ tuʒˌuʁ lə- ʁˈuʒ",
-                "de": "[ˈʁoːtvaɪ̯n, ˈɪmɐ ˈʁoːtvaɪ̯n]",
-                "it": "[ˌil rˈosso\n sˈɛmpre ˌil rˈosso]",
-                "es": "[el ˈtinto ˈsjɛmpɾe el ˈtinto]",
-                "nl": "[də rˈoːdə\n ˈɑltɛɪ tə rˈoːdə]",
-                "pt": "[tʃˈiŋtʊ\n sˌeɪmpry tʃˈiŋtʊ]",
-                "en": "[ðə ɹˈɛd ˈɔːlweɪz ðə ɹˈɛd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-022",
-            "text": {
-                "fr": "Parfait, prenons une bouteille.",
-                "en": "Perfect, let's take a bottle.",
-                "de": "Perfekt, nehmen wir eine Flasche.",
-                "it": "Perfetto, prendiamo una bottiglia.",
-                "es": "Perfecto, llevemos una botella.",
-                "nl": "Perfect, laten we een fles nemen.",
-                "pt": "Perfeito, vamos pegar uma garrafa.",
-                "en_pt": "Perfect, let's get a bottle."
-            },
-            "ipa": {
-                "fr": "paʁfˈɛ pʁənˈɔ̃z yn butˈɛj",
-                "de": "[pɛʁˈfɛkt, ˈneːmən viːɐ̯ ˈaɪ̯nə ˈflaʃə]",
-                "it": "[perfˈɛtːo\n prendjˈaːmo ˌʊna botːˈiːʎa]",
-                "es": "[peɾˈfekto ʎeˈβemos ˈuna boˈteʎa]",
-                "nl": "[pˈɛrfɛkt\n lˈaːtən ʋə ən flˈɛs nˈeːmən]",
-                "pt": "[pˌeɾəfˈeɪtʊ\n vˌɐ̃mʊs peɡˈaɾ ˌumæ ɡˌaxˈafæ]",
-                "en": "[pˈɜːfɛkt lˈɛts tˈeɪk ɐ bˈɒtəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-023",
-            "text": {
-                "fr": "L'après-midi, Sophie et Lucas se promènent dans les rues du Marais.",
-                "en": "In the afternoon, Sophie and Lucas walk through the streets of De Pijp.",
-                "de": "Am Nachmittag spazieren Sophie und Lucas durch die Straßen von Kreuzberg.",
-                "it": "Nel pomeriggio, Sophie e Lucas passeggiano per le strade di Trastevere.",
-                "es": "Por la tarde, Sophie y Lucas pasean por las calles de Malasaña.",
-                "nl": "'s Middags wandelen Sophie en Lucas door de straten van De Pijp.",
-                "pt": "À tarde, Sophie e Lucas passeiam pelas ruas da Vila Madalena.",
-                "en_pt": "In the afternoon, Sophie and Lucas walk through the streets of Vila Madalena."
-            },
-            "ipa": {
-                "fr": "lapʁˌɛmidˈi sɔfˈi e lykˈa sə- pʁɔmˈɛn dɑ̃ le- ʁˈy dy- maʁˈɛ",
-                "de": "[am ˈnaːxmitaːk ˈʃpaːt͡siːʁən ˈzɔfiː ʊnt ˈluːkas dʊʁç diː ˈʃtʁaːsən fɔn ˈkʁɔɪ̯tsbɛʁk]",
-                "it": "[nˌɛl pˌomerˈidʒːo\n sˈopje ˌe lˈuːkas passˈɛdʒːano pˌɛr lˌe strˈaːde dˌɪ trastˈevere]",
-                "es": "[poɾ la ˈtarðe ˈsofi i ˈlukas paˈsean poɾ las ˈkaʎes ðe malaˈsaɲa]",
-                "nl": "[s mˈɪdɑxs ʋˈɑndələn sɔphˈi ɛn lˈykɑs doːr də strˈaːtən vɑn də pˈɛɪp]",
-                "pt": "[ˌaː tˈaɾədʒy\n sˌofˈij i lˈukæs pˌasˈeɪɐ̃ʊ̃ pˈelæz xˈuæz da vˈilæ mˌadalˈenæ]",
-                "en": "[ɪnðɪ ˌaftənˈuːn sˈəʊfi and lˈuːkəz wˈɔːk θɹuː ðə stɹˈiːts ɒv də pˈeɪp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-024",
-            "text": {
-                "fr": "Ils entrent dans une petite épicerie.",
-                "en": "They enter a small grocery store.",
-                "de": "Sie gehen in einen kleinen Lebensmittelladen.",
-                "it": "Entrano in un piccolo negozio di alimentari.",
-                "es": "Entran en una pequeña tienda de alimentación.",
-                "nl": "Ze gaan een kleine kruidenierswinkel binnen.",
-                "pt": "Eles entram em uma pequena mercearia."
-            },
-            "ipa": {
-                "fr": "ilz ˈɑ̃tʁ dɑ̃z yn pətˈit episʁˈi",
-                "de": "[ziː ˈɡeːən ˈaɪ̯nən ˈklaɪ̯nən ˈleːbənsˌmɪtəllaːdn̩]",
-                "it": "[ˈentrano ˌin ˌʊn pˈikːolo neɡˈɔtsio dˌɪ ˌalimentˈaːrɪ]",
-                "es": "[ˈentɾan en ˈuna peˈkeɲa ˈtjenda ðe alimenˈtaθjon]",
-                "nl": "[zə ɣˈaːn ən klˈɛɪnə krˌœydənˌirsʋɪŋkˈɛl bˈɪnən]",
-                "pt": "[ˌelyz ˈeɪŋtrɐ̃ʊ̃ ˈeɪŋ ˌumæ pˌekˈenæ mˌeɾəseaɾˈiæ]",
-                "en": "[ðeɪ ˈɛntəɹ ɐ smˈɔːl ɡɹˈəʊsəɹɪ stˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-025",
-            "text": {
-                "fr": "Lucas examine les fromages sur le comptoir.",
-                "en": "Lucas examines the cheeses on the counter.",
-                "de": "Lucas betrachtet die Käse auf dem Tresen.",
-                "it": "Lucas esamina i formaggi sul bancone.",
-                "es": "Lucas examina los quesos sobre el mostrador.",
-                "nl": "Lucas bekijkt de kazen op de toonbank.",
-                "pt": "Lucas examina os queijos no balcão."
-            },
-            "ipa": {
-                "fr": "lykˈaz ɛɡzamˈin le- fʁɔmˈaʒ syʁ lə- kɔ̃twˈaʁ",
-                "de": "[ˈluːkas bəˈtʁaxtət diː ˈkɛːzə aʊ̯f deːm ˈtʁeːzn̩]",
-                "it": "[lˈuːkas ezˈamina ˌɪ formˈadʒːɪ sˌʊl bankˈoːne]",
-                "es": "[ˈlukas eksaˈmina los ˈkesos ˈsoβɾe el mosˈtɾaðoɾ]",
-                "nl": "[lˈykɑs bəkˈɛɪk tə kˈaːzən ɔp də tˈoːnbɑŋk]",
-                "pt": "[lˈukæz ˌezæmˈinæ ʊs kˈeɪʒʊz nʊ baʊkˈɐ̃ʊ̃]",
-                "en": "[lˈuːkəz ɛɡzˈamɪnz ðə tʃˈiːzɪz ɒnðə kˈaʊntə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-026",
             "text": {
                 "fr": "Sophie fait la grimace.",
                 "en": "Sophie makes a face.",
@@ -815,25 +410,24 @@
             }
         },
         {
-            "id": "scene-02-027",
+            "id": "scene-02-015",
             "text": {
-                "fr": "Ils marchent vers la boulangerie.",
-                "en": "They walk towards the bakery.",
-                "de": "Sie gehen zur Bäckerei.",
-                "it": "Si dirigono verso la panetteria.",
-                "es": "Caminan hacia la churrería.",
-                "nl": "Ze lopen naar de bakkerij.",
-                "pt": "Eles caminham em direção à padaria.",
-                "en_pt": "They walk toward the bakery."
+                "fr": "C'est trop cher pour moi.",
+                "en": "That's too expensive for me.",
+                "de": "Das ist mir zu teuer.",
+                "it": "È troppo caro per me.",
+                "es": "Es demasiado caro para mí.",
+                "nl": "Dat is te duur voor mij.",
+                "pt": "Está muito caro para mim."
             },
             "ipa": {
-                "fr": "il mˈaʁʃ vɛʁ la- bulɑ̃ʒʁˈi",
-                "de": "[ziː ˈɡeːən tsuːɐ̯ ˈbɛkəʁaɪ̯]",
-                "it": "[sˌɪ dirˈiɡono vˌɛrso lˌa pˌanetːerˈiːa]",
-                "es": "[kaˈminan ˈaθja la tʃuˈreɾia]",
-                "nl": "[zə lˈoːpən naːr də bˌɑkərˈɛɪ]",
-                "pt": "[ˌelys kˌæmˈiɲɐ̃ʊ̃ ˈeɪŋ dʒˌiɾesˈɐ̃ʊ̃ ˌaː pˌadaɾˈiæ]",
-                "en": "[ðeɪ wˈɔːk tʊwˈɔːdz ðə bˈeɪkəɹɪ]"
+                "fr": "sɛ tʁo ʃˈɛʁ puʁ mwˈa",
+                "de": "[das ɪst miːɐ̯ tsuː ˈtɔɪ̯ɐ]",
+                "it": "[ˌɛ trˈɔpːo kˈaːro pˌɛr mˈe]",
+                "es": "[es deˈmasjaðo ˈkaɾo paɾa ˈmi]",
+                "nl": "[dɑt ɪs tə dˈyr vɔːr mˈɛɪ]",
+                "pt": "[estˌa mwˈiŋtʊ kˈaɾʊ pˌaɾæ mˈiŋ]",
+                "en": "[ðats tˈuː ɛkspˈɛnsɪv fɔː mˌiː]"
             },
             "provenance": {
                 "fr": "original",
@@ -846,7 +440,466 @@
             }
         },
         {
+            "id": "scene-02-016",
+            "text": {
+                "pt": "Olha, diz a comerciante, tenho tomates de ontem.",
+                "en": "Look, says the shopkeeper, I have tomatoes from yesterday."
+            },
+            "ipa": {
+                "pt": "[ˈɔljæ\n dʒˈiz a kˌomeɾəsiˈɐ̃ŋtʃy\n tˌeɲʊ tˌomˈatʃyz dʒj ˈoŋteɪŋ]",
+                "en": "[lˈʊk sˈɛz ðə ʃˈɒpkiːpə aɪ hav təmˈɑːtəʊz fɹɒm jˈɛstədˌeɪ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-017",
+            "text": {
+                "pt": "Quatro reais o quilo.",
+                "en": "Four reais per kilo."
+            },
+            "ipa": {
+                "pt": "[kwˈatrʊ xeˈaɪz ʊ kˈilʊ]",
+                "en": "[fˈɔː ɹˈiːiz pɜː kˈiːləʊ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-018",
+            "text": {
+                "fr": "D'accord, nous prenons un kilo.",
+                "en": "Okay, we'll take a kilo.",
+                "de": "Okay, wir nehmen ein Kilo.",
+                "it": "Va bene, prendiamo un chilo.",
+                "es": "Vale, llevamos un kilo.",
+                "nl": "Oké, we nemen een kilo.",
+                "pt": "Tá bom, a gente leva um quilo.",
+                "en_pt": "Okay, we'll take one kilo."
+            },
+            "ipa": {
+                "fr": "dakˈɔʁ nu pʁənˈɔ̃z œ̃ kilˈo",
+                "de": "[oˈkaɪ̯, viːɐ̯ ˈneːmən aɪ̯n ˈkiːlo]",
+                "it": "[vˈa bˈɛːne\n prendjˈaːmo ˌʊn kˈiːlo]",
+                "es": "[ˈβale ʎeˈβamos un ˈkilo]",
+                "nl": "[oːkˈeː\n ʋə nˈeːmən ən kˈiloː]",
+                "pt": "[tˈa bˈoŋ\n a ʒˈeɪŋtʃy lˈɛvæ ũŋ kˈilʊ]",
+                "en": "[əʊkˈeɪ wiːl tˈeɪk ɐ kˈiːləʊ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-019",
+            "text": {
+                "pt": "Eles continuam as compras.",
+                "en": "They continue shopping."
+            },
+            "ipa": {
+                "pt": "[ˌelys kˌoŋtʃinˈuɐ̃ʊ̃ as kˈompræs]",
+                "en": "[ðeɪ kəntˈɪnjuː ʃˈɒpɪŋ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-020",
+            "text": {
+                "fr": "Où est la boulangerie?",
+                "en": "Where is the bakery?",
+                "de": "Wo ist die Bäckerei?",
+                "it": "Dove è la panetteria?",
+                "es": "¿Dónde está la churrería?",
+                "nl": "Waar is de bakkerij?",
+                "pt": "Lucas pergunta: Onde fica a padaria?",
+                "en_pt": "Lucas asks: Where is the bakery?"
+            },
+            "ipa": {
+                "fr": "u ɛ la- bulɑ̃ʒʁˈi",
+                "de": "[voː ɪst diː ˈbɛkəʁaɪ̯]",
+                "it": "[dˈoːve ˌɛ lˌa pˌanetːerˈiːa]",
+                "es": "[ˈdonde esˈta la tʃuˈreɾia]",
+                "nl": "[ʋˈaːr ɪs də bˌɑkərˈɛɪ]",
+                "pt": "[lˈukæs pˌeɾəɡˈũŋtæ\n ˌoŋdʒy fˈikæ a pˌadaɾˈiæ]",
+                "en": "[wˌeəɹ ɪz ðə bˈeɪkəɹɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-021",
+            "text": {
+                "fr": "Elle est au coin de la rue, après l'église.",
+                "en": "It's on the corner of the street, after the church.",
+                "de": "Sie ist an der Ecke, nach der Kirche.",
+                "it": "È all'angolo della strada, dopo la chiesa.",
+                "es": "Está en la esquina de la calle, después de la iglesia.",
+                "nl": "Die is om de hoek, voorbij de kerk.",
+                "pt": "É na esquina, depois da igreja.",
+                "en_pt": "It's on the corner, past the church."
+            },
+            "ipa": {
+                "fr": "ɛl ɛt o kwˈɛ̃ də- la- ʁˈy apʁˌɛ leɡlˈiz",
+                "de": "[ziː ɪst an deːɐ̯ ˈʔɛkə, naːx deːɐ̯ ˈkɪʁçə]",
+                "it": "[ˌɛ allˈaŋɡolo dˌɛlla strˈaːda\n dˈoːpo lˌa kjˈɛːza]",
+                "es": "[esˈta en la esˈkiɲa ðe la ˈkaʎe deˈspwes ðe la iˈɣlesja]",
+                "nl": "[di ɪs ɔm də hˈuk\n vˈɔːrbˌɛɪ də kˈɛrk]",
+                "pt": "[ɛ na ˌeskˈinæ\n depˈoɪz da ˌiɡrˈeʒæ]",
+                "en": "[ɪts ɒnðə kˈɔːnəɹ ɒvðə stɹˈiːt ˈaftə ðə tʃˈɜːtʃ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-022",
+            "text": {
+                "pt": "Saindo da loja, Sophie respira o ar fresco.",
+                "en": "Leaving the shop, Sophie breathes in the fresh air."
+            },
+            "ipa": {
+                "pt": "[sˌaˈiŋdʊ da lˈɔʒæ\n sˌofˈiy xˌespˈiɾæ u ˈar frˈeskʊ]",
+                "en": "[lˈiːvɪŋ ðə ʃˈɒp sˈəʊfi bɹˈiːðz ɪnðə fɹˈɛʃ ˈeə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-023",
+            "text": {
+                "fr": "J'aime ce quartier.",
+                "en": "I like this neighborhood.",
+                "de": "Ich mag diesen Kiez.",
+                "it": "Mi piace questo quartiere.",
+                "es": "Me gusta mucho este barrio.",
+                "nl": "Ik hou van deze buurt.",
+                "pt": "Eu adoro esse bairro.",
+                "en_pt": "I love this neighborhood."
+            },
+            "ipa": {
+                "fr": "ʒˈɛm sə- kaʁtjˈe",
+                "de": "[ɪç maːk ˈdiːzn̩ ˈkiːts]",
+                "it": "[mˌɪ pjˈaːtʃe kwˌɛsto kwˌartiˈɛːre]",
+                "es": "[me ˈɣusta ˈmutʃo ˈeste ˈβarjo]",
+                "nl": "[ɪk hˈʌʊ vɑn dˌeːzə bˈyrt]",
+                "pt": "[eʊ ˌadˈɔɾw ˌesi bˈaɪxʊ]",
+                "en": "[aɪ lˈaɪk ðɪs nˈeɪbəhˌʊd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-024",
+            "text": {
+                "fr": "Moi aussi, c'est très joli",
+                "en": "Me too, it's very pretty.",
+                "de": "Ich auch, er ist wirklich hübsch.",
+                "it": "Anche a me, è molto bello",
+                "es": "A mí también, es muy bonito.",
+                "nl": "Ik ook, het is heel mooi",
+                "pt": "Eu também, é muito bonito.",
+                "en_pt": "Me too, it's very beautiful."
+            },
+            "ipa": {
+                "fr": "mwˌa osˈi sɛ tʁɛ ʒɔlˈi",
+                "de": "[ɪç aʊ̯x, ɛɐ̯ ɪst ˈvɪʁklɪç ˈhʏpʃ]",
+                "it": "[ˈanke ˌa mˈe\n ˌɛ mˈolto bˈɛllo]",
+                "es": "[a ˈmi tamˈbjɛn es ˈmwi βoˈnito]",
+                "nl": "[ɪk ˈoːk\n hət ɪs hˈeːl mˈoːj]",
+                "pt": "[eʊ tɐ̃mbˈeɪŋ\n ɛ mwˈiŋtʊ bˌonˈitʊ]",
+                "en": "[mˌiː tˈuː ɪts vˈɛɹɪ pɹˈɪti]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-025",
+            "text": {
+                "fr": "Les vieux bâtiments ont du charme.",
+                "en": "The old buildings have charm.",
+                "de": "Die alten Gebäude haben Charme.",
+                "it": "I vecchi edifici hanno il loro fascino.",
+                "es": "Los edificios antiguos tienen su encanto.",
+                "nl": "De oude gebouwen hebben charme.",
+                "pt": "Os prédios antigos têm charme."
+            },
+            "ipa": {
+                "fr": "le- vjˈø batimˈɑ̃z ˈɔ̃ dy- ʃˈaʁm",
+                "de": "[diː ˈʔaltən ɡəˈbɔɪ̯də ˈhaːbn̩ ˈʃaʁm]",
+                "it": "[ˌɪ vˈekːɪ ˌedifˈiːtʃɪ ˌanno ˌil lˌɔro fˈaʃino]",
+                "es": "[los eðiˈfiθjos anˈtiɣwos ˈtjɛnen su enˈtʃanto]",
+                "nl": "[də ˈʌʊdə ɣəbˈʌʊən hˌɛbən ʃˈɑrmə]",
+                "pt": "[ʊs prˈɛdʒjʊz ˌɐ̃ŋtʃˈiɡʊs teɪŋ ʃˈaɾəmy]",
+                "en": "[ðɪ ˈəʊld bˈɪldɪŋz hav tʃˈɑːm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-026",
+            "text": {
+                "fr": "Ils marchent vers la boulangerie.",
+                "en": "They walk toward the bakery.",
+                "de": "Sie gehen zur Bäckerei.",
+                "it": "Si dirigono verso la panetteria.",
+                "es": "Caminan hacia la churrería.",
+                "nl": "Ze lopen naar de bakkerij.",
+                "pt": "Eles caminham em direção à padaria."
+            },
+            "ipa": {
+                "fr": "il mˈaʁʃ vɛʁ la- bulɑ̃ʒʁˈi",
+                "de": "[ziː ˈɡeːən tsuːɐ̯ ˈbɛkəʁaɪ̯]",
+                "it": "[sˌɪ dirˈiɡono vˌɛrso lˌa pˌanetːerˈiːa]",
+                "es": "[kaˈminan ˈaθja la tʃuˈreɾia]",
+                "nl": "[zə lˈoːpən naːr də bˌɑkərˈɛɪ]",
+                "pt": "[ˌelys kˌæmˈiɲɐ̃ʊ̃ ˈeɪŋ dʒˌiɾesˈɐ̃ʊ̃ ˌaː pˌadaɾˈiæ]",
+                "en": "[ðeɪ wˈɔːk tʊwˈɔːd ðə bˈeɪkəɹɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-027",
+            "text": {
+                "pt": "Lucas tem uma ideia.",
+                "en": "Lucas has an idea."
+            },
+            "ipa": {
+                "pt": "[lˈukæs teɪŋ ˌumæ ˌidˈɛɪæ]",
+                "en": "[lˈuːkəz hɐz ɐn aɪdˈiə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
             "id": "scene-02-028",
+            "text": {
+                "fr": "On achète du vin?",
+                "en": "Shall we buy some wine?",
+                "de": "Kaufen wir Wein?",
+                "it": "Compriamo del vino?",
+                "es": "¿Compramos vino?",
+                "nl": "Zullen we wijn kopen?",
+                "pt": "A gente compra vinho?",
+                "en_pt": "Should we buy wine?"
+            },
+            "ipa": {
+                "fr": "ɔ̃n aʃˈɛt dy- vˈɛ̃",
+                "de": "[ˈkaʊ̯fn̩ viːɐ̯ ˈvaɪ̯n]",
+                "it": "[kˌompriˈaːmo dˌɛl vˈiːno]",
+                "es": "[komˈpɾamos ˈβino]",
+                "nl": "[zˌɵlən ʋə ʋˈɛɪn kˈoːpən]",
+                "pt": "[a ʒˈeɪŋtʃy kˈompræ vˈiɲʊ]",
+                "en": "[ʃˌal wiː bˈaɪ sˌʌm wˈaɪn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-029",
+            "text": {
+                "pt": "Boa ideia!",
+                "en": "Good idea!"
+            },
+            "ipa": {
+                "pt": "[bˈoæ ˌidˈɛɪæ]",
+                "en": "[ɡˈʊd aɪdˈiə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-030",
+            "text": {
+                "fr": "Bonne idée! On peut prendre une bouteille pour ce soir.",
+                "en": "Good idea! We can get a bottle for tonight.",
+                "de": "Gute Idee! Wir können eine Flasche für heute Abend nehmen.",
+                "it": "Buona idea! Possiamo prendere una bottiglia per stasera.",
+                "es": "¡Buena idea! Podemos llevar una botella para esta noche.",
+                "nl": "Goed idee! We kunnen een fles voor vanavond nemen.",
+                "pt": "Podemos pegar uma garrafa para hoje à noite.",
+                "en_pt": "We can get a bottle for tonight."
+            },
+            "ipa": {
+                "fr": "bˈɔn idˈe ɔ̃ pˈø pʁˈɑ̃dʁ yn butˈɛj puʁ sə- swˈaʁ",
+                "de": "[ˈɡuːtə ʔiˈdeː! viːɐ̯ ˈkœnən ˈaɪ̯nə ˈflaʃə fʏɐ̯ ˈhoɪ̯tə ˈʔaːbnt ˈneːmən]",
+                "it": "[bʊˌona idˈɛːa\n possjˈaːmo prˈendere ˌʊna botːˈiːʎa pˌɛr stazˈeːra]",
+                "es": "[ˈbwena iˈðea poˈðemos ʎeˈβaɾ una boˈteʎa paɾa ˈesta ˈnotʃe]",
+                "nl": "[ɣˈut idˈeː\n ʋə kˌɵnən ən flˈɛs vɔːr vɑnˈaːvɔnt nˈeːmən]",
+                "pt": "[podˌemʊs peɡˈaɾ ˌumæ ɡˌaxˈafæ pˌaɾæ ˈoʒj ˌaː nˈoɪtʃy]",
+                "en": "[ɡˈʊd aɪdˈiə wiː kan ɡɛt ɐ bˈɒtəl fɔː tənˈaɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-031",
+            "text": {
+                "fr": "Quel vin tu préfères?",
+                "en": "Which wine do you prefer?",
+                "de": "Welchen Wein bevorzugst du?",
+                "it": "Quale vino preferisci?",
+                "es": "¿Qué vino prefieres?",
+                "nl": "Welke wijn heb je liever?",
+                "pt": "Que vinho você prefere?",
+                "en_pt": "What wine do you prefer?"
+            },
+            "ipa": {
+                "fr": "kɛl vˈɛ̃ ty pʁefˈɛʁ",
+                "de": "[ˈvɛlçn̩ ˈvaɪ̯n bəˈfɔɐ̯t͡sʊkst duː]",
+                "it": "[kwˈaːle vˈiːno prˌeferˈiːʃɪ]",
+                "es": "[ke ˈβino pɾeˈfjeɾes]",
+                "nl": "[ʋˈɛlkə ʋˈɛɪn hɛp jə lˈivər]",
+                "pt": "[ky vˈiɲʊ vosˌe prˌefˈɛɾy]",
+                "en": "[wˌɪtʃ wˈaɪn dˈuː juː pɹɪfˈɜː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-032",
+            "text": {
+                "fr": "Le rouge, toujours le rouge.",
+                "en": "Red, always red.",
+                "de": "Rotwein, immer Rotwein.",
+                "it": "Il rosso, sempre il rosso.",
+                "es": "El tinto, siempre el tinto.",
+                "nl": "De rode, altijd de rode.",
+                "pt": "Tinto, sempre tinto."
+            },
+            "ipa": {
+                "fr": "lə- ʁˈuʒ tuʒˌuʁ lə- ʁˈuʒ",
+                "de": "[ˈʁoːtvaɪ̯n, ˈɪmɐ ˈʁoːtvaɪ̯n]",
+                "it": "[ˌil rˈosso\n sˈɛmpre ˌil rˈosso]",
+                "es": "[el ˈtinto ˈsjɛmpɾe el ˈtinto]",
+                "nl": "[də rˈoːdə\n ˈɑltɛɪ tə rˈoːdə]",
+                "pt": "[tʃˈiŋtʊ\n sˌeɪmpry tʃˈiŋtʊ]",
+                "en": "[ɹˈɛd ˈɔːlweɪz ɹˈɛd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-033",
+            "text": {
+                "fr": "Parfait, prenons une bouteille.",
+                "en": "Perfect, let's take a bottle.",
+                "de": "Perfekt, nehmen wir eine Flasche.",
+                "it": "Perfetto, prendiamo una bottiglia.",
+                "es": "Perfecto, llevemos una botella.",
+                "nl": "Perfect, laten we een fles nemen.",
+                "pt": "Perfeito, vamos pegar uma garrafa.",
+                "en_pt": "Perfect, let's get a bottle."
+            },
+            "ipa": {
+                "fr": "paʁfˈɛ pʁənˈɔ̃z yn butˈɛj",
+                "de": "[pɛʁˈfɛkt, ˈneːmən viːɐ̯ ˈaɪ̯nə ˈflaʃə]",
+                "it": "[perfˈɛtːo\n prendjˈaːmo ˌʊna botːˈiːʎa]",
+                "es": "[peɾˈfekto ʎeˈβemos ˈuna boˈteʎa]",
+                "nl": "[pˈɛrfɛkt\n lˈaːtən ʋə ən flˈɛs nˈeːmən]",
+                "pt": "[pˌeɾəfˈeɪtʊ\n vˌɐ̃mʊs peɡˈaɾ ˌumæ ɡˌaxˈafæ]",
+                "en": "[pˈɜːfɛkt lˈɛts tˈeɪk ɐ bˈɒtəl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-02-034",
             "text": {
                 "fr": "Ils entrent dans un petit magasin de vins.",
                 "en": "They enter a small wine shop.",
@@ -876,7 +929,7 @@
             }
         },
         {
-            "id": "scene-02-029",
+            "id": "scene-02-035",
             "text": {
                 "fr": "Le propriétaire les conseille et ils repartent avec un bon bordeaux.",
                 "en": "The owner advises them and they leave with a good Bordeaux.",
@@ -907,137 +960,83 @@
             }
         },
         {
-            "id": "scene-02-030",
-            "text": {
-                "pt": "Bom dia, diz a comerciante.",
-                "en": "Good morning, says the shopkeeper."
-            },
-            "ipa": {
-                "pt": "[bˈoŋ dʒˈiæ\n dʒˈiz a kˌomeɾəsiˈɐ̃ŋtʃy]",
-                "en": "[ɡˈʊd mˈɔːnɪŋ sˈɛz ðə ʃˈɒpkiːpə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-031",
-            "text": {
-                "pt": "Sim, está muito bom.",
-                "en": "Yes, it's very good."
-            },
-            "ipa": {
-                "pt": "[sˈiŋ\n estˌa mwˈiŋtʊ bˈoŋ]",
-                "en": "[jˈɛs ɪts vˈɛɹɪ ɡˈʊd]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-032",
-            "text": {
-                "pt": "Perfeito.",
-                "en": "Perfect."
-            },
-            "ipa": {
-                "pt": "[pˌeɾəfˈeɪtʊ]",
-                "en": "[pˈɜːfɛkt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-033",
-            "text": {
-                "pt": "Olha, diz a comerciante, tenho tomates de ontem.",
-                "en": "Look, says the shopkeeper, I have tomatoes from yesterday."
-            },
-            "ipa": {
-                "pt": "[ˈɔljæ\n dʒˈiz a kˌomeɾəsiˈɐ̃ŋtʃy\n tˌeɲʊ tˌomˈatʃyz dʒj ˈoŋteɪŋ]",
-                "en": "[lˈʊk sˈɛz ðə ʃˈɒpkiːpə aɪ hav təmˈɑːtəʊz fɹɒm jˈɛstədˌeɪ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-034",
-            "text": {
-                "pt": "Quatro reais o quilo.",
-                "en": "Four reais per kilo."
-            },
-            "ipa": {
-                "pt": "[kwˈatrʊ xeˈaɪz ʊ kˈilʊ]",
-                "en": "[fˈɔː ɹˈiːiz pɜː kˈiːləʊ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-02-035",
-            "text": {
-                "pt": "Eles continuam as compras.",
-                "en": "They continue shopping."
-            },
-            "ipa": {
-                "pt": "[ˌelys kˌoŋtʃinˈuɐ̃ʊ̃ as kˈompræs]",
-                "en": "[ðeɪ kəntˈɪnjuː ʃˈɒpɪŋ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-02-036",
             "text": {
-                "pt": "Saindo da loja, Sophie respira o ar fresco.",
-                "en": "Leaving the shop, Sophie breathes in the fresh air."
+                "fr": "Bonjour,",
+                "en": "Hello",
+                "de": "Hallo,",
+                "it": "Ciao,",
+                "es": "Hola,",
+                "nl": "Hoi,"
             },
             "ipa": {
-                "pt": "[sˌaˈiŋdʊ da lˈɔʒæ\n sˌofˈiy xˌespˈiɾæ u ˈar frˈeskʊ]",
-                "en": "[lˈiːvɪŋ ðə ʃˈɒp sˈəʊfi bɹˈiːðz ɪnðə fɹˈɛʃ ˈeə]"
+                "fr": "bɔ̃ʒˈuʁ",
+                "de": "[ˈhalo]",
+                "it": "[tʃˈaʊ]",
+                "es": "[ˈola]",
+                "nl": "[hˈoːi]",
+                "en": "[həlˈəʊ]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-02-037",
             "text": {
-                "pt": "Lucas tem uma ideia.",
-                "en": "Lucas has an idea."
+                "fr": "Regardez,",
+                "en": "Look,",
+                "de": "Schau mal,",
+                "it": "Guarda,",
+                "es": "Mira,",
+                "nl": "Kijk,"
             },
             "ipa": {
-                "pt": "[lˈukæs teɪŋ ˌumæ ˌidˈɛɪæ]",
-                "en": "[lˈuːkəz hɐz ɐn aɪdˈiə]"
+                "fr": "ʁəɡaʁdˈe",
+                "de": "[ʃaʊ̯ mal]",
+                "it": "[ɡwˈaːrda]",
+                "es": "[ˈmiɾa]",
+                "nl": "[kˈɛɪk]",
+                "en": "[lˈʊk]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-02-038",
             "text": {
-                "pt": "Boa ideia!",
-                "en": "Good idea!"
+                "fr": "j'ai des tomates d'hier. Deux euros le kilo.",
+                "en": "I have yesterday's tomatoes. Two euros per kilo.",
+                "de": "ich habe noch Tomaten von gestern. Zwei Euro pro Kilo.",
+                "it": "ho dei pomodori di ieri. Due euro al chilo.",
+                "es": "tengo tomates de ayer. Dos euros el kilo.",
+                "nl": "ik heb tomaten van gisteren. Twee euro per kilo."
             },
             "ipa": {
-                "pt": "[bˈoæ ˌidˈɛɪæ]",
-                "en": "[ɡˈʊd aɪdˈiə]"
+                "fr": "ʒe de- tɔmˈat djˈɛʁ dˈøz øʁˈo lə- kilˈo",
+                "de": "[ɪç ˈhaːbə nɔx toˈmaːtn̩ fɔn ˈɡɛstɐn. tsvaɪ̯ ˈʔøːʁo pʁoː ˈkiːlo]",
+                "it": "[ˌo dˌɛj pˌomodˈoːrɪ dˌɪ jˈɛːrɪ\n dˈuːe ˈɛʊro ˌal kˈiːlo]",
+                "es": "[ˈteŋɡo toˈmates ðe aˈʝeɾ dos ˈewɾos el ˈkilo]",
+                "nl": "[ɪk hɛp toːmˈaːtən vɑn ɣˈɪstərən\n tʋˈeː ˈøːroː pˈɛr kˈiloː]",
+                "en": "[aɪ hav jˈɛstədˌeɪz təmˈɑːtəʊz tˈuː jˈʊəɹəʊz pɜː kˈiːləʊ]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-03.json
+++ b/language_materials/unified/stories/scene-03.json
@@ -24,12 +24,73 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-03-001",
+            "text": {
+                "fr": "Le soir, dans l'appartement de Sophie, ils partagent le vin et du fromage.",
+                "en": "In the evening, in Sophie's apartment, they share wine and cheese.",
+                "de": "Abends, in Sophies Wohnung, teilen sie Wein und Käse.",
+                "it": "La sera, nell'appartamento di Sophie, condividono vino e formaggio.",
+                "es": "Por la noche, en el apartamento de Sophie, comparten vino y queso.",
+                "nl": "'s Avonds, in het appartement van Sophie, delen ze wijn en kaas.",
+                "pt": "À noite, no apartamento de Sophie, eles compartilham o vinho e queijo.",
+                "en_pt": "In the evening, at Sophie's apartment, they share the wine and cheese."
+            },
+            "ipa": {
+                "fr": "lə- swˈaʁ dɑ̃ lapaʁtəmˈɑ̃ də- sɔfˈi il paʁtˈaʒ lə- vˈɛ̃ e dy- fʁɔmˈaʒ",
+                "de": "[ˈaːbənts ɪn ˈzoːfiːs ˈvɔnʊŋ ˈtaɪ̯lən ziː vaɪ̯n ʊnt keːzə]",
+                "it": "[lˌa sˈeːra\n nellˌapːartamˈento dˌɪ sˈopje\n kˌondivˈidono vˈiːno ˌe formˈadʒːo]",
+                "es": "[poɾ la ˈnoʧe en el apaɾtaˈmento ðe ˈsofi komˈpaɾten ˈβino i ˈkeso]",
+                "nl": "[s ˈaːvɔnts\n ɪn hət ˌɑpɑrtəmˈɛnt vɑn sɔphˈi\n dˈeːlən zə ʋˈɛɪn ɛn kˈaːs]",
+                "pt": "[ˌaː nˈoɪtʃy\n nʊ ˌapaɾətæmˈeɪŋtʊ dʒy sˌofˈiy\n ˌelys kˌompaɾətʃˈiljɐ̃ʊ̃ ʊ vˈiɲw i kˈeɪʒʊ]",
+                "en": "[ɪnðɪ ˈiːvnɪŋ ɪn sˈəʊfiz ɐpˈɑːtmənt ðeɪ ʃˈeə wˈaɪn and tʃˈiːz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-002",
+            "text": {
+                "fr": "La conversation devient plus profonde.",
+                "en": "The conversation becomes deeper.",
+                "de": "Das Gespräch wird tiefer.",
+                "it": "La conversazione diventa più profonda.",
+                "es": "La conversación se hace más profunda.",
+                "nl": "Het gesprek wordt dieper.",
+                "pt": "A conversa fica mais profunda."
+            },
+            "ipa": {
+                "fr": "la- kɔ̃vɛʁsasjˈɔ̃ dəvjˈɛ̃ ply pʁɔfˈɔ̃d",
+                "de": "[das ɡəˈʃpʁɛːç vɪʁt ˈtiːfɐ]",
+                "it": "[lˌa kˌonversˌatsiˈɔːne divˈɛnta pjˌʊ profˈonda]",
+                "es": "[la konβeɾsaˈθjon se aˈθe mas pɾoˈfunda]",
+                "nl": "[hət ɣəsprˈɛk ʋɔr tˈipər]",
+                "pt": "[a kˌoŋvˈɛɾəsæ fˈikæ mˈaɪs prˌofˈũŋdæ]",
+                "en": "[ðə kɒnvəsˈeɪʃən bɪkˌʌmz dˈiːpə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-003",
             "text": {
                 "fr": "Tu sais, Lucas, je suis fatigué de cette vie,",
                 "en": "You know, Lucas, I'm tired of this life,",
@@ -60,10 +121,10 @@
             }
         },
         {
-            "id": "scene-03-002",
+            "id": "scene-03-004",
             "text": {
                 "fr": "Moi aussi, tout est pareil chaque jour",
-                "en": "Me too, every day is the same.",
+                "en": "Me too, everything is the same every day",
                 "de": "Ich auch, jeden Tag ist alles gleich",
                 "it": "Anch'io, è sempre tutto uguale ogni giorno",
                 "es": "Yo también, todo es igual cada día",
@@ -78,7 +139,7 @@
                 "es": "[ʝo tamˈbjen ˈtoðo es iˈɣwal ˈkaða ˈdi.a]",
                 "nl": "[ɪk ˈoːk\n ˈɛlkə dˈɑx ɪs hˈɛtzɛlvdə]",
                 "pt": "[eʊ tɐ̃mbˈeɪŋ\n tˈudw ɛ iɡwˈaʊ tˈodʊ dʒˈiæ]",
-                "en": "[mˌiː tˈuː ˈɛvɹɪ dˈeɪ ɪz ðə sˈeɪm]"
+                "en": "[mˌiː tˈuː ˈɛvɹɪθˌɪŋ ɪz ðə sˈeɪm ˈɛvɹɪ dˈeɪ]"
             },
             "provenance": {
                 "fr": "original",
@@ -91,34 +152,22 @@
             }
         },
         {
-            "id": "scene-03-003",
+            "id": "scene-03-005",
             "text": {
-                "fr": "Métro, boulot, dodo.",
-                "en": "Tram, work, sleep.",
-                "de": "U-Bahn, Arbeit, Schlaf.",
-                "it": "Metro, lavoro, dormire.",
-                "es": "Metro, curro, cama.",
-                "nl": "Tram, werk, slaap."
+                "pt": "Trânsito, trabalho, casa.",
+                "en": "Traffic, work, home."
             },
             "ipa": {
-                "fr": "metʁˈo bulˈo dɔdˈo",
-                "de": "[ʔuːˈbaːn ˈaʁbaɪ̯t ˈʃlaːf]",
-                "it": "[mˈeːtro\n lavˈɔːro\n dormˈiːre]",
-                "es": "[ˈmetɾo ˈkur.o ˈkama]",
-                "nl": "[trˈɑm\n ʋˈɛrk\n slˈaːp]",
-                "en": "[tɹˈam wˈɜːk slˈiːp]"
+                "pt": "[trˈɐ̃ŋzitʊ\n trˌabˈaljʊ\n kˈazæ]",
+                "en": "[tɹˈafɪk wˈɜːk hˈəʊm]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-03-004",
+            "id": "scene-03-006",
             "text": {
                 "fr": "On pourrait voyager quelque part",
                 "en": "We could travel somewhere",
@@ -149,7 +198,7 @@
             }
         },
         {
-            "id": "scene-03-005",
+            "id": "scene-03-007",
             "text": {
                 "fr": "Pour de vrai, pas juste en parler.",
                 "en": "For real, not just talk about it.",
@@ -180,7 +229,38 @@
             }
         },
         {
-            "id": "scene-03-006",
+            "id": "scene-03-008",
+            "text": {
+                "fr": "Lucas se redresse sur le canapé.",
+                "en": "Lucas sits up on the couch.",
+                "de": "Lucas setzt sich aufrecht auf das Sofa.",
+                "it": "Lucas si rialza sul divano.",
+                "es": "Lucas se yergue en el sofá.",
+                "nl": "Lucas zit rechtop op de bank.",
+                "pt": "Lucas se endireita no sofá.",
+                "en_pt": "Lucas sits up straight on the sofa."
+            },
+            "ipa": {
+                "fr": "lykˈa sə- ʁədʁˈɛs syʁ lə- kanapˈe",
+                "de": "[ˈluːkas zɛt͡st zɪç ˈaʊ̯fʁɛçt aʊ̯f das ˈzoːfa]",
+                "it": "[lˈuːkas sˌɪ riˈaltsa sˌʊl divˈaːno]",
+                "es": "[ˈlukas se ˈʝeɾɡe en el soˈfa]",
+                "nl": "[lˈykɑ sˈɪt rˈɛxtɔp ɔp də bˈɑŋk]",
+                "pt": "[lˈukæs sj ˌeɪŋdʒiɾˈeɪtæ nʊ sofˈa]",
+                "en": "[lˈuːkəz sˈɪts ˌʌp ɒnðə kˈaʊtʃ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-009",
             "text": {
                 "fr": "Où veux-tu aller?",
                 "en": "Where do you want to go?",
@@ -210,7 +290,22 @@
             }
         },
         {
-            "id": "scene-03-007",
+            "id": "scene-03-010",
+            "text": {
+                "pt": "Ainda não sei.",
+                "en": "I don't know yet."
+            },
+            "ipa": {
+                "pt": "[ˌaˈiŋdæ nˌɐ̃ʊ̃ sˈeɪ]",
+                "en": "[aɪ dˈəʊnt nˈəʊ jˈɛt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-011",
             "text": {
                 "fr": "Je ne sais pas encore. Mais loin d'ici.",
                 "en": "I don't know yet. But far from here.",
@@ -241,7 +336,7 @@
             }
         },
         {
-            "id": "scene-03-008",
+            "id": "scene-03-012",
             "text": {
                 "fr": "La montagne ou la mer?",
                 "en": "The mountains or the sea?",
@@ -272,7 +367,22 @@
             }
         },
         {
-            "id": "scene-03-009",
+            "id": "scene-03-013",
+            "text": {
+                "pt": "pergunta Lucas.",
+                "en": "Lucas asks."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ lˈukæs]",
+                "en": "[lˈuːkəz ˈasks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-014",
             "text": {
                 "fr": "La montagne, j'adore la nature",
                 "en": "The mountains, I love nature",
@@ -303,7 +413,7 @@
             }
         },
         {
-            "id": "scene-03-010",
+            "id": "scene-03-015",
             "text": {
                 "fr": "Les arbres, l'air pur, le silence.",
                 "en": "The trees, the fresh air, the silence.",
@@ -334,34 +444,37 @@
             }
         },
         {
-            "id": "scene-03-011",
+            "id": "scene-03-016",
             "text": {
-                "fr": "Les Alpes?",
-                "en": "The Ardennes?",
-                "de": "Die Alpen?",
-                "it": "Le Alpi?",
-                "es": "¿Los Pirineos?",
-                "nl": "De Ardennen?"
+                "pt": "A Serra da Mantiqueira?",
+                "en": "The Serra da Mantiqueira?"
             },
             "ipa": {
-                "fr": "le-z ˈalp",
-                "de": "[diː ˈalpn̩]",
-                "it": "[lˌe ˈalpɪ]",
-                "es": "[los piɾiˈne.os]",
-                "nl": "[də ˈɑrdɛnən]",
-                "en": "[ðɪ ˈɑːdənz]"
+                "pt": "[a sˈɛxæ da mˌɐ̃ŋtʃikˈeɪɾæ]",
+                "en": "[ðə sˈɛɹə dˈɑː mˈantɪkwˌeəɹə]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-03-012",
+            "id": "scene-03-017",
+            "text": {
+                "pt": "Sim!",
+                "en": "Yes!"
+            },
+            "ipa": {
+                "pt": "[sˈiŋ]",
+                "en": "[jˈɛs]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-018",
             "text": {
                 "fr": "Oui! C'est une excellente idée!",
                 "en": "Yes! That's an excellent idea!",
@@ -392,10 +505,41 @@
             }
         },
         {
-            "id": "scene-03-013",
+            "id": "scene-03-019",
+            "text": {
+                "fr": "Lucas se lève avec enthousiasme.",
+                "en": "Lucas gets up with enthusiasm.",
+                "de": "Lucas steht begeistert auf.",
+                "it": "Lucas si alza con entusiasmo.",
+                "es": "Lucas se levanta con entusiasmo.",
+                "nl": "Lucas staat enthousiast op.",
+                "pt": "Lucas se levanta com entusiasmo.",
+                "en_pt": "Lucas stands up enthusiastically."
+            },
+            "ipa": {
+                "fr": "lykˈa sə- lˈɛv avˌɛkɛnθˈawzɪˌazmɪ",
+                "de": "[ˈluːkas ʃteːt bəˈɡaɪ̯stɐt aʊ̯f]",
+                "it": "[lˈuːkas sˌɪ ˈaltsa kˌon ˌentʊzjˈazmo]",
+                "es": "[ˈlukas se leˈβanta kon entuˈsjasmo]",
+                "nl": "[lˈykɑ stˈaːt ˌɛntuʒˈɑst ˈɔp]",
+                "pt": "[lˈukæs sy lˌevˈɐ̃ŋtæ koŋ ˌeɪŋtuziˈazmʊ]",
+                "en": "[lˈuːkəz ɡˈɛts ˌʌp wɪð ɛnθjˈuːzɪˌazəm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-020",
             "text": {
                 "fr": "Quand partons-nous?",
-                "en": "When are we going?",
+                "en": "When are we leaving?",
                 "de": "Wann fahren wir?",
                 "it": "Quando partiamo?",
                 "es": "¿Cuándo nos vamos?",
@@ -410,7 +554,7 @@
                 "es": "[ˈkwando nos ˈβamos]",
                 "nl": "[ʋɑnˈɪr ɣˈaːn ʋə]",
                 "pt": "[kwˈɐ̃ŋdʊ vˌɐ̃mʊs paɾətʃˈir]",
-                "en": "[wˌɛn ɑː wiː ɡˈəʊɪŋ]"
+                "en": "[wˌɛn ɑː wiː lˈiːvɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -423,7 +567,7 @@
             }
         },
         {
-            "id": "scene-03-014",
+            "id": "scene-03-021",
             "text": {
                 "fr": "Bientôt, très bientôt.",
                 "en": "Soon, very soon.",
@@ -441,222 +585,6 @@
                 "nl": "[bˈɪnənkˌɔrt\n hˈeːl bˈɪnənkˌɔrt]",
                 "pt": "[lˈɔɡʊ\n mwˈiŋtʊ lˈɔɡʊ]",
                 "en": "[sˈuːn vˈɛɹɪ sˈuːn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-015",
-            "text": {
-                "fr": "J'ai un peu peur, tu sais.",
-                "en": "I'm a bit scared, you know.",
-                "de": "Ich habe ein bisschen Angst, weißt du.",
-                "it": "Ho un po' paura, sai.",
-                "es": "Tengo un poco de miedo, ya sabes.",
-                "nl": "Ik ben een beetje bang, weet je.",
-                "pt": "Estou com um pouco de medo, sabe.",
-                "en_pt": "I'm a little scared, you know."
-            },
-            "ipa": {
-                "fr": "ʒe œ̃ pø pˈœʁ ty sˈɛ",
-                "de": "[ɪç ˈhaːbə aɪ̯n ˈbɪsçən ˈaŋst vaɪst duː]",
-                "it": "[ˌo ˌʊn pˈo paˈuːra\n sˈaɪ]",
-                "es": "[ˈteŋɡo un ˈpoko ðe ˈmjeðo ʝa ˈsaβes]",
-                "nl": "[ɪk bɛn ən bˈeːtʲə bˈɑŋ\n ʋˈeːt jə]",
-                "pt": "[estˌow koŋ ũŋ pˈowkʊ dʒy mˈedʊ\n sˈaby]",
-                "en": "[aɪm ɐ bˈɪt skˈeəd juː nˈəʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-016",
-            "text": {
-                "fr": "N'aie pas peur, ça va bien se passer.",
-                "en": "Don't be scared, it will all be okay.",
-                "de": "Hab keine Angst, es wird alles gut.",
-                "it": "Non avere paura, andrà tutto bene.",
-                "es": "No tengas miedo, va a salir bien.",
-                "nl": "Wees niet bang, het komt allemaal goed.",
-                "pt": "Não tenha medo, vai dar tudo certo.",
-                "en_pt": "Don't be afraid, everything will be okay."
-            },
-            "ipa": {
-                "fr": "nɛ pa pˈœʁ sa vˈa bjˈɛ̃ sə- pasˈe",
-                "de": "[haːp ˈkaɪ̯nə ˈaŋst ɛs vɪʁt ˈaləs ɡuːt]",
-                "it": "[nˌon avˈeːre paˈuːra\n andrˈa tˈutːo bˈɛːne]",
-                "es": "[no ˈteŋɡas ˈmjeðo βa a saˈliɾ ˈβjen]",
-                "nl": "[ʋˈeːs nˌit bˈɑŋ\n hət kˈɔmt ˌɑləmˈaːl ɣˈut]",
-                "pt": "[nˌɐ̃ʊ̃ tˈeɲæ mˈedʊ\n vaɪ dˈar tˈudʊ sˈɛɾətʊ]",
-                "en": "[dˈəʊnt biː skˈeəd ɪt wɪl ˈɔːl biː əʊkˈeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-017",
-            "text": {
-                "fr": "Tu as raison, allons-y! Qu'est-ce qu'on risque?",
-                "en": "You're right, let's go! What do we have to lose?",
-                "de": "Du hast recht, los geht's! Was haben wir zu verlieren?",
-                "it": "Hai ragione, andiamo! Cosa rischiamo?",
-                "es": "Tienes razón, ¡vamos! ¿Qué podemos perder?",
-                "nl": "Je hebt gelijk, laten we gaan! Wat hebben we te verliezen?",
-                "pt": "O que a gente tem a perder?",
-                "en_pt": "What do we have to lose?"
-            },
-            "ipa": {
-                "fr": "ty a ʁɛzˈɔ̃ alˈɔ̃ziɡʁˈɛk kɛs kɔ̃ ʁˈisk",
-                "de": "[duː hast ʁɛçt loːs ɡeːts vas ˈhaːbn̩ viːɐ̯ t͡suː fɛɐ̯ˈliːʁən]",
-                "it": "[ˌaj radʒˈoːne\n andjˈaːmo\n kˈɔːza riskjˈaːmo]",
-                "es": "[ˈtjenes raˈθon ˈbamos ˈke poˈðemos peɾˈðeɾ]",
-                "nl": "[jə hɛpt ɣəlˈɛɪk\n lˈaːtən ʋə ɣˈaːn\n ʋɑt hˌɛbən ʋə tə vərlˈizən]",
-                "pt": "[ʊ ky a ʒˈeɪŋtʃy teɪŋ a peɾədˈer]",
-                "en": "[jɔː ɹˈaɪt lˈɛts ɡˈəʊ wˌɒt dˈuː wiː hav tə lˈuːz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-018",
-            "text": {
-                "fr": "Le soir, dans l'appartement de Sophie, ils partagent le vin et du fromage.",
-                "en": "In the evening, at Sophie's apartment, they share wine and cheese.",
-                "de": "Abends, in Sophies Wohnung, teilen sie Wein und Käse.",
-                "it": "La sera, nell'appartamento di Sophie, condividono vino e formaggio.",
-                "es": "Por la noche, en el apartamento de Sophie, comparten vino y queso.",
-                "nl": "'s Avonds, in het appartement van Sophie, delen ze wijn en kaas.",
-                "pt": "À noite, no apartamento de Sophie, eles compartilham o vinho e queijo.",
-                "en_pt": "In the evening, at Sophie's apartment, they share the wine and cheese."
-            },
-            "ipa": {
-                "fr": "lə- swˈaʁ dɑ̃ lapaʁtəmˈɑ̃ də- sɔfˈi il paʁtˈaʒ lə- vˈɛ̃ e dy- fʁɔmˈaʒ",
-                "de": "[ˈaːbənts ɪn ˈzoːfiːs ˈvɔnʊŋ ˈtaɪ̯lən ziː vaɪ̯n ʊnt keːzə]",
-                "it": "[lˌa sˈeːra\n nellˌapːartamˈento dˌɪ sˈopje\n kˌondivˈidono vˈiːno ˌe formˈadʒːo]",
-                "es": "[poɾ la ˈnoʧe en el apaɾtaˈmento ðe ˈsofi komˈpaɾten ˈβino i ˈkeso]",
-                "nl": "[s ˈaːvɔnts\n ɪn hət ˌɑpɑrtəmˈɛnt vɑn sɔphˈi\n dˈeːlən zə ʋˈɛɪn ɛn kˈaːs]",
-                "pt": "[ˌaː nˈoɪtʃy\n nʊ ˌapaɾətæmˈeɪŋtʊ dʒy sˌofˈiy\n ˌelys kˌompaɾətʃˈiljɐ̃ʊ̃ ʊ vˈiɲw i kˈeɪʒʊ]",
-                "en": "[ɪnðɪ ˈiːvnɪŋ at sˈəʊfiz ɐpˈɑːtmənt ðeɪ ʃˈeə wˈaɪn and tʃˈiːz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-019",
-            "text": {
-                "fr": "La conversation devient plus profonde.",
-                "en": "The conversation becomes deeper.",
-                "de": "Das Gespräch wird tiefer.",
-                "it": "La conversazione diventa più profonda.",
-                "es": "La conversación se hace más profunda.",
-                "nl": "Het gesprek wordt dieper.",
-                "pt": "A conversa fica mais profunda."
-            },
-            "ipa": {
-                "fr": "la- kɔ̃vɛʁsasjˈɔ̃ dəvjˈɛ̃ ply pʁɔfˈɔ̃d",
-                "de": "[das ɡəˈʃpʁɛːç vɪʁt ˈtiːfɐ]",
-                "it": "[lˌa kˌonversˌatsiˈɔːne divˈɛnta pjˌʊ profˈonda]",
-                "es": "[la konβeɾsaˈθjon se aˈθe mas pɾoˈfunda]",
-                "nl": "[hət ɣəsprˈɛk ʋɔr tˈipər]",
-                "pt": "[a kˌoŋvˈɛɾəsæ fˈikæ mˈaɪs prˌofˈũŋdæ]",
-                "en": "[ðə kɒnvəsˈeɪʃən bɪkˌʌmz dˈiːpə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-020",
-            "text": {
-                "fr": "Lucas se redresse sur le canapé.",
-                "en": "Lucas sits upright on the couch.",
-                "de": "Lucas setzt sich aufrecht auf das Sofa.",
-                "it": "Lucas si rialza sul divano.",
-                "es": "Lucas se yergue en el sofá.",
-                "nl": "Lucas zit rechtop op de bank.",
-                "pt": "Lucas se endireita no sofá.",
-                "en_pt": "Lucas sits up straight on the sofa."
-            },
-            "ipa": {
-                "fr": "lykˈa sə- ʁədʁˈɛs syʁ lə- kanapˈe",
-                "de": "[ˈluːkas zɛt͡st zɪç ˈaʊ̯fʁɛçt aʊ̯f das ˈzoːfa]",
-                "it": "[lˈuːkas sˌɪ riˈaltsa sˌʊl divˈaːno]",
-                "es": "[ˈlukas se ˈʝeɾɡe en el soˈfa]",
-                "nl": "[lˈykɑ sˈɪt rˈɛxtɔp ɔp də bˈɑŋk]",
-                "pt": "[lˈukæs sj ˌeɪŋdʒiɾˈeɪtæ nʊ sofˈa]",
-                "en": "[lˈuːkəz sˈɪts ˈʌpɹaɪt ɒnðə kˈaʊtʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-021",
-            "text": {
-                "fr": "Lucas se lève avec enthousiasme.",
-                "en": "Lucas gets up enthusiastically.",
-                "de": "Lucas steht begeistert auf.",
-                "it": "Lucas si alza con entusiasmo.",
-                "es": "Lucas se levanta con entusiasmo.",
-                "nl": "Lucas staat enthousiast op.",
-                "pt": "Lucas se levanta com entusiasmo.",
-                "en_pt": "Lucas stands up enthusiastically."
-            },
-            "ipa": {
-                "fr": "lykˈa sə- lˈɛv avˌɛkɛnθˈawzɪˌazmɪ",
-                "de": "[ˈluːkas ʃteːt bəˈɡaɪ̯stɐt aʊ̯f]",
-                "it": "[lˈuːkas sˌɪ ˈaltsa kˌon ˌentʊzjˈazmo]",
-                "es": "[ˈlukas se leˈβanta kon entuˈsjasmo]",
-                "nl": "[lˈykɑ stˈaːt ˌɛntuʒˈɑst ˈɔp]",
-                "pt": "[lˈukæs sy lˌevˈɐ̃ŋtæ koŋ ˌeɪŋtuziˈazmʊ]",
-                "en": "[lˈuːkəz ɡˈɛts ˌʌp ɛnθjˌuːzɪˈastɪkli]"
             },
             "provenance": {
                 "fr": "original",
@@ -701,6 +629,36 @@
         {
             "id": "scene-03-023",
             "text": {
+                "fr": "J'ai un peu peur, tu sais.",
+                "en": "I'm a little scared, you know.",
+                "de": "Ich habe ein bisschen Angst, weißt du.",
+                "it": "Ho un po' paura, sai.",
+                "es": "Tengo un poco de miedo, ya sabes.",
+                "nl": "Ik ben een beetje bang, weet je.",
+                "pt": "Estou com um pouco de medo, sabe."
+            },
+            "ipa": {
+                "fr": "ʒe œ̃ pø pˈœʁ ty sˈɛ",
+                "de": "[ɪç ˈhaːbə aɪ̯n ˈbɪsçən ˈaŋst vaɪst duː]",
+                "it": "[ˌo ˌʊn pˈo paˈuːra\n sˈaɪ]",
+                "es": "[ˈteŋɡo un ˈpoko ðe ˈmjeðo ʝa ˈsaβes]",
+                "nl": "[ɪk bɛn ən bˈeːtʲə bˈɑŋ\n ʋˈeːt jə]",
+                "pt": "[estˌow koŋ ũŋ pˈowkʊ dʒy mˈedʊ\n sˈaby]",
+                "en": "[aɪm ɐ lˈɪtəl skˈeəd juː nˈəʊ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-024",
+            "text": {
                 "fr": "Lucas lui prend la main.",
                 "en": "Lucas takes her hand.",
                 "de": "Lucas nimmt ihre Hand.",
@@ -729,82 +687,38 @@
             }
         },
         {
-            "id": "scene-03-024",
-            "text": {
-                "pt": "Trânsito, trabalho, casa.",
-                "en": "Traffic, work, home."
-            },
-            "ipa": {
-                "pt": "[trˈɐ̃ŋzitʊ\n trˌabˈaljʊ\n kˈazæ]",
-                "en": "[tɹˈafɪk wˈɜːk hˈəʊm]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-03-025",
             "text": {
-                "pt": "Ainda não sei.",
-                "en": "I don't know yet."
+                "fr": "N'aie pas peur, ça va bien se passer.",
+                "en": "Don't be afraid, it will be fine.",
+                "de": "Hab keine Angst, es wird alles gut.",
+                "it": "Non avere paura, andrà tutto bene.",
+                "es": "No tengas miedo, va a salir bien.",
+                "nl": "Wees niet bang, het komt allemaal goed.",
+                "pt": "Não tenha medo, vai dar tudo certo.",
+                "en_pt": "Don't be afraid, everything will be okay."
             },
             "ipa": {
-                "pt": "[ˌaˈiŋdæ nˌɐ̃ʊ̃ sˈeɪ]",
-                "en": "[aɪ dˈəʊnt nˈəʊ jˈɛt]"
+                "fr": "nɛ pa pˈœʁ sa vˈa bjˈɛ̃ sə- pasˈe",
+                "de": "[haːp ˈkaɪ̯nə ˈaŋst ɛs vɪʁt ˈaləs ɡuːt]",
+                "it": "[nˌon avˈeːre paˈuːra\n andrˈa tˈutːo bˈɛːne]",
+                "es": "[no ˈteŋɡas ˈmjeðo βa a saˈliɾ ˈβjen]",
+                "nl": "[ʋˈeːs nˌit bˈɑŋ\n hət kˈɔmt ˌɑləmˈaːl ɣˈut]",
+                "pt": "[nˌɐ̃ʊ̃ tˈeɲæ mˈedʊ\n vaɪ dˈar tˈudʊ sˈɛɾətʊ]",
+                "en": "[dˈəʊnt biː ɐfɹˈeɪd ɪt wɪl biː fˈaɪn]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-03-026",
-            "text": {
-                "pt": "pergunta Lucas.",
-                "en": "Lucas asks."
-            },
-            "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ lˈukæs]",
-                "en": "[lˈuːkəz ˈasks]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-027",
-            "text": {
-                "pt": "A Serra da Mantiqueira?",
-                "en": "The Serra da Mantiqueira?"
-            },
-            "ipa": {
-                "pt": "[a sˈɛxæ da mˌɐ̃ŋtʃikˈeɪɾæ]",
-                "en": "[ðə sˈɛɹə dˈɑː mˈantɪkwˌeəɹə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-028",
-            "text": {
-                "pt": "Sim!",
-                "en": "Yes!"
-            },
-            "ipa": {
-                "pt": "[sˈiŋ]",
-                "en": "[jˈɛs]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-03-029",
             "text": {
                 "pt": "Você tem razão, vamos!",
                 "en": "You're right, let's go!"
@@ -815,6 +729,91 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-027",
+            "text": {
+                "fr": "Tu as raison, allons-y! Qu'est-ce qu'on risque?",
+                "en": "You're right, let's go! What do we have to lose?",
+                "de": "Du hast recht, los geht's! Was haben wir zu verlieren?",
+                "it": "Hai ragione, andiamo! Cosa rischiamo?",
+                "es": "Tienes razón, ¡vamos! ¿Qué podemos perder?",
+                "nl": "Je hebt gelijk, laten we gaan! Wat hebben we te verliezen?",
+                "pt": "O que a gente tem a perder?",
+                "en_pt": "What do we have to lose?"
+            },
+            "ipa": {
+                "fr": "ty a ʁɛzˈɔ̃ alˈɔ̃ziɡʁˈɛk kɛs kɔ̃ ʁˈisk",
+                "de": "[duː hast ʁɛçt loːs ɡeːts vas ˈhaːbn̩ viːɐ̯ t͡suː fɛɐ̯ˈliːʁən]",
+                "it": "[ˌaj radʒˈoːne\n andjˈaːmo\n kˈɔːza riskjˈaːmo]",
+                "es": "[ˈtjenes raˈθon ˈbamos ˈke poˈðemos peɾˈðeɾ]",
+                "nl": "[jə hɛpt ɣəlˈɛɪk\n lˈaːtən ʋə ɣˈaːn\n ʋɑt hˌɛbən ʋə tə vərlˈizən]",
+                "pt": "[ʊ ky a ʒˈeɪŋtʃy teɪŋ a peɾədˈer]",
+                "en": "[jɔː ɹˈaɪt lˈɛts ɡˈəʊ wˌɒt dˈuː wiː hav tə lˈuːz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-028",
+            "text": {
+                "fr": "Métro, boulot, dodo.",
+                "en": "Subway, work, sleep.",
+                "de": "U-Bahn, Arbeit, Schlaf.",
+                "it": "Metro, lavoro, dormire.",
+                "es": "Metro, curro, cama.",
+                "nl": "Tram, werk, slaap."
+            },
+            "ipa": {
+                "fr": "metʁˈo bulˈo dɔdˈo",
+                "de": "[ʔuːˈbaːn ˈaʁbaɪ̯t ˈʃlaːf]",
+                "it": "[mˈeːtro\n lavˈɔːro\n dormˈiːre]",
+                "es": "[ˈmetɾo ˈkur.o ˈkama]",
+                "nl": "[trˈɑm\n ʋˈɛrk\n slˈaːp]",
+                "en": "[sˈʌbweɪ wˈɜːk slˈiːp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-03-029",
+            "text": {
+                "fr": "Les Alpes?",
+                "en": "The Alps?",
+                "de": "Die Alpen?",
+                "it": "Le Alpi?",
+                "es": "¿Los Pirineos?",
+                "nl": "De Ardennen?"
+            },
+            "ipa": {
+                "fr": "le-z ˈalp",
+                "de": "[diː ˈalpn̩]",
+                "it": "[lˌe ˈalpɪ]",
+                "es": "[los piɾiˈne.os]",
+                "nl": "[də ˈɑrdɛnən]",
+                "en": "[ðɪ ˈalps]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-04.json
+++ b/language_materials/unified/stories/scene-04.json
@@ -24,30 +24,30 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-04-001",
             "text": {
-                "fr": "C'est décidé, nous partons!",
-                "en": "It's decided, we're going!",
-                "de": "Es ist beschlossen, wir fahren los!",
-                "it": "È deciso, partiamo!",
-                "es": "¡Está decidido, nos vamos!",
-                "nl": "Het is besloten, we gaan!",
-                "pt": "Está decidido, vamos viajar!",
-                "en_pt": "It's decided, we're going to travel!"
+                "fr": "Le lendemain matin, Lucas arrive chez Sophie avec son ordinateur portable.",
+                "en": "The next morning, Lucas arrives at Sophie's with his laptop.",
+                "de": "Am nächsten Morgen kommt Lucas mit seinem Laptop zu Sophie.",
+                "it": "La mattina dopo, Lucas arriva a casa di Sophie con il suo computer portatile.",
+                "es": "A la mañana siguiente, Lucas llega a casa de Sophie con su ordenador portátil.",
+                "nl": "De volgende ochtend komt Lucas met zijn laptop bij Sophie thuis.",
+                "pt": "Na manhã seguinte, Lucas chega na casa de Sophie com seu laptop.",
+                "en_pt": "The next morning, Lucas arrives at Sophie's place with his laptop."
             },
             "ipa": {
-                "fr": "sɛ desidˈe nu paʁtˈɔ̃",
-                "de": "[ɛs ɪst bəˈʃlɔsn̩, viːɐ̯ ˈfaːɐ̯ən loːs]",
-                "it": "[ˌɛ detʃˈiːzo\n partjˈaːmo]",
-                "es": "[ˈesta ðeθiˈðiðo nos ˈβamos]",
-                "nl": "[hət ɪs bəslˈoːtən\n ʋə ɣˈaːn]",
-                "pt": "[estˌa dˌesidʒˈidʊ\n vˌɐ̃mʊz vˌiaʒˈar]",
-                "en": "[ɪts dɪsˈaɪdɪd wiə ɡˈəʊɪŋ]"
+                "fr": "lə- lɑ̃dmˈɛ̃ matˈɛ̃ lykˈaz aʁˈiv ʃe sɔfˈi avˌɛk sɔ̃n ɔʁdinatˈœʁ pɔʁtˈabl",
+                "de": "[ʔam ˈnɛçstn̩ ˈmɔʁɡn̩ kɔmt ˈluːkas mɪt ˈzaɪ̯nəm ˈlɛptɔp t͡suː ˈzoːfi]",
+                "it": "[lˌa matːˈiːna dˈoːpo\n lˈuːkas arɾˈiːva ˌa kˈaːza dˌɪ sˈopje kˌon ˌil sˌʊo kompjˈuːter portˈatile]",
+                "es": "[a la maˈɲana siˈɣjente ˈlukas ˈʎeɣa a ˈkasa ðe ˈsofi kon su orðenaˈðoɾ poɾˈtatil]",
+                "nl": "[də vˈɔlɣəndə ˈɔxtənt kˈɔmt lˈykɑs mɛt zɛɪn (en)lˈaptɒp(nl) bɛɪ sɔphˈi tˈœys]",
+                "pt": "[na mɐ̃ɲˈɐ̃ sˌeɡˈiŋtʃy\n lˈukæs ʃˈeɡæ na kˈazæ dʒy sˌofˈiy koŋ seʊ lɛptˈɔp]",
+                "en": "[ðə nˈɛkst mˈɔːnɪŋ lˈuːkəz ɐɹˈaɪvz at sˈəʊfiz wɪð hɪz lˈaptɒp]"
             },
             "provenance": {
                 "fr": "original",
@@ -62,20 +62,23 @@
         {
             "id": "scene-04-002",
             "text": {
-                "fr": "Dans combien de temps?",
-                "en": "How much longer?",
-                "de": "Wie lange dauert es?",
-                "it": "Tra quanto tempo?",
-                "es": "¿En cuánto tiempo?",
-                "nl": "Hoe lang nog?"
+                "fr": "C'est décidé, nous partons!",
+                "en": "It's decided, we're leaving!",
+                "de": "Es ist beschlossen, wir fahren los!",
+                "it": "È deciso, partiamo!",
+                "es": "¡Está decidido, nos vamos!",
+                "nl": "Het is besloten, we gaan!",
+                "pt": "Está decidido, vamos viajar!",
+                "en_pt": "It's decided, we're going to travel!"
             },
             "ipa": {
-                "fr": "dɑ̃ kɔ̃bjˈɛ̃ də- tˈɑ̃",
-                "de": "[viː ˈlaŋə ˈdaʊ̯ɐt ɛs]",
-                "it": "[trˌa kwˈanto tˈɛmpo]",
-                "es": "[en ˈkwanto ˈtjempo]",
-                "nl": "[hˈu lˈɑŋ nˈɔx]",
-                "en": "[hˌaʊ mˈʌtʃ lˈɒŋɡə]"
+                "fr": "sɛ desidˈe nu paʁtˈɔ̃",
+                "de": "[ɛs ɪst bəˈʃlɔsn̩, viːɐ̯ ˈfaːɐ̯ən loːs]",
+                "it": "[ˌɛ detʃˈiːzo\n partjˈaːmo]",
+                "es": "[ˈesta ðeθiˈðiðo nos ˈβamos]",
+                "nl": "[hət ɪs bəslˈoːtən\n ʋə ɣˈaːn]",
+                "pt": "[estˌa dˌesidʒˈidʊ\n vˌɐ̃mʊz vˌiaʒˈar]",
+                "en": "[ɪts dɪsˈaɪdɪd wiə lˈiːvɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -83,11 +86,57 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-04-003",
+            "text": {
+                "pt": "anuncia ele.",
+                "en": "he announces."
+            },
+            "ipa": {
+                "pt": "[ˌænũŋsˈiæ ˈely]",
+                "en": "[hiː ɐnˈaʊnsɪz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-004",
+            "text": {
+                "pt": "Daqui a quanto tempo?",
+                "en": "How soon?"
+            },
+            "ipa": {
+                "pt": "[dakˈi a kwˈɐ̃ŋtʊ tˈeɪmpʊ]",
+                "en": "[hˌaʊ sˈuːn]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-005",
+            "text": {
+                "pt": "Uma semana.",
+                "en": "One week."
+            },
+            "ipa": {
+                "pt": "[ˌumæ sˌemˈɐ̃næ]",
+                "en": "[wˈɒn wˈiːk]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-006",
             "text": {
                 "fr": "Dans une semaine. J'ai regardé les trains cette nuit.",
                 "en": "In a week. I looked at the trains last night.",
@@ -118,10 +167,25 @@
             }
         },
         {
-            "id": "scene-04-004",
+            "id": "scene-04-007",
+            "text": {
+                "pt": "Uma semana?",
+                "en": "One week?"
+            },
+            "ipa": {
+                "pt": "[ˌumæ sˌemˈɐ̃næ]",
+                "en": "[wˈɒn wˈiːk]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-008",
             "text": {
                 "fr": "Une semaine? C'est si rapide!",
-                "en": "A week? That's so quick!",
+                "en": "A week? That's so fast!",
                 "de": "Eine Woche? Das ist so schnell!",
                 "it": "Una settimana? È così rapido!",
                 "es": "¿Una semana? ¡Es tan rápido!",
@@ -136,7 +200,7 @@
                 "es": "[ˈuna seˈmana es tan ˈraˈpiðo]",
                 "nl": "[ən ʋˈeːk\n dɑt ɪ soː snˈɛl]",
                 "pt": "[ɛ tˈɐ̃ʊ̃ xˈapidʊ]",
-                "en": "[ɐ wˈiːk ðats sˌəʊ kwˈɪk]"
+                "en": "[ɐ wˈiːk ðats sˌəʊ fˈast]"
             },
             "provenance": {
                 "fr": "original",
@@ -149,7 +213,7 @@
             }
         },
         {
-            "id": "scene-04-005",
+            "id": "scene-04-009",
             "text": {
                 "fr": "Oui, mais c'est mieux comme ça",
                 "en": "Yes, but it's better this way",
@@ -180,16 +244,15 @@
             }
         },
         {
-            "id": "scene-04-006",
+            "id": "scene-04-010",
             "text": {
                 "fr": "Si on attend trop, on ne partira jamais.",
-                "en": "If we wait too long, we'll never go.",
+                "en": "If we wait too long, we'll never leave.",
                 "de": "Wenn wir zu lange warten, fahren wir nie ab.",
                 "it": "Se aspettiamo troppo, non partiremo mai.",
                 "es": "Si esperamos demasiado, nunca nos iremos.",
                 "nl": "Als we te lang wachten, gaan we nooit.",
-                "pt": "Se a gente esperar muito, nunca vai sair.",
-                "en_pt": "If we wait too long, we'll never leave."
+                "pt": "Se a gente esperar muito, nunca vai sair."
             },
             "ipa": {
                 "fr": "sˈi ɔ̃n atˈɑ̃ tʁˈo ɔ̃ nə- paʁtiʁˈa ʒamˈɛ",
@@ -198,7 +261,7 @@
                 "es": "[si espeˈɾamos ðemaˈsjaðo ˈnunka nos iˈɾemos]",
                 "nl": "[ɑls ʋə tə lˈɑŋ ʋˈɑxtən\n ɣˈaːn ʋə nˈoːjt]",
                 "pt": "[sj a ʒˈeɪŋtʃj ˌespeɾˈar mwˈiŋtʊ\n nˌũŋkæ vaɪ saˈir]",
-                "en": "[ɪf wiː wˈeɪt tˈuː lˈɒŋ wiːl nˈɛvə ɡˈəʊ]"
+                "en": "[ɪf wiː wˈeɪt tˈuː lˈɒŋ wiːl nˈɛvə lˈiːv]"
             },
             "provenance": {
                 "fr": "original",
@@ -211,10 +274,25 @@
             }
         },
         {
-            "id": "scene-04-007",
+            "id": "scene-04-011",
+            "text": {
+                "pt": "Sophie pensa.",
+                "en": "Sophie thinks."
+            },
+            "ipa": {
+                "pt": "[sˌofˈiy pˈeɪŋsæ]",
+                "en": "[sˈəʊfi θˈɪŋks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-012",
             "text": {
                 "fr": "Tu as raison. Qu'est-ce qu'on emporte?",
-                "en": "You're right. What are we taking?",
+                "en": "You're right. What do we take?",
                 "de": "Du hast recht. Was nehmen wir mit?",
                 "it": "Hai ragione. Cosa portiamo?",
                 "es": "Tienes razón. ¿Qué llevamos?",
@@ -229,7 +307,7 @@
                 "es": "[ˈtjenes raˈθon ke ʎeˈβamos]",
                 "nl": "[jə hɛpt ɣəlˈɛɪk\n ʋɑt nˈeːmən ʋə mˈeː]",
                 "pt": "[vosˌe teɪŋ xazˈɐ̃ʊ̃]",
-                "en": "[jɔː ɹˈaɪt wˌɒt ɑː wiː tˈeɪkɪŋ]"
+                "en": "[jɔː ɹˈaɪt wˌɒt dˈuː wiː tˈeɪk]"
             },
             "provenance": {
                 "fr": "original",
@@ -242,7 +320,22 @@
             }
         },
         {
-            "id": "scene-04-008",
+            "id": "scene-04-013",
+            "text": {
+                "pt": "O que a gente leva?",
+                "en": "What should we bring?"
+            },
+            "ipa": {
+                "pt": "[ʊ ky a ʒˈeɪŋtʃy lˈɛvæ]",
+                "en": "[wˌɒt ʃˌʊd wiː bɹˈɪŋ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-014",
             "text": {
                 "fr": "Pas grand-chose, juste l'essentiel",
                 "en": "Not much, just the essentials",
@@ -273,10 +366,10 @@
             }
         },
         {
-            "id": "scene-04-009",
+            "id": "scene-04-015",
             "text": {
                 "fr": "Des vêtements chauds, une lampe de poche.",
-                "en": "Warm clothes, a flashlight.",
+                "en": "Warm clothes, a pocket lamp.",
                 "de": "Warme Kleidung, eine Taschenlampe.",
                 "it": "Vestiti caldi, una torcia elettrica.",
                 "es": "Ropa de abrigo, una linterna.",
@@ -291,7 +384,7 @@
                 "es": "[ˈropa ðe aˈβɾiɣo ˈuna linˈteɾna]",
                 "nl": "[ʋˈɑrmə klˈɪːrən\n ən zˈɑklɑmp]",
                 "pt": "[xˈowpæs kˈeɪŋtʃys\n ˌumæ lˌɐ̃ŋtˈɛɾənæ]",
-                "en": "[wˈɔːm klˈəʊðz ɐ flˈaʃlaɪt]"
+                "en": "[wˈɔːm klˈəʊðz ɐ pˈɒkɪt lˈamp]"
             },
             "provenance": {
                 "fr": "original",
@@ -304,7 +397,7 @@
             }
         },
         {
-            "id": "scene-04-010",
+            "id": "scene-04-016",
             "text": {
                 "fr": "Un sac à dos chacun,",
                 "en": "A backpack each,",
@@ -335,7 +428,7 @@
             }
         },
         {
-            "id": "scene-04-011",
+            "id": "scene-04-017",
             "text": {
                 "fr": "Et nos téléphones?",
                 "en": "And our phones?",
@@ -366,10 +459,10 @@
             }
         },
         {
-            "id": "scene-04-012",
+            "id": "scene-04-018",
             "text": {
                 "fr": "Bien sûr, pour les photos. Et pour la sécurité.",
-                "en": "Of course, for the photos. And for safety.",
+                "en": "Of course, for photos. And for safety.",
                 "de": "Natürlich, für Fotos und zur Sicherheit.",
                 "it": "Certo, per le foto. E per la sicurezza.",
                 "es": "Claro, para las fotos. Y por seguridad.",
@@ -384,7 +477,7 @@
                 "es": "[ˈklaɾo ˈpara las ˈfotos i poɾ seguˈɾiðað]",
                 "nl": "[naːtˈyrlək\n vɔːr də fˈoːtoːs\n ɛn vɔːr də vˈɛɪləxhˌɛɪt]",
                 "pt": "[klˈaɾʊ\n pˌaɾæ as fˈɔtʊs]",
-                "en": "[ɒv kˈɔːs fəðə fˈəʊtəʊz and fɔː sˈeɪfti]"
+                "en": "[ɒv kˈɔːs fɔː fˈəʊtəʊz and fɔː sˈeɪfti]"
             },
             "provenance": {
                 "fr": "original",
@@ -397,7 +490,67 @@
             }
         },
         {
-            "id": "scene-04-013",
+            "id": "scene-04-019",
+            "text": {
+                "pt": "E para segurança.",
+                "en": "And for safety."
+            },
+            "ipa": {
+                "pt": "[i pˌaɾæ sˌeɡuɾˈɐ̃ŋsæ]",
+                "en": "[and fɔː sˈeɪfti]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-020",
+            "text": {
+                "fr": "Sophie commence à faire une liste.",
+                "en": "Sophie starts making a list.",
+                "de": "Sophie fängt an, eine Liste zu machen.",
+                "it": "Sophie inizia a fare una lista.",
+                "es": "Sophie empieza a hacer una lista.",
+                "nl": "Sophie begint een lijst te maken.",
+                "pt": "Sophie começa a fazer uma lista."
+            },
+            "ipa": {
+                "fr": "sɔfˈi kɔmˈɑ̃s a fˈɛʁ yn lˈist",
+                "de": "[ˈzoːfi ˈfɛŋt ʔan, ˈʔaɪ̯nə ˈlɪstə t͡su ˈmaχn̩]",
+                "it": "[sˈopje inˈitsia ˌa fˌare ˌʊna lˈista]",
+                "es": "[ˈsofi emˈpjeθa a aˈθeɾ ˈuna ˈlista]",
+                "nl": "[sɔphˈi bəɣˈɪnt ən lˈɛɪst tə mˈaːkən]",
+                "pt": "[sˌofˈiy kˌomˈɛsæ a fazˌeɾ ˌumæ lˈistæ]",
+                "en": "[sˈəʊfi stˈɑːts mˌeɪkɪŋ ɐ lˈɪst]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-021",
+            "text": {
+                "pt": "Estou empolgada!",
+                "en": "I'm so excited!"
+            },
+            "ipa": {
+                "pt": "[estˌow ˌeɪmpowɡˈadæ]",
+                "en": "[aɪm sˌəʊ ɛksˈaɪtɪd]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-022",
             "text": {
                 "fr": "Je suis excitée! C'est vraiment en train d'arriver!",
                 "en": "I'm excited! It's really happening!",
@@ -428,7 +581,37 @@
             }
         },
         {
-            "id": "scene-04-014",
+            "id": "scene-04-023",
+            "text": {
+                "pt": "Lucas sorri.",
+                "en": "Lucas smiles."
+            },
+            "ipa": {
+                "pt": "[lˈukæs soxˈi]",
+                "en": "[lˈuːkəz smˈaɪlz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-024",
+            "text": {
+                "pt": "Eu também.",
+                "en": "Me too."
+            },
+            "ipa": {
+                "pt": "[eʊ tɐ̃mbˈeɪŋ]",
+                "en": "[mˌiː tˈuː]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-04-025",
             "text": {
                 "fr": "Moi aussi. Une nouvelle aventure commence.",
                 "en": "Me too. A new adventure begins.",
@@ -459,212 +642,29 @@
             }
         },
         {
-            "id": "scene-04-015",
-            "text": {
-                "fr": "Le lendemain matin, Lucas arrive chez Sophie avec son ordinateur portable.",
-                "en": "The next morning, Lucas arrives at Sophie's place with his laptop.",
-                "de": "Am nächsten Morgen kommt Lucas mit seinem Laptop zu Sophie.",
-                "it": "La mattina dopo, Lucas arriva a casa di Sophie con il suo computer portatile.",
-                "es": "A la mañana siguiente, Lucas llega a casa de Sophie con su ordenador portátil.",
-                "nl": "De volgende ochtend komt Lucas met zijn laptop bij Sophie thuis.",
-                "pt": "Na manhã seguinte, Lucas chega na casa de Sophie com seu laptop."
-            },
-            "ipa": {
-                "fr": "lə- lɑ̃dmˈɛ̃ matˈɛ̃ lykˈaz aʁˈiv ʃe sɔfˈi avˌɛk sɔ̃n ɔʁdinatˈœʁ pɔʁtˈabl",
-                "de": "[ʔam ˈnɛçstn̩ ˈmɔʁɡn̩ kɔmt ˈluːkas mɪt ˈzaɪ̯nəm ˈlɛptɔp t͡suː ˈzoːfi]",
-                "it": "[lˌa matːˈiːna dˈoːpo\n lˈuːkas arɾˈiːva ˌa kˈaːza dˌɪ sˈopje kˌon ˌil sˌʊo kompjˈuːter portˈatile]",
-                "es": "[a la maˈɲana siˈɣjente ˈlukas ˈʎeɣa a ˈkasa ðe ˈsofi kon su orðenaˈðoɾ poɾˈtatil]",
-                "nl": "[də vˈɔlɣəndə ˈɔxtənt kˈɔmt lˈykɑs mɛt zɛɪn (en)lˈaptɒp(nl) bɛɪ sɔphˈi tˈœys]",
-                "pt": "[na mɐ̃ɲˈɐ̃ sˌeɡˈiŋtʃy\n lˈukæs ʃˈeɡæ na kˈazæ dʒy sˌofˈiy koŋ seʊ lɛptˈɔp]",
-                "en": "[ðə nˈɛkst mˈɔːnɪŋ lˈuːkəz ɐɹˈaɪvz at sˈəʊfiz plˈeɪs wɪð hɪz lˈaptɒp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-016",
-            "text": {
-                "fr": "Sophie commence à faire une liste.",
-                "en": "Sophie starts making a list.",
-                "de": "Sophie fängt an, eine Liste zu machen.",
-                "it": "Sophie inizia a fare una lista.",
-                "es": "Sophie empieza a hacer una lista.",
-                "nl": "Sophie begint een lijst te maken.",
-                "pt": "Sophie começa a fazer uma lista."
-            },
-            "ipa": {
-                "fr": "sɔfˈi kɔmˈɑ̃s a fˈɛʁ yn lˈist",
-                "de": "[ˈzoːfi ˈfɛŋt ʔan, ˈʔaɪ̯nə ˈlɪstə t͡su ˈmaχn̩]",
-                "it": "[sˈopje inˈitsia ˌa fˌare ˌʊna lˈista]",
-                "es": "[ˈsofi emˈpjeθa a aˈθeɾ ˈuna ˈlista]",
-                "nl": "[sɔphˈi bəɣˈɪnt ən lˈɛɪst tə mˈaːkən]",
-                "pt": "[sˌofˈiy kˌomˈɛsæ a fazˌeɾ ˌumæ lˈistæ]",
-                "en": "[sˈəʊfi stˈɑːts mˌeɪkɪŋ ɐ lˈɪst]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-017",
-            "text": {
-                "pt": "anuncia ele.",
-                "en": "he announces."
-            },
-            "ipa": {
-                "pt": "[ˌænũŋsˈiæ ˈely]",
-                "en": "[hiː ɐnˈaʊnsɪz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-018",
-            "text": {
-                "pt": "Daqui a quanto tempo?",
-                "en": "How soon?"
-            },
-            "ipa": {
-                "pt": "[dakˈi a kwˈɐ̃ŋtʊ tˈeɪmpʊ]",
-                "en": "[hˌaʊ sˈuːn]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-019",
-            "text": {
-                "pt": "Uma semana.",
-                "en": "One week."
-            },
-            "ipa": {
-                "pt": "[ˌumæ sˌemˈɐ̃næ]",
-                "en": "[wˈɒn wˈiːk]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-020",
-            "text": {
-                "pt": "Uma semana?",
-                "en": "One week?"
-            },
-            "ipa": {
-                "pt": "[ˌumæ sˌemˈɐ̃næ]",
-                "en": "[wˈɒn wˈiːk]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-021",
-            "text": {
-                "pt": "Sophie pensa.",
-                "en": "Sophie thinks."
-            },
-            "ipa": {
-                "pt": "[sˌofˈiy pˈeɪŋsæ]",
-                "en": "[sˈəʊfi θˈɪŋks]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-022",
-            "text": {
-                "pt": "O que a gente leva?",
-                "en": "What should we bring?"
-            },
-            "ipa": {
-                "pt": "[ʊ ky a ʒˈeɪŋtʃy lˈɛvæ]",
-                "en": "[wˌɒt ʃˌʊd wiː bɹˈɪŋ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-023",
-            "text": {
-                "pt": "E para segurança.",
-                "en": "And for safety."
-            },
-            "ipa": {
-                "pt": "[i pˌaɾæ sˌeɡuɾˈɐ̃ŋsæ]",
-                "en": "[and fɔː sˈeɪfti]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-024",
-            "text": {
-                "pt": "Estou empolgada!",
-                "en": "I'm so excited!"
-            },
-            "ipa": {
-                "pt": "[estˌow ˌeɪmpowɡˈadæ]",
-                "en": "[aɪm sˌəʊ ɛksˈaɪtɪd]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-04-025",
-            "text": {
-                "pt": "Lucas sorri.",
-                "en": "Lucas smiles."
-            },
-            "ipa": {
-                "pt": "[lˈukæs soxˈi]",
-                "en": "[lˈuːkəz smˈaɪlz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-04-026",
             "text": {
-                "pt": "Eu também.",
-                "en": "Me too."
+                "fr": "Dans combien de temps?",
+                "en": "In how much time?",
+                "de": "Wie lange dauert es?",
+                "it": "Tra quanto tempo?",
+                "es": "¿En cuánto tiempo?",
+                "nl": "Hoe lang nog?"
             },
             "ipa": {
-                "pt": "[eʊ tɐ̃mbˈeɪŋ]",
-                "en": "[mˌiː tˈuː]"
+                "fr": "dɑ̃ kɔ̃bjˈɛ̃ də- tˈɑ̃",
+                "de": "[viː ˈlaŋə ˈdaʊ̯ɐt ɛs]",
+                "it": "[trˌa kwˈanto tˈɛmpo]",
+                "es": "[en ˈkwanto ˈtjempo]",
+                "nl": "[hˈu lˈɑŋ nˈɔx]",
+                "en": "[ɪn hˌaʊ mˈʌtʃ tˈaɪm]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-05.json
+++ b/language_materials/unified/stories/scene-05.json
@@ -24,30 +24,30 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-05-001",
             "text": {
-                "fr": "Deux billets pour Grenoble, s'il vous plaît,",
-                "en": "Two tickets to Maastricht, please.",
-                "de": "Zwei Tickets nach München bitte,",
-                "it": "Due biglietti per Roma Termini, per favore.",
-                "es": "Dos billetes para Segovia, por favor.",
-                "nl": "Twee kaartjes naar Maastricht, alsjeblieft.",
-                "pt": "Duas passagens para Campos do Jordão, por favor, diz Lucas.",
-                "en_pt": "Two tickets to Campos do Jordão, please, Lucas says."
+                "fr": "Une semaine plus tard, Sophie et Lucas se tiennent devant la Gare de Lyon.",
+                "en": "One week later, Sophie and Lucas stand in front of the Gare de Lyon.",
+                "de": "Eine Woche später stehen Sophie und Lucas vor dem Hauptbahnhof.",
+                "it": "Una settimana dopo, Sophie e Lucas stanno davanti alla stazione Termini.",
+                "es": "Una semana después, Sophie y Lucas están frente a la Estación de Atocha.",
+                "nl": "Een week later staan Sophie en Lucas voor het Centraal Station.",
+                "pt": "Uma semana depois, Sophie e Lucas estão na frente da Rodoviária do Tietê.",
+                "en_pt": "One week later, Sophie and Lucas are in front of the Tietê Bus Station."
             },
             "ipa": {
-                "fr": "dˈø bijˈɛ puʁ ɡʁənˈɔbl sil vu plˈɛ",
-                "de": "[ˈtsvaɪ̯ ˈtɪkɪts naχ ˈmʏnçn̩ ˈbɪtə]",
-                "it": "[dˈuːe biʎˈetːɪ pˌɛr rˈɔːma tˈɛrminɪ\n pˌɛr favˈoːre]",
-                "es": "[ˈdos βiˈʎetes paɾa seˈɣoβja poɾ faˈβoɾ]",
-                "nl": "[tʋˈeː kˈaːrtʲəs naːr mˈaːstrɪxt\n ˌɑlʃɛblˈift]",
-                "pt": "[dˈuæs pˌasˈaʒeɪŋs pˌaɾæ kˈɐ̃mpʊz dʊ ʒoɾədˈɐ̃ʊ̃\n por favˈor\n dʒˈiz lˈukæs]",
-                "en": "[tˈuː tˈɪkɪts tə mˈɑːstɹɪtʃt plˈiːz]"
+                "fr": "yn səmˈɛn ply tˈaʁ sɔfˈi e lykˈa sə- tjˈɛn dəvˈɑ̃ la- ɡˈaʁ də- ljˈɔ̃",
+                "de": "[ˈaɪ̯nə ˈvɔxə ˈʃpɛːtɐ ˈʃteːən ˈzoːfiː ʊnt ˈluːkas fɔɐ̯ deːm ˈhaʊ̯ptbaːnhoːf]",
+                "it": "[ˌʊna sˌɛtːimˈaːna dˈoːpo\n sˈopje ˌe lˈuːkas stˈanno davˈantɪ ˌalla stˌatsiˈɔːne tˈɛrminɪ]",
+                "es": "[ˈuna seˈmana desˈpwes ˈsofi i ˈlukas esˈtan ˈfɾente a la estaˈθjon de aˈtotʃa]",
+                "nl": "[ən ʋˈeːk lˈaːtər stˈaːn sɔphˈi ɛn lˈykɑs vɔːr hət sɛntrˈaːl staːʃˈɔn]",
+                "pt": "[ˌumæ sˌemˈɐ̃næ depˈoɪs\n sˌofˈij i lˈukæz estˌɐ̃ʊ̃ na frˈeɪŋtʃy da xˌodoviˈaɾjæ dʊ tʃˌietˈe]",
+                "en": "[wˈɒn wˈiːk lˈeɪtə sˈəʊfi and lˈuːkəz stˈand ɪn fɹˈʌnt ɒvðə ɡˈeə də lˈaɪɒn]"
             },
             "provenance": {
                 "fr": "original",
@@ -62,23 +62,22 @@
         {
             "id": "scene-05-002",
             "text": {
-                "fr": "Aller simple ou aller-retour?",
-                "en": "One-way or return?",
-                "de": "Einfache Fahrt oder Hin- und Rückfahrt?",
-                "it": "Solo andata o andata e ritorno?",
-                "es": "¿Ida o ida y vuelta?",
-                "nl": "Enkele reis of retour?",
-                "pt": "Só ida ou ida e volta?",
-                "en_pt": "One way or round trip?"
+                "fr": "Leurs sacs à dos sont prêts.",
+                "en": "Their backpacks are ready.",
+                "de": "Ihre Rucksäcke sind gepackt.",
+                "it": "I loro zaini sono pronti.",
+                "es": "Sus mochilas están listas.",
+                "nl": "Hun rugzakken zijn klaar.",
+                "pt": "Suas mochilas estão prontas."
             },
             "ipa": {
-                "fr": "alˈe sˈɛ̃pl u alˈeʁətˈuʁ",
-                "de": "[ˈaɪ̯nfaxə faːɐ̯t ˈoːdɐ hɪnʊnt ˈʁʏkfart]",
-                "it": "[sˈoːlo andˈaːta ˌo andˈaːta ˌe ritˈoːrno]",
-                "es": "[ˈiða o ˈiða i ˈbwelta]",
-                "nl": "[ˈɛŋkələ rˈɛɪs ɔf rˈeːtuːr]",
-                "pt": "[sˈɔ ˈidæ ow ˈidæ i vˈɔltæ]",
-                "en": "[wˈɒnwˈeɪ ɔː ɹɪtˈɜːn]"
+                "fr": "lœʁ sˈakz adˈɔs sˈɔ̃ pʁˈɛ",
+                "de": "[ˈiːʁə ˈʁʊkzɛkə zɪnt ɡəˈpakt]",
+                "it": "[ˌɪ lˌɔro dzˈaɪːnɪ sˌono prˈontɪ]",
+                "es": "[sus moˈtʃilas esˈtan ˈlistas]",
+                "nl": "[hɵn rˈɵɣzɑkən zɛɪn klˈaːr]",
+                "pt": "[sˌuæz mˌoʃˈilæz estˌɐ̃ʊ̃ prˈoŋtæs]",
+                "en": "[ðeə bˈakpaks ɑː ɹˈɛdi]"
             },
             "provenance": {
                 "fr": "original",
@@ -93,23 +92,22 @@
         {
             "id": "scene-05-003",
             "text": {
-                "fr": "Aller simple.",
-                "en": "One-way.",
-                "de": "Einfache Fahrt.",
-                "it": "Solo andata.",
-                "es": "Ida.",
-                "nl": "Enkele reis.",
-                "pt": "Só ida.",
-                "en_pt": "One way."
+                "fr": "L'excitation se mêle à la nervosité.",
+                "en": "Excitement mixes with nervousness.",
+                "de": "Aufregung mischt sich mit Nervosität.",
+                "it": "L'eccitazione si mescola alla nervosità.",
+                "es": "La emoción se mezcla con la nerviosidad.",
+                "nl": "Opwinding vermengt zich met nervositeit.",
+                "pt": "A empolgação se mistura com o nervosismo."
             },
             "ipa": {
-                "fr": "alˈe sˈɛ̃pl",
-                "de": "[ˈaɪ̯nfaxə faːɐ̯t]",
-                "it": "[sˈoːlo andˈaːta]",
-                "es": "[ˈiða]",
-                "nl": "[ˈɛŋkələ rˈɛɪs]",
-                "pt": "[sˈɔ ˈidæ]",
-                "en": "[wˈɒnwˈeɪ]"
+                "fr": "lɛksitasjˈɔ̃ sə- mˈɛl a la- nɛʁvozitˈe",
+                "de": "[ˈaʊ̯fʁeːɡʊŋ ˈmɪʃt zɪç mɪt nɛʁvoˈziːtɛːt]",
+                "it": "[lˌetʃːitˌatsiˈɔːne sˌɪ mˈeskola ˌalla nˌɛrvozitˈa]",
+                "es": "[la emoˈθjon se ˈmeθkla kon la nerβjoˈsiðað]",
+                "nl": "[ˈɔpʋˌɪndɪŋ vərmˈɛŋt zɪx mɛt nˌɛrvoːzitˈɛɪt]",
+                "pt": "[a ˌeɪmpowɡasˈɐ̃ʊ̃ sy mˌistˈuɾæ koŋ ʊ nˌeɾəvozˈizmʊ]",
+                "en": "[ɛksˈaɪtmənt mˈɪksɪz wɪð nˈɜːvəsnəs]"
             },
             "provenance": {
                 "fr": "original",
@@ -123,6 +121,142 @@
         },
         {
             "id": "scene-05-004",
+            "text": {
+                "fr": "Ils s'approchent du guichet.",
+                "en": "They approach the ticket counter.",
+                "de": "Sie gehen zum Schalter.",
+                "it": "Si avvicinano allo sportello.",
+                "es": "Se acercan al mostrador.",
+                "nl": "Ze benaderen het loket.",
+                "pt": "Eles se aproximam do guichê."
+            },
+            "ipa": {
+                "fr": "il sapʁˈɔʃ dy- ɡiʃˈɛ",
+                "de": "[ziː ˈɡeːən t͡sʊm ˈʃaltɐ]",
+                "it": "[sˌɪ ˌavvitʃinˈaːno ˌallo sportˈɛllo]",
+                "es": "[se aθeɾˈkan al mosˈtɾaðoɾ]",
+                "nl": "[zə bənˈaːdərən hət loːkˈɛt]",
+                "pt": "[ˌelys sj ˌaprosˈimɐ̃ʊ̃ dʊ ɡiʃˈe]",
+                "en": "[ðeɪ ɐpɹˈəʊtʃ ðə tˈɪkɪt kˈaʊntə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-005",
+            "text": {
+                "fr": "Deux billets pour Grenoble, s'il vous plaît,",
+                "en": "  Two tickets to Grenoble, please,",
+                "de": "Zwei Tickets nach München bitte,",
+                "it": "Due biglietti per Roma Termini, per favore.",
+                "es": "Dos billetes para Segovia, por favor.",
+                "nl": "Twee kaartjes naar Maastricht, alsjeblieft.",
+                "pt": "Duas passagens para Campos do Jordão, por favor, diz Lucas.",
+                "en_pt": "Two tickets to Campos do Jordão, please, Lucas says."
+            },
+            "ipa": {
+                "fr": "dˈø bijˈɛ puʁ ɡʁənˈɔbl sil vu plˈɛ",
+                "de": "[ˈtsvaɪ̯ ˈtɪkɪts naχ ˈmʏnçn̩ ˈbɪtə]",
+                "it": "[dˈuːe biʎˈetːɪ pˌɛr rˈɔːma tˈɛrminɪ\n pˌɛr favˈoːre]",
+                "es": "[ˈdos βiˈʎetes paɾa seˈɣoβja poɾ faˈβoɾ]",
+                "nl": "[tʋˈeː kˈaːrtʲəs naːr mˈaːstrɪxt\n ˌɑlʃɛblˈift]",
+                "pt": "[dˈuæs pˌasˈaʒeɪŋs pˌaɾæ kˈɐ̃mpʊz dʊ ʒoɾədˈɐ̃ʊ̃\n por favˈor\n dʒˈiz lˈukæs]",
+                "en": "[tˈuː tˈɪkɪts tə ɡɹˈɛnəʊbəl plˈiːz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-006",
+            "text": {
+                "fr": "Aller simple ou aller-retour?",
+                "en": "One way or round trip?",
+                "de": "Einfache Fahrt oder Hin- und Rückfahrt?",
+                "it": "Solo andata o andata e ritorno?",
+                "es": "¿Ida o ida y vuelta?",
+                "nl": "Enkele reis of retour?",
+                "pt": "Só ida ou ida e volta?"
+            },
+            "ipa": {
+                "fr": "alˈe sˈɛ̃pl u alˈeʁətˈuʁ",
+                "de": "[ˈaɪ̯nfaxə faːɐ̯t ˈoːdɐ hɪnʊnt ˈʁʏkfart]",
+                "it": "[sˈoːlo andˈaːta ˌo andˈaːta ˌe ritˈoːrno]",
+                "es": "[ˈiða o ˈiða i ˈbwelta]",
+                "nl": "[ˈɛŋkələ rˈɛɪs ɔf rˈeːtuːr]",
+                "pt": "[sˈɔ ˈidæ ow ˈidæ i vˈɔltæ]",
+                "en": "[wˈɒn wˈeɪ ɔː ɹˈaʊnd tɹˈɪp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-007",
+            "text": {
+                "pt": "pergunta a atendente.",
+                "en": "the attendant asks."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ a ˌateɪŋdˈeɪŋtʃy]",
+                "en": "[ðɪ ɐtˈɛndənt ˈasks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-008",
+            "text": {
+                "fr": "Aller simple.",
+                "en": "One way.",
+                "de": "Einfache Fahrt.",
+                "it": "Solo andata.",
+                "es": "Ida.",
+                "nl": "Enkele reis.",
+                "pt": "Só ida."
+            },
+            "ipa": {
+                "fr": "alˈe sˈɛ̃pl",
+                "de": "[ˈaɪ̯nfaxə faːɐ̯t]",
+                "it": "[sˈoːlo andˈaːta]",
+                "es": "[ˈiða]",
+                "nl": "[ˈɛŋkələ rˈɛɪs]",
+                "pt": "[sˈɔ ˈidæ]",
+                "en": "[wˈɒn wˈeɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-009",
             "text": {
                 "fr": "Le train part à quelle heure?",
                 "en": "What time does the train leave?",
@@ -153,15 +287,31 @@
             }
         },
         {
-            "id": "scene-05-005",
+            "id": "scene-05-010",
+            "text": {
+                "pt": "pergunta Sophie.",
+                "en": "Sophie asks."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ sˌofˈiy]",
+                "en": "[sˈəʊfi ˈasks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-011",
             "text": {
                 "fr": "À onze heures quinze",
-                "en": "At eleven fifteen.",
+                "en": "At eleven fifteen",
                 "de": "Um elf Uhr fünfzehn",
                 "it": "Alle undici e quindici",
                 "es": "A las once y cuarto",
                 "nl": "Om elf uur vijftien.",
-                "pt": "Às onze e quinze."
+                "pt": "Às onze e quinze.",
+                "en_pt": "At eleven fifteen."
             },
             "ipa": {
                 "fr": "a ˈɔ̃z ˈœʁ kˈɛ̃z",
@@ -183,10 +333,10 @@
             }
         },
         {
-            "id": "scene-05-006",
+            "id": "scene-05-012",
             "text": {
                 "fr": "Vous avez de la chance, c'est le TGV direct.",
-                "en": "You're in luck, it's the direct Intercity.",
+                "en": "You're lucky, it's the direct TGV.",
                 "de": "Ihr habt Glück, es ist der direkte ICE.",
                 "it": "Sei fortunato, è un Frecciarossa diretto.",
                 "es": "Tienes suerte, es el tren directo.",
@@ -201,7 +351,7 @@
                 "es": "[ˈtjenes ˈswerte es el tɾen diˈɾekto]",
                 "nl": "[jə hɛpt ɣəlˈɵk\n hət ɪs də dˈirɛktə ˈɪntərsˌiti]",
                 "pt": "[vosˌes teɪŋ sˈɔɾətʃy\n ɛ ʊ dʒˌiɾˈɛtʊ]",
-                "en": "[jɔːɹ ɪn lˈʌk ɪts ðə daɪɹˈɛkt ˌɪntəsˈɪti]"
+                "en": "[jɔː lˈʌki ɪts ðə daɪɹˈɛkt tˌiːdʒˌiːvˈiː]"
             },
             "provenance": {
                 "fr": "original",
@@ -214,15 +364,46 @@
             }
         },
         {
-            "id": "scene-05-007",
+            "id": "scene-05-013",
+            "text": {
+                "fr": "Lucas regarde sa montre.",
+                "en": "Lucas looks at his watch.",
+                "de": "Lucas schaut auf die Uhr.",
+                "it": "Lucas guarda l'orologio.",
+                "es": "Lucas mira su reloj.",
+                "nl": "Lucas kijkt op zijn horloge.",
+                "pt": "Lucas olha o relógio."
+            },
+            "ipa": {
+                "fr": "lykˈa ʁəɡˈaʁd sa- mˈɔ̃tʁ",
+                "de": "[ˈluːkas ʃaʊ̯t aʊ̯f diː ʔuːɐ]",
+                "it": "[lˈuːkas ɡwˈaːrda lˌɔrolˈɔːdʒo]",
+                "es": "[ˈlukas ˈmiɾa su reˈlox]",
+                "nl": "[lˈykɑs kˈɛɪkt ɔp zɛɪn hˈɔrloːxə]",
+                "pt": "[lˈukæz ˈɔljæ ʊ xˌelˈɔʒjʊ]",
+                "en": "[lˈuːkəz lˈʊks at hɪz wˈɒtʃ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-014",
             "text": {
                 "fr": "Nous avons le temps de prendre un café?",
-                "en": "Do we have time for a coffee?",
+                "en": "Do we have time to grab a coffee?",
                 "de": "Haben wir Zeit für einen Kaffee?",
                 "it": "Abbiamo tempo per un caffè?",
                 "es": "¿Tenemos tiempo para tomar un café?",
                 "nl": "Hebben we tijd voor een koffie?",
-                "pt": "Temos tempo de tomar um café?"
+                "pt": "Temos tempo de tomar um café?",
+                "en_pt": "Do we have time for a coffee?"
             },
             "ipa": {
                 "fr": "nuz avˈɔ̃ lə- tˈɑ̃ də- pʁˈɑ̃dʁ œ̃ kafˈe",
@@ -231,7 +412,7 @@
                 "es": "[teˈnemos ˈtjempo paɾa toˈmaɾ un kaˈfe]",
                 "nl": "[hˌɛbən ʋə tˈɛɪd vɔːr ən kɔfˈi]",
                 "pt": "[tˌemʊs tˈeɪmpʊ dʒy tomˈaɾ ũŋ kafˈɛ]",
-                "en": "[dˈuː wiː hav tˈaɪm fəɹə kˈɒfɪ]"
+                "en": "[dˈuː wiː hav tˈaɪm tə ɡɹˈab ɐ kˈɒfɪ]"
             },
             "provenance": {
                 "fr": "original",
@@ -244,7 +425,7 @@
             }
         },
         {
-            "id": "scene-05-008",
+            "id": "scene-05-015",
             "text": {
                 "fr": "Oui, nous avons une demi-heure.",
                 "en": "Yes, we have half an hour.",
@@ -274,22 +455,25 @@
             }
         },
         {
-            "id": "scene-05-009",
+            "id": "scene-05-016",
             "text": {
-                "fr": "Quel quai pour le train de Grenoble?",
-                "en": "Which platform is the train to Maastricht on?",
-                "de": "Auf welchem Bahnsteig fährt der Zug nach München?",
-                "it": "Quale binario per il treno per Roma Termini?",
-                "es": "¿En qué andén sale el tren para Segovia?",
-                "nl": "Op welk perron is de trein naar Maastricht?"
+                "fr": "Ils trouvent un café dans la gare.",
+                "en": "They find a café in the station.",
+                "de": "Sie finden ein Café im Bahnhof.",
+                "it": "Trovano un caffè nella stazione.",
+                "es": "Encuentran un café en la estación.",
+                "nl": "Ze vinden een café in het station.",
+                "pt": "Eles encontram uma lanchonete na rodoviária.",
+                "en_pt": "They find a snack bar in the bus station."
             },
             "ipa": {
-                "fr": "kɛl kˈe puʁ lə- tʁˈɛ̃ də- ɡʁənˈɔbl",
-                "de": "[aʊ̯f ˈvɛlçəm ˈbaːnʃtaɪ̯k fɛːɐ̯t deːɐ̯ t͡suːk naχ ˈmʏnçn̩]",
-                "it": "[kwˈaːle binˈario pˌɛr ˌil trˈɛːno pˌɛr rˈɔːma tˈɛrminɪ]",
-                "es": "[en ke anˈden ˈsale el tɾen paɾa seˈɣoβja]",
-                "nl": "[ɔp ʋˈɛlk pɛɾrˈɔn ɪs də trˈɛɪn naːr mˈaːstrɪxt]",
-                "en": "[wˌɪtʃ plˈatfɔːm ɪz ðə tɹˈeɪn tə mˈɑːstɹɪtʃt ˈɒn]"
+                "fr": "il tʁˈuvt œ̃ kafˈe dɑ̃ la- ɡˈaʁ",
+                "de": "[ziː ˈfɪndn̩ aɪ̯n kaˈfeː ɪm ˈbaːnhoːf]",
+                "it": "[trˈovano ˌʊn kaffˈɛ nˌɛlla stˌatsiˈɔːne]",
+                "es": "[enˈkwentɾan un kaˈfe en la estaˈθjon]",
+                "nl": "[zə vˈɪndən ən kaːfˈeː ɪn hət staːʃˈɔn]",
+                "pt": "[ˌelyz ˌeɪŋkˈoŋtrɐ̃ʊ̃ ˌumæ lˌɐ̃ŋʃonˈɛtʃy na xˌodoviˈaɾjæ]",
+                "en": "[ðeɪ fˈaɪnd ɐ kafˈeɪ ɪnðə stˈeɪʃən]"
             },
             "provenance": {
                 "fr": "original",
@@ -297,11 +481,27 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-05-010",
+            "id": "scene-05-017",
+            "text": {
+                "pt": "Sophie pergunta ao atendente: Qual plataforma para o ônibus de Campos do Jordão?",
+                "en": "Sophie asks the attendant: Which platform for the Campos do Jordão bus?"
+            },
+            "ipa": {
+                "pt": "[sˌofˈiy pˌeɾəɡˈũŋtæ aʊ ˌateɪŋdˈeɪŋtʃy\n kwˈaʊ plˌatafˈɔɾəmæ pˌaɾæ u ˈonibuz dʒy kˈɐ̃mpʊz dʊ ʒoɾədˈɐ̃ʊ̃]",
+                "en": "[sˈəʊfi ˈasks ðɪ ɐtˈɛndənt wˌɪtʃ plˈatfɔːm fəðə kˈampəʊz dˈuː dʒˈɔːdaʊ bˈʌs]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-018",
             "text": {
                 "fr": "Le quai numéro sept. Vous verrez les panneaux.",
                 "en": "Platform number seven. You'll see the signs.",
@@ -332,7 +532,37 @@
             }
         },
         {
-            "id": "scene-05-011",
+            "id": "scene-05-019",
+            "text": {
+                "pt": "Você vai ver os painéis.",
+                "en": "You'll see the signs."
+            },
+            "ipa": {
+                "pt": "[vosˌe vaɪ vˈeɾ ʊs paɪnˈɛɪs]",
+                "en": "[juːl sˈiː ðə sˈaɪnz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-020",
+            "text": {
+                "pt": "Lucas verifica sua mochila.",
+                "en": "Lucas checks his backpack."
+            },
+            "ipa": {
+                "pt": "[lˈukæz vˌeɾifˈikæ sˌuæ mˌoʃˈilæ]",
+                "en": "[lˈuːkəz tʃˈɛks hɪz bˈakpak]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-021",
             "text": {
                 "fr": "N'oublie pas ton sac!",
                 "en": "Don't forget your bag!",
@@ -363,10 +593,25 @@
             }
         },
         {
-            "id": "scene-05-012",
+            "id": "scene-05-022",
+            "text": {
+                "pt": "Já peguei.",
+                "en": "I already got it."
+            },
+            "ipa": {
+                "pt": "[ʒˈa peɡˈeɪ]",
+                "en": "[aɪ ɔːlɹˌɛdi ɡˈɒt ɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-023",
             "text": {
                 "fr": "Je l'ai déjà pris. Et toi, tu as les billets?",
-                "en": "I've already grabbed it. And you, do you have the tickets?",
+                "en": "I've already taken it. And you, do you have the tickets?",
                 "de": "Ich habe ihn schon geholt. Und du, hast du die Tickets?",
                 "it": "L'ho già presa. E tu, hai i biglietti?",
                 "es": "Ya la he cogido. ¿Y tú, tienes los billetes?",
@@ -381,7 +626,7 @@
                 "es": "[ʝa la e koˈxiðo i ˈtu ˈtjenes los βiˈʎetes]",
                 "nl": "[ɪk hɛp hˈɛm ˈɑl ɣəpˈɑkt\n ˈɛn jɛɪ\n hɛp jə də kˈaːrtʲəs]",
                 "pt": "[i vosˈe\n teɪŋ as pˌasˈaʒeɪŋs]",
-                "en": "[aɪv ɔːlɹˌɛdi ɡɹˈabd ɪt and jˈuː dˈuː juː hav ðə tˈɪkɪts]"
+                "en": "[aɪv ɔːlɹˌɛdi tˈeɪkən ɪt and jˈuː dˈuː juː hav ðə tˈɪkɪts]"
             },
             "provenance": {
                 "fr": "original",
@@ -394,7 +639,7 @@
             }
         },
         {
-            "id": "scene-05-013",
+            "id": "scene-05-024",
             "text": {
                 "fr": "Oui, dans ma poche.",
                 "en": "Yes, in my pocket.",
@@ -424,7 +669,22 @@
             }
         },
         {
-            "id": "scene-05-014",
+            "id": "scene-05-025",
+            "text": {
+                "pt": "Sophie respira fundo.",
+                "en": "Sophie takes a deep breath."
+            },
+            "ipa": {
+                "pt": "[sˌofˈiy xˌespˈiɾæ fˈũŋdʊ]",
+                "en": "[sˈəʊfi tˈeɪks ɐ dˈiːp bɹˈɛθ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-026",
             "text": {
                 "fr": "Tu es prêt pour l'aventure?",
                 "en": "Are you ready for the adventure?",
@@ -454,7 +714,7 @@
             }
         },
         {
-            "id": "scene-05-015",
+            "id": "scene-05-027",
             "text": {
                 "fr": "Oui, plus que jamais!",
                 "en": "Yes, more than ever!",
@@ -484,343 +744,10 @@
             }
         },
         {
-            "id": "scene-05-016",
-            "text": {
-                "fr": "Le train arrive bientôt.",
-                "en": "The train is coming soon.",
-                "de": "Der Zug kommt bald.",
-                "it": "Il treno arriva presto.",
-                "es": "El tren llegará pronto.",
-                "nl": "De trein komt zo.",
-                "pt": "O ônibus vai chegar logo.",
-                "en_pt": "The bus will arrive soon."
-            },
-            "ipa": {
-                "fr": "lə- tʁˈɛ̃ aʁˈiv bjɛ̃tˈo",
-                "de": "[deːɐ̯ t͡suːk kɔmt bald]",
-                "it": "[ˌil trˈɛːno arɾˈiːva prˈɛsto]",
-                "es": "[el tɾen ʎeˈɣaɾa ˈpɾonto]",
-                "nl": "[də trˈɛɪn kˈɔmt zˈoː]",
-                "pt": "[u ˈonibuz vaɪ ʃeɡˈar lˈɔɡʊ]",
-                "en": "[ðə tɹˈeɪn ɪz kˈʌmɪŋ sˈuːn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-017",
-            "text": {
-                "fr": "Montons vite, il y a du monde,",
-                "en": "Let's board quickly, it's crowded,",
-                "de": "Schnell einsteigen, es wird voll,",
-                "it": "Saliamo in fretta, c'è molta gente.",
-                "es": "Subamos rápido, que hay mucha gente.",
-                "nl": "Laten we snel instappen, het is druk,",
-                "pt": "Vamos rápido, tem muita gente, diz Lucas.",
-                "en_pt": "Let's go quickly, there are a lot of people, Lucas says."
-            },
-            "ipa": {
-                "fr": "mɔ̃tˈɔ̃ vˈit il i a dy- mˈɔ̃d",
-                "de": "[ʃnɛl ˈaɪ̯nʃtaɪ̯ɡn̩, ɛs vɪɐ̯t fɔl]",
-                "it": "[sˌaliˈaːmo ˌin frˈetːa\n tʃˌɛ mˈolta dʒˈɛnte]",
-                "es": "[suˈβamos ˈrapido ke ai ˈmutʃa ˈxente]",
-                "nl": "[lˈaːtən ʋə snˈɛl ˈɪnstˌɑpən\n hət ɪs drˈɵk]",
-                "pt": "[vˌɐ̃mʊz xˈapidʊ\n teɪŋ mwˈiŋtæ ʒˈeɪŋtʃy\n dʒˈiz lˈukæs]",
-                "en": "[lˈɛts bˈɔːd kwˈɪkli ɪts kɹˈaʊdɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-018",
-            "text": {
-                "fr": "Voici nos places. Près de la fenêtre!",
-                "en": "Here are our seats. By the window!",
-                "de": "Hier sind unsere Plätze. Neben dem Fenster!",
-                "it": "Ecco i nostri posti. Vicino alla finestra!",
-                "es": "Aquí están nuestros asientos. ¡Junto a la ventana!",
-                "nl": "Hier zijn onze plaatsen. Bij het raam!",
-                "pt": "Aqui estão nossos lugares.",
-                "en_pt": "Here are our seats."
-            },
-            "ipa": {
-                "fr": "vwasˌi no plˈas pʁɛ də- la- fənˈɛtʁ",
-                "de": "[hiːɐ̯ zɪnt ʔʊnzəʁə ˈplɛt͡sə. ˈneːbn̩ deːm ˈfɛnstɐ]",
-                "it": "[ˈɛkːo ˌɪ nˌɔstrɪ pˈostɪ\n vitʃˈiːno ˌalla finˈɛstra]",
-                "es": "[aˈki esˈtan nwestɾos aˈsjentos ˈxunto a la βenˈtana]",
-                "nl": "[hˈir zɛɪn ɔnzˌə plˈaːtsən\n bɛɪ hət rˈaːm]",
-                "pt": "[akˈi estˌɐ̃ʊ̃ nˌɔsʊs lˌuɡˈaɾys]",
-                "en": "[hˈiəɹ ɑːɹ aʊə sˈiːts baɪ ðə wˈɪndəʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-019",
-            "text": {
-                "fr": "C'est parti pour une nouvelle vie!",
-                "en": "Here we go, on to a new life!",
-                "de": "Los geht's, auf zu einem neuen Leben!",
-                "it": "Si parte per una nuova vita!",
-                "es": "¡Empezamos una nueva vida!",
-                "nl": "Daar gaan we, op naar een nieuw leven!",
-                "pt": "Lá vamos nós para uma nova vida!",
-                "en_pt": "Here we go to a new life!"
-            },
-            "ipa": {
-                "fr": "sɛ paʁtˈi puʁ yn nuvˈɛl vˈi",
-                "de": "[loːs ɡeːts, aʊ̯f t͡su ˈaɪ̯nəm ˈnɔɪ̯ən ˈleːbn̩]",
-                "it": "[sˌɪ pˈaːrte pˌɛr ˌʊna nʊˈɔːva vˈiːta]",
-                "es": "[empeˈθamos ˈuna ˈnweβa ˈβiða]",
-                "nl": "[dˈaːr ɣˈaːn ʋə\n ɔp naːr ən nˈiw lˈeːvən]",
-                "pt": "[lˈa vˌɐ̃mʊz nɔs pˌaɾæ ˌumæ nˈɔvæ vˈidæ]",
-                "en": "[hˈiə wiː ɡˈəʊ ˌɒn tʊ ɐ njˈuː lˈaɪf]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-020",
-            "text": {
-                "fr": "Une semaine plus tard, Sophie et Lucas se tiennent devant la Gare de Lyon.",
-                "en": "A week later, Sophie and Lucas are standing in front of the Central Station.",
-                "de": "Eine Woche später stehen Sophie und Lucas vor dem Hauptbahnhof.",
-                "it": "Una settimana dopo, Sophie e Lucas stanno davanti alla stazione Termini.",
-                "es": "Una semana después, Sophie y Lucas están frente a la Estación de Atocha.",
-                "nl": "Een week later staan Sophie en Lucas voor het Centraal Station.",
-                "pt": "Uma semana depois, Sophie e Lucas estão na frente da Rodoviária do Tietê.",
-                "en_pt": "One week later, Sophie and Lucas are in front of the Tietê Bus Station."
-            },
-            "ipa": {
-                "fr": "yn səmˈɛn ply tˈaʁ sɔfˈi e lykˈa sə- tjˈɛn dəvˈɑ̃ la- ɡˈaʁ də- ljˈɔ̃",
-                "de": "[ˈaɪ̯nə ˈvɔxə ˈʃpɛːtɐ ˈʃteːən ˈzoːfiː ʊnt ˈluːkas fɔɐ̯ deːm ˈhaʊ̯ptbaːnhoːf]",
-                "it": "[ˌʊna sˌɛtːimˈaːna dˈoːpo\n sˈopje ˌe lˈuːkas stˈanno davˈantɪ ˌalla stˌatsiˈɔːne tˈɛrminɪ]",
-                "es": "[ˈuna seˈmana desˈpwes ˈsofi i ˈlukas esˈtan ˈfɾente a la estaˈθjon de aˈtotʃa]",
-                "nl": "[ən ʋˈeːk lˈaːtər stˈaːn sɔphˈi ɛn lˈykɑs vɔːr hət sɛntrˈaːl staːʃˈɔn]",
-                "pt": "[ˌumæ sˌemˈɐ̃næ depˈoɪs\n sˌofˈij i lˈukæz estˌɐ̃ʊ̃ na frˈeɪŋtʃy da xˌodoviˈaɾjæ dʊ tʃˌietˈe]",
-                "en": "[ɐ wˈiːk lˈeɪtə sˈəʊfi and lˈuːkəz ɑː stˈandɪŋ ɪn fɹˈʌnt ɒvðə sˈɛntɹəl stˈeɪʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-021",
-            "text": {
-                "fr": "Leurs sacs à dos sont prêts.",
-                "en": "Their backpacks are ready.",
-                "de": "Ihre Rucksäcke sind gepackt.",
-                "it": "I loro zaini sono pronti.",
-                "es": "Sus mochilas están listas.",
-                "nl": "Hun rugzakken zijn klaar.",
-                "pt": "Suas mochilas estão prontas."
-            },
-            "ipa": {
-                "fr": "lœʁ sˈakz adˈɔs sˈɔ̃ pʁˈɛ",
-                "de": "[ˈiːʁə ˈʁʊkzɛkə zɪnt ɡəˈpakt]",
-                "it": "[ˌɪ lˌɔro dzˈaɪːnɪ sˌono prˈontɪ]",
-                "es": "[sus moˈtʃilas esˈtan ˈlistas]",
-                "nl": "[hɵn rˈɵɣzɑkən zɛɪn klˈaːr]",
-                "pt": "[sˌuæz mˌoʃˈilæz estˌɐ̃ʊ̃ prˈoŋtæs]",
-                "en": "[ðeə bˈakpaks ɑː ɹˈɛdi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-022",
-            "text": {
-                "fr": "L'excitation se mêle à la nervosité.",
-                "en": "Excitement mixes with nervousness.",
-                "de": "Aufregung mischt sich mit Nervosität.",
-                "it": "L'eccitazione si mescola alla nervosità.",
-                "es": "La emoción se mezcla con la nerviosidad.",
-                "nl": "Opwinding vermengt zich met nervositeit.",
-                "pt": "A empolgação se mistura com o nervosismo."
-            },
-            "ipa": {
-                "fr": "lɛksitasjˈɔ̃ sə- mˈɛl a la- nɛʁvozitˈe",
-                "de": "[ˈaʊ̯fʁeːɡʊŋ ˈmɪʃt zɪç mɪt nɛʁvoˈziːtɛːt]",
-                "it": "[lˌetʃːitˌatsiˈɔːne sˌɪ mˈeskola ˌalla nˌɛrvozitˈa]",
-                "es": "[la emoˈθjon se ˈmeθkla kon la nerβjoˈsiðað]",
-                "nl": "[ˈɔpʋˌɪndɪŋ vərmˈɛŋt zɪx mɛt nˌɛrvoːzitˈɛɪt]",
-                "pt": "[a ˌeɪmpowɡasˈɐ̃ʊ̃ sy mˌistˈuɾæ koŋ ʊ nˌeɾəvozˈizmʊ]",
-                "en": "[ɛksˈaɪtmənt mˈɪksɪz wɪð nˈɜːvəsnəs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-023",
-            "text": {
-                "fr": "Ils s'approchent du guichet.",
-                "en": "They approach the ticket counter.",
-                "de": "Sie gehen zum Schalter.",
-                "it": "Si avvicinano allo sportello.",
-                "es": "Se acercan al mostrador.",
-                "nl": "Ze benaderen het loket.",
-                "pt": "Eles se aproximam do guichê."
-            },
-            "ipa": {
-                "fr": "il sapʁˈɔʃ dy- ɡiʃˈɛ",
-                "de": "[ziː ˈɡeːən t͡sʊm ˈʃaltɐ]",
-                "it": "[sˌɪ ˌavvitʃinˈaːno ˌallo sportˈɛllo]",
-                "es": "[se aθeɾˈkan al mosˈtɾaðoɾ]",
-                "nl": "[zə bənˈaːdərən hət loːkˈɛt]",
-                "pt": "[ˌelys sj ˌaprosˈimɐ̃ʊ̃ dʊ ɡiʃˈe]",
-                "en": "[ðeɪ ɐpɹˈəʊtʃ ðə tˈɪkɪt kˈaʊntə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-024",
-            "text": {
-                "fr": "Lucas regarde sa montre.",
-                "en": "Lucas looks at his watch.",
-                "de": "Lucas schaut auf die Uhr.",
-                "it": "Lucas guarda l'orologio.",
-                "es": "Lucas mira su reloj.",
-                "nl": "Lucas kijkt op zijn horloge.",
-                "pt": "Lucas olha o relógio."
-            },
-            "ipa": {
-                "fr": "lykˈa ʁəɡˈaʁd sa- mˈɔ̃tʁ",
-                "de": "[ˈluːkas ʃaʊ̯t aʊ̯f diː ʔuːɐ]",
-                "it": "[lˈuːkas ɡwˈaːrda lˌɔrolˈɔːdʒo]",
-                "es": "[ˈlukas ˈmiɾa su reˈlox]",
-                "nl": "[lˈykɑs kˈɛɪkt ɔp zɛɪn hˈɔrloːxə]",
-                "pt": "[lˈukæz ˈɔljæ ʊ xˌelˈɔʒjʊ]",
-                "en": "[lˈuːkəz lˈʊks at hɪz wˈɒtʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-025",
-            "text": {
-                "fr": "Ils trouvent un café dans la gare.",
-                "en": "They find a cafe in the station.",
-                "de": "Sie finden ein Café im Bahnhof.",
-                "it": "Trovano un caffè nella stazione.",
-                "es": "Encuentran un café en la estación.",
-                "nl": "Ze vinden een café in het station.",
-                "pt": "Eles encontram uma lanchonete na rodoviária.",
-                "en_pt": "They find a snack bar in the bus station."
-            },
-            "ipa": {
-                "fr": "il tʁˈuvt œ̃ kafˈe dɑ̃ la- ɡˈaʁ",
-                "de": "[ziː ˈfɪndn̩ aɪ̯n kaˈfeː ɪm ˈbaːnhoːf]",
-                "it": "[trˈovano ˌʊn kaffˈɛ nˌɛlla stˌatsiˈɔːne]",
-                "es": "[enˈkwentɾan un kaˈfe en la estaˈθjon]",
-                "nl": "[zə vˈɪndən ən kaːfˈeː ɪn hət staːʃˈɔn]",
-                "pt": "[ˌelyz ˌeɪŋkˈoŋtrɐ̃ʊ̃ ˌumæ lˌɐ̃ŋʃonˈɛtʃy na xˌodoviˈaɾjæ]",
-                "en": "[ðeɪ fˈaɪnd ɐ kˈafeɪ ɪnðə stˈeɪʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-026",
-            "text": {
-                "fr": "Sophie respire profondément.",
-                "en": "Sophie takes a deep breath.",
-                "de": "Sophie atmet tief ein.",
-                "it": "Sophie respira profondamente.",
-                "es": "Sophie respira hondo.",
-                "nl": "Sophie haalt diep adem."
-            },
-            "ipa": {
-                "fr": "sɔfˈi ʁɛspˈiʁ pʁɔfɔ̃demˈɑ̃",
-                "de": "[ˈzoːfiː ˈatmət tiːf aɪ̯n]",
-                "it": "[sˈopje respˈiːra prˌofondamˈente]",
-                "es": "[ˈsofi resˈpiɾa ˈondo]",
-                "nl": "[sɔphˈi hˈaːl tˈip ˈaːdəm]",
-                "en": "[sˈəʊfi tˈeɪks ɐ dˈiːp bɹˈɛθ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-027",
+            "id": "scene-05-028",
             "text": {
                 "fr": "Une annonce résonne dans la gare.",
-                "en": "An announcement resounds through the station.",
+                "en": "An announcement echoes through the station.",
                 "de": "Eine Durchsage erschallt im Bahnhof.",
                 "it": "Un annuncio risuona nella stazione.",
                 "es": "Una anunciación resuena en la estación.",
@@ -835,38 +762,7 @@
                 "es": "[ˈuna anunθjaˈθjon resuˈena en la estaˈθjon]",
                 "nl": "[ən ˈɔmrupbˌɪːrɪxt klˈɪŋkt doːr hət staːʃˈɔn]",
                 "pt": "[ũŋ ˌænˈũŋsjʊ xˌesˈoæ na xˌodoviˈaɾjæ]",
-                "en": "[ɐn ɐnˈaʊnsmənt ɹɪzˈaʊndz θɹuː ðə stˈeɪʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-028",
-            "text": {
-                "fr": "Ils trouvent leurs places dans le wagon.",
-                "en": "They find their seats in the wagon.",
-                "de": "Sie finden ihre Plätze im Waggon.",
-                "it": "Trovano i loro posti nel vagone.",
-                "es": "Encuentran sus asientos en el vagón.",
-                "nl": "Ze vinden hun plaatsen in de wagon.",
-                "pt": "Eles encontram seus assentos no ônibus.",
-                "en_pt": "They find their seats on the bus."
-            },
-            "ipa": {
-                "fr": "il tʁˈuv lœʁ plˈas dɑ̃ lə- vaɡˈɔ̃",
-                "de": "[ziː ˈfɪndn̩ ˈiːʁə ˈplɛt͡sə ɪm ˈvaɡɔn]",
-                "it": "[trˈovano ˌɪ lˌɔro pˈostɪ nˌɛl vaɡˈoːne]",
-                "es": "[enˈkwentɾan sus aˈsjentos en el βaˈɣon]",
-                "nl": "[zə vˈɪndən hɵn plˈaːtsən ɪn də ʋaːɣˈɔn]",
-                "pt": "[ˌelyz ˌeɪŋkˈoŋtrɐ̃ʊ̃ seʊz ˌasˈeɪŋtʊz nʊ ˈonibus]",
-                "en": "[ðeɪ fˈaɪnd ðeə sˈiːts ɪnðə wˈaɡən]"
+                "en": "[ɐn ɐnˈaʊnsmənt ˈɛkəʊz θɹuː ðə stˈeɪʃən]"
             },
             "provenance": {
                 "fr": "original",
@@ -881,20 +777,23 @@
         {
             "id": "scene-05-029",
             "text": {
-                "fr": "Sophie regarde Paris qui s'éloigne.",
-                "en": "Sophie watches as Amsterdam fades away.",
-                "de": "Sophie sieht Berlin, das sich entfernt.",
-                "it": "Sophie guarda Roma che si allontana.",
-                "es": "Sophie mira cómo Madrid se aleja.",
-                "nl": "Sophie kijkt hoe Amsterdam achter hen verdwijnt."
+                "fr": "Le train arrive bientôt.",
+                "en": "The train is arriving soon.",
+                "de": "Der Zug kommt bald.",
+                "it": "Il treno arriva presto.",
+                "es": "El tren llegará pronto.",
+                "nl": "De trein komt zo.",
+                "pt": "O ônibus vai chegar logo.",
+                "en_pt": "The bus will arrive soon."
             },
             "ipa": {
-                "fr": "sɔfˈi ʁəɡˈaʁd paʁˈi ki selwˈaɲ",
-                "de": "[ˈzoːfiː ziːt bɛʁˈliːn, das zɪç ɛntˈfɛʁnt]",
-                "it": "[sˈopje ɡwˈaːrda rˈɔːma kˌe sˌɪ ˌallontˈaːna]",
-                "es": "[ˈsofi ˈmiɾa ˈkomo maˈðɾið se aˈlexa]",
-                "nl": "[sɔphˈi kˈɛɪkt hˈu ˈɑmstərdˌɑm ˈɑxtər hɛn vərdʋˈɛɪnt]",
-                "en": "[sˈəʊfi wˈɒtʃɪz az ˈamstədˌam fˈeɪdz ɐwˈeɪ]"
+                "fr": "lə- tʁˈɛ̃ aʁˈiv bjɛ̃tˈo",
+                "de": "[deːɐ̯ t͡suːk kɔmt bald]",
+                "it": "[ˌil trˈɛːno arɾˈiːva prˈɛsto]",
+                "es": "[el tɾen ʎeˈɣaɾa ˈpɾonto]",
+                "nl": "[də trˈɛɪn kˈɔmt zˈoː]",
+                "pt": "[u ˈonibuz vaɪ ʃeɡˈar lˈɔɡʊ]",
+                "en": "[ðə tɹˈeɪn ɪz ɐɹˈaɪvɪŋ sˈuːn]"
             },
             "provenance": {
                 "fr": "original",
@@ -902,20 +801,37 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-05-030",
             "text": {
-                "pt": "pergunta a atendente.",
-                "en": "the attendant asks."
+                "fr": "Montons vite, il y a du monde,",
+                "en": "Let's get on quickly, there are a lot of people,",
+                "de": "Schnell einsteigen, es wird voll,",
+                "it": "Saliamo in fretta, c'è molta gente.",
+                "es": "Subamos rápido, que hay mucha gente.",
+                "nl": "Laten we snel instappen, het is druk,",
+                "pt": "Vamos rápido, tem muita gente, diz Lucas.",
+                "en_pt": "Let's go quickly, there are a lot of people, Lucas says."
             },
             "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ a ˌateɪŋdˈeɪŋtʃy]",
-                "en": "[ðɪ ɐtˈɛndənt ˈasks]"
+                "fr": "mɔ̃tˈɔ̃ vˈit il i a dy- mˈɔ̃d",
+                "de": "[ʃnɛl ˈaɪ̯nʃtaɪ̯ɡn̩, ɛs vɪɐ̯t fɔl]",
+                "it": "[sˌaliˈaːmo ˌin frˈetːa\n tʃˌɛ mˈolta dʒˈɛnte]",
+                "es": "[suˈβamos ˈrapido ke ai ˈmutʃa ˈxente]",
+                "nl": "[lˈaːtən ʋə snˈɛl ˈɪnstˌɑpən\n hət ɪs drˈɵk]",
+                "pt": "[vˌɐ̃mʊz xˈapidʊ\n teɪŋ mwˈiŋtæ ʒˈeɪŋtʃy\n dʒˈiz lˈukæs]",
+                "en": "[lˈɛts ɡɛt ˌɒn kwˈɪkli ðeəɹˌɑːɹ ɐ lˈɒt ɒv pˈiːpəl]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -923,14 +839,30 @@
         {
             "id": "scene-05-031",
             "text": {
-                "pt": "pergunta Sophie.",
-                "en": "Sophie asks."
+                "fr": "Ils trouvent leurs places dans le wagon.",
+                "en": "They find their seats in the carriage.",
+                "de": "Sie finden ihre Plätze im Waggon.",
+                "it": "Trovano i loro posti nel vagone.",
+                "es": "Encuentran sus asientos en el vagón.",
+                "nl": "Ze vinden hun plaatsen in de wagon.",
+                "pt": "Eles encontram seus assentos no ônibus.",
+                "en_pt": "They find their seats on the bus."
             },
             "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ sˌofˈiy]",
-                "en": "[sˈəʊfi ˈasks]"
+                "fr": "il tʁˈuv lœʁ plˈas dɑ̃ lə- vaɡˈɔ̃",
+                "de": "[ziː ˈfɪndn̩ ˈiːʁə ˈplɛt͡sə ɪm ˈvaɡɔn]",
+                "it": "[trˈovano ˌɪ lˌɔro pˈostɪ nˌɛl vaɡˈoːne]",
+                "es": "[enˈkwentɾan sus aˈsjentos en el βaˈɣon]",
+                "nl": "[zə vˈɪndən hɵn plˈaːtsən ɪn də ʋaːɣˈɔn]",
+                "pt": "[ˌelyz ˌeɪŋkˈoŋtrɐ̃ʊ̃ seʊz ˌasˈeɪŋtʊz nʊ ˈonibus]",
+                "en": "[ðeɪ fˈaɪnd ðeə sˈiːts ɪnðə kˈaɹɪdʒ]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -938,80 +870,36 @@
         {
             "id": "scene-05-032",
             "text": {
-                "pt": "Sophie pergunta ao atendente: Qual plataforma para o ônibus de Campos do Jordão?",
-                "en": "Sophie asks the attendant: Which platform for the Campos do Jordão bus?"
+                "fr": "Voici nos places. Près de la fenêtre!",
+                "en": "Here are our seats. Near the window!",
+                "de": "Hier sind unsere Plätze. Neben dem Fenster!",
+                "it": "Ecco i nostri posti. Vicino alla finestra!",
+                "es": "Aquí están nuestros asientos. ¡Junto a la ventana!",
+                "nl": "Hier zijn onze plaatsen. Bij het raam!",
+                "pt": "Aqui estão nossos lugares.",
+                "en_pt": "Here are our seats."
             },
             "ipa": {
-                "pt": "[sˌofˈiy pˌeɾəɡˈũŋtæ aʊ ˌateɪŋdˈeɪŋtʃy\n kwˈaʊ plˌatafˈɔɾəmæ pˌaɾæ u ˈonibuz dʒy kˈɐ̃mpʊz dʊ ʒoɾədˈɐ̃ʊ̃]",
-                "en": "[sˈəʊfi ˈasks ðɪ ɐtˈɛndənt wˌɪtʃ plˈatfɔːm fəðə kˈampəʊz dˈuː dʒˈɔːdaʊ bˈʌs]"
+                "fr": "vwasˌi no plˈas pʁɛ də- la- fənˈɛtʁ",
+                "de": "[hiːɐ̯ zɪnt ʔʊnzəʁə ˈplɛt͡sə. ˈneːbn̩ deːm ˈfɛnstɐ]",
+                "it": "[ˈɛkːo ˌɪ nˌɔstrɪ pˈostɪ\n vitʃˈiːno ˌalla finˈɛstra]",
+                "es": "[aˈki esˈtan nwestɾos aˈsjentos ˈxunto a la βenˈtana]",
+                "nl": "[hˈir zɛɪn ɔnzˌə plˈaːtsən\n bɛɪ hət rˈaːm]",
+                "pt": "[akˈi estˌɐ̃ʊ̃ nˌɔsʊs lˌuɡˈaɾys]",
+                "en": "[hˈiəɹ ɑːɹ aʊə sˈiːts nˌiə ðə wˈɪndəʊ]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-05-033",
-            "text": {
-                "pt": "Você vai ver os painéis.",
-                "en": "You'll see the signs."
-            },
-            "ipa": {
-                "pt": "[vosˌe vaɪ vˈeɾ ʊs paɪnˈɛɪs]",
-                "en": "[juːl sˈiː ðə sˈaɪnz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-034",
-            "text": {
-                "pt": "Lucas verifica sua mochila.",
-                "en": "Lucas checks his backpack."
-            },
-            "ipa": {
-                "pt": "[lˈukæz vˌeɾifˈikæ sˌuæ mˌoʃˈilæ]",
-                "en": "[lˈuːkəz tʃˈɛks hɪz bˈakpak]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-035",
-            "text": {
-                "pt": "Já peguei.",
-                "en": "I already got it."
-            },
-            "ipa": {
-                "pt": "[ʒˈa peɡˈeɪ]",
-                "en": "[aɪ ɔːlɹˌɛdi ɡˈɒt ɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-036",
-            "text": {
-                "pt": "Sophie respira fundo.",
-                "en": "Sophie takes a deep breath."
-            },
-            "ipa": {
-                "pt": "[sˌofˈiy xˌespˈiɾæ fˈũŋdʊ]",
-                "en": "[sˈəʊfi tˈeɪks ɐ dˈiːp bɹˈɛθ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-05-037",
             "text": {
                 "pt": "Perto da janela!",
                 "en": "By the window!"
@@ -1026,7 +914,7 @@
             }
         },
         {
-            "id": "scene-05-038",
+            "id": "scene-05-034",
             "text": {
                 "pt": "O ônibus parte.",
                 "en": "The bus departs."
@@ -1041,7 +929,7 @@
             }
         },
         {
-            "id": "scene-05-039",
+            "id": "scene-05-035",
             "text": {
                 "pt": "Sophie olha São Paulo ficando para trás.",
                 "en": "Sophie watches São Paulo receding behind them."
@@ -1052,6 +940,118 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-036",
+            "text": {
+                "fr": "C'est parti pour une nouvelle vie!",
+                "en": "Here we go for a new life!",
+                "de": "Los geht's, auf zu einem neuen Leben!",
+                "it": "Si parte per una nuova vita!",
+                "es": "¡Empezamos una nueva vida!",
+                "nl": "Daar gaan we, op naar een nieuw leven!",
+                "pt": "Lá vamos nós para uma nova vida!",
+                "en_pt": "Here we go to a new life!"
+            },
+            "ipa": {
+                "fr": "sɛ paʁtˈi puʁ yn nuvˈɛl vˈi",
+                "de": "[loːs ɡeːts, aʊ̯f t͡su ˈaɪ̯nəm ˈnɔɪ̯ən ˈleːbn̩]",
+                "it": "[sˌɪ pˈaːrte pˌɛr ˌʊna nʊˈɔːva vˈiːta]",
+                "es": "[empeˈθamos ˈuna ˈnweβa ˈβiða]",
+                "nl": "[dˈaːr ɣˈaːn ʋə\n ɔp naːr ən nˈiw lˈeːvən]",
+                "pt": "[lˈa vˌɐ̃mʊz nɔs pˌaɾæ ˌumæ nˈɔvæ vˈidæ]",
+                "en": "[hˈiə wiː ɡˌəʊ fəɹə njˈuː lˈaɪf]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-037",
+            "text": {
+                "fr": "Quel quai pour le train de Grenoble?",
+                "en": "Which platform for the Grenoble train?",
+                "de": "Auf welchem Bahnsteig fährt der Zug nach München?",
+                "it": "Quale binario per il treno per Roma Termini?",
+                "es": "¿En qué andén sale el tren para Segovia?",
+                "nl": "Op welk perron is de trein naar Maastricht?"
+            },
+            "ipa": {
+                "fr": "kɛl kˈe puʁ lə- tʁˈɛ̃ də- ɡʁənˈɔbl",
+                "de": "[aʊ̯f ˈvɛlçəm ˈbaːnʃtaɪ̯k fɛːɐ̯t deːɐ̯ t͡suːk naχ ˈmʏnçn̩]",
+                "it": "[kwˈaːle binˈario pˌɛr ˌil trˈɛːno pˌɛr rˈɔːma tˈɛrminɪ]",
+                "es": "[en ke anˈden ˈsale el tɾen paɾa seˈɣoβja]",
+                "nl": "[ɔp ʋˈɛlk pɛɾrˈɔn ɪs də trˈɛɪn naːr mˈaːstrɪxt]",
+                "en": "[wˌɪtʃ plˈatfɔːm fəðə ɡɹˈɛnəʊbəl tɹˈeɪn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-038",
+            "text": {
+                "fr": "Sophie respire profondément.",
+                "en": "Sophie breathes deeply.",
+                "de": "Sophie atmet tief ein.",
+                "it": "Sophie respira profondamente.",
+                "es": "Sophie respira hondo.",
+                "nl": "Sophie haalt diep adem."
+            },
+            "ipa": {
+                "fr": "sɔfˈi ʁɛspˈiʁ pʁɔfɔ̃demˈɑ̃",
+                "de": "[ˈzoːfiː ˈatmət tiːf aɪ̯n]",
+                "it": "[sˈopje respˈiːra prˌofondamˈente]",
+                "es": "[ˈsofi resˈpiɾa ˈondo]",
+                "nl": "[sɔphˈi hˈaːl tˈip ˈaːdəm]",
+                "en": "[sˈəʊfi bɹˈiːðz dˈiːpli]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-05-039",
+            "text": {
+                "fr": "Sophie regarde Paris qui s'éloigne.",
+                "en": "Sophie looks at Paris as it fades away.",
+                "de": "Sophie sieht Berlin, das sich entfernt.",
+                "it": "Sophie guarda Roma che si allontana.",
+                "es": "Sophie mira cómo Madrid se aleja.",
+                "nl": "Sophie kijkt hoe Amsterdam achter hen verdwijnt."
+            },
+            "ipa": {
+                "fr": "sɔfˈi ʁəɡˈaʁd paʁˈi ki selwˈaɲ",
+                "de": "[ˈzoːfiː ziːt bɛʁˈliːn, das zɪç ɛntˈfɛʁnt]",
+                "it": "[sˈopje ɡwˈaːrda rˈɔːma kˌe sˌɪ ˌallontˈaːna]",
+                "es": "[ˈsofi ˈmiɾa ˈkomo maˈðɾið se aˈlexa]",
+                "nl": "[sɔphˈi kˈɛɪkt hˈu ˈɑmstərdˌɑm ˈɑxtər hɛn vərdʋˈɛɪnt]",
+                "en": "[sˈəʊfi lˈʊks at pˈaɹɪs az ɪt fˈeɪdz ɐwˈeɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-06.json
+++ b/language_materials/unified/stories/scene-06.json
@@ -24,648 +24,30 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-06-001",
             "text": {
-                "fr": "Nous avons finalement quitté Paris,",
-                "en": "We have finally left Amsterdam,",
-                "de": "Wir haben schließlich Berlin verlassen,",
-                "it": "Abbiamo finalmente lasciato Roma,",
-                "es": "Finalmente hemos dejado Madrid,",
-                "nl": "We zijn eindelijk uit Amsterdam vertrokken,"
+                "pt": "O ônibus viaja pela rodovia Dutra.",
+                "en": "The bus travels along the Dutra highway."
             },
             "ipa": {
-                "fr": "nuz avˈɔ̃ finalmˈɑ̃ kitˈe paʁˈi",
-                "de": "[viːɐ̯ haːbm̩ ʃliːslɪç ˈbɛɐ̯liːn fɛɐ̯ˈlasn̩]",
-                "it": "[abːjˌamo fˌinalmˈente laʃˈaːto rˈɔːma]",
-                "es": "[fiˈnalmen̩te eˈmos deˈxaðo maˈðɾið]",
-                "nl": "[ʋə zɛɪn ˈɛɪndələk œyt ˈɑmstərdˌɑm vərtrˌɔkən]",
-                "en": "[wiː hav fˈaɪnəli lˈɛft ˈamstədˌam]"
+                "pt": "[u ˈonibuz vˌiˈaʒæ pˈelæ xˌodovˈiæ dˈutræ]",
+                "en": "[ðə bˈʌs tɹˈavəlz ɐlˈɒŋ ðə dˈʌtɹə hˈaɪweɪ]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-06-002",
             "text": {
-                "fr": "As-tu fermé la porte à clé?",
-                "en": "Did you lock the door?",
-                "de": "Hast du die Tür abgeschlossen?",
-                "it": "Hai chiuso la porta a chiave?",
-                "es": "¿Has cerrado la puerta con llave?",
-                "nl": "Heb je de deur op slot gedaan?",
-                "pt": "Você trancou a porta direito?",
-                "en_pt": "Did you lock the door properly?"
-            },
-            "ipa": {
-                "fr": "atˈy fɛʁmˈe la- pˈɔʁt a klˈe",
-                "de": "[hast du diː tyːɐ̯ ˈapɡəʃlɔsn̩]",
-                "it": "[ˌaj kjˈuːzo lˌa pˈɔːrta ˌa kjˈaːve]",
-                "es": "[as θeˈraðo la ˈpweɾta kon ˈʎaβe]",
-                "nl": "[hɛp jə də dˈøːr ɔp slˈɔt ɣədˈaːn]",
-                "pt": "[vosˌe trɐ̃ŋkˈow a pˈɔɾətæ dʒˌiɾˈeɪtʊ]",
-                "en": "[dˈɪd juː lˈɒk ðə dˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-003",
-            "text": {
-                "fr": "Oui, j'ai vérifié trois fois",
-                "en": "Yes, I checked three times",
-                "de": "Ja, ich habe dreimal nachgeprüft",
-                "it": "Sì, ho controllato tre volte",
-                "es": "Sí, lo he comprobado tres veces",
-                "nl": "Ja, ik heb drie keer gecontroleerd",
-                "pt": "Sim, verifiquei três vezes.",
-                "en_pt": "Yes, I checked three times."
-            },
-            "ipa": {
-                "fr": "wˈi ʒe veʁifjˈe tʁwˈa fwˈa",
-                "de": "[jaː ɪç haːbə ˈdʁaɪ̯maːl ˈnaːxɡəˌpʁyːft]",
-                "it": "[sˈi\n ˌo kˌontrollˈaːto trˈe vˈɔlte]",
-                "es": "[si lo e kompɾoˈβaðo ˈtɾes ˈβeθes]",
-                "nl": "[jˈaː\n ɪk hɛp drˈi kˈɪːr ɣəkˌɔntroːlˈɪrt]",
-                "pt": "[sˈiŋ\n vˌeɾifikˈeɪ trˈez vˈezys]",
-                "en": "[jˈɛs aɪ tʃˈɛkt θɹˈiː tˈaɪmz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-004",
-            "text": {
-                "fr": "Et toi, tu as prévenu ton travail?",
-                "en": "And you, did you notify your work?",
-                "de": "Und du, hast du deiner Arbeit Bescheid gesagt?",
-                "it": "E tu, hai avvisato al lavoro?",
-                "es": "¿Y tú, has avisado en tu trabajo?",
-                "nl": "En jij, heb je je werk ingelicht?",
-                "pt": "E você, avisou seu trabalho?"
-            },
-            "ipa": {
-                "fr": "e twˈa ty a pʁevnˈy tɔ̃ tʁavˈaj",
-                "de": "[ʊnt duː hast duː ˈdaɪ̯nɐ ˈaɐ̯baɪ̯t bəˈʃaɪ̯t ɡəˈzaːkt]",
-                "it": "[ˌe tˈu\n ˌaj ˌavvizˈaːto ˌal lavˈɔːro]",
-                "es": "[i tu as aβiˈsaðo en tu tɾaˈβaxo]",
-                "nl": "[ˈɛn jɛɪ\n hɛp jə jə ʋˈɛrk ˈɪnɣəlˌɪxt]",
-                "pt": "[i vosˈe\n ˌavizˈow seʊ trˌabˈaljʊ]",
-                "en": "[and jˈuː dˈɪd juː nˈəʊtɪfˌaɪ jɔː wˈɜːk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-005",
-            "text": {
-                "fr": "Oui, j'ai envoyé un email hier soir.",
-                "en": "Yes, I sent an email last night.",
-                "de": "Ja, ich habe gestern Abend eine E-Mail geschickt.",
-                "it": "Sì, ho inviato una mail ieri sera.",
-                "es": "Sí, envié un correo anoche.",
-                "nl": "Ja, ik heb gisteravond een e-mail gestuurd.",
-                "pt": "Sim, mandei um email ontem à noite."
-            },
-            "ipa": {
-                "fr": "wˈi ʒe ɑ̃vwajˈe œ̃nˈiːmɛːjl jˈɛʁ swˈaʁ",
-                "de": "[jaː ɪç haːbə ˈɡɛstɐn ˈaːbm̩t ˈaɪ̯nə ˈiːmeɪ̯l ɡəˈʃɪkt]",
-                "it": "[sˈi\n ˌo ˌinvɪˈaːto ˌʊna mˈeːil jˈɛːrɪ sˈeːra]",
-                "es": "[si emˈbje un koˈrɛ.o aˈnoʧe]",
-                "nl": "[jˈaː\n ɪk hɛp ɣˈɪstɪːrˌaːvɔnt ən ˈiːmeːl ɣəstˈyrt]",
-                "pt": "[sˈiŋ\n mɐ̃ŋdˈeɪ ũŋ ˌemaˈiʊ ˈoŋteɪŋ ˌaː nˈoɪtʃy]",
-                "en": "[jˈɛs aɪ sˈɛnt ɐn ˈiːmeɪl lˈast nˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-006",
-            "text": {
-                "fr": "Qu'est-ce que tu ressens?",
-                "en": "What do you feel?",
-                "de": "Wie fühlst du dich?",
-                "it": "Come ti senti?",
-                "es": "¿Qué sientes?",
-                "nl": "Wat voel je?",
-                "pt": "O que você está sentindo?",
-                "en_pt": "What are you feeling?"
-            },
-            "ipa": {
-                "fr": "kɛskˌə ty ʁəsˈɛn",
-                "de": "[viː ˈfyːlst duː dɪç]",
-                "it": "[kˌome tˌɪ sˈɛntɪ]",
-                "es": "[ke ˈsjentes]",
-                "nl": "[ʋɑt vˈul jə]",
-                "pt": "[ʊ ky vosˌe estˌa sˌeɪŋtʃˈiŋdʊ]",
-                "en": "[wˌɒt dˈuː juː fˈiːl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-007",
-            "text": {
-                "fr": "Je me sens libre et un peu nerveux. C'est bizarre, non?",
-                "en": "I feel free and a bit nervous. Weird, right?",
-                "de": "Ich fühle mich frei und ein bisschen nervös. Komisch, oder?",
-                "it": "Mi sento libero e un po' nervoso. È strano, vero?",
-                "es": "Me siento libre y un poco nervioso. ¿Es raro, verdad?",
-                "nl": "Ik voel me vrij en een beetje nerveus. Raar hè?",
-                "pt": "Me sinto livre e um pouco nervoso.",
-                "en_pt": "I feel free and a little nervous."
-            },
-            "ipa": {
-                "fr": "ʒə- mə- sˈɑ̃ lˈibʁ e œ̃ pø nɛʁvˈø sɛ bizˈaʁ nˈɔ̃",
-                "de": "[ɪç ˈfyːlə mɪç fʁaɪ̯ ʊnt aɪ̯n ˈbɪsn̩ ˈnɛʁvøːs ˈkɔmɪʃ ˈoːdɐ]",
-                "it": "[mˌɪ sˈɛnto lˈibero ˌe ˌʊn pˈo nervˈoːzo\n ˌɛ strˈaːno\n vˈeːro]",
-                "es": "[me ˈsjento ˈliβɾe i un ˈpoko nerˈβjoso es ˈraɾo βeɾˈðað]",
-                "nl": "[ɪk vˈul mə vrˈɛɪ ɛn ən bˈeːtʲə nˈɛrvøːs\n rˈaːr hˈeː]",
-                "pt": "[my sˈiŋtʊ lˈivri i ũŋ pˈowkʊ nˌeɾəvˈozʊ]",
-                "en": "[aɪ fˈiːl fɹˈiː and ɐ bˈɪt nˈɜːvəs wˈiəd ɹˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-008",
-            "text": {
-                "fr": "Moi aussi, c'est normal. On change toute notre vie.",
-                "en": "Me too, it's normal. We are changing our entire life.",
-                "de": "Ich auch, das ist normal. Wir ändern unser ganzes Leben.",
-                "it": "Anche io, è normale. Stiamo cambiando tutta la nostra vita.",
-                "es": "Yo también, es normal. Estamos cambiando toda nuestra vida.",
-                "nl": "Ik ook, het is normaal. We veranderen ons hele leven.",
-                "pt": "A gente está mudando toda nossa vida.",
-                "en_pt": "We're changing our whole life."
-            },
-            "ipa": {
-                "fr": "mwˌa osˈi sɛ nɔʁmˈal ɔ̃ ʃˈɑ̃ʒ tut nɔtʁ vˈi",
-                "de": "[ɪç aʊ̯x das ɪst noʁˈmaːl viːɐ̯ ˈɛndəʁn ˈʊnzɐ ˈɡantsəs ˈleːbn̩]",
-                "it": "[ˈanke ˈio\n ˌɛ normˈaːle\n stjˈaːmo kambjˈando tˈutːa lˌa nˌɔstra vˈiːta]",
-                "es": "[ʝo tamˈbjen es norˈmal esˈtamos kamˈβjando ˈtoða ˈnwes.tɾa ˈβiða]",
-                "nl": "[ɪk ˈoːk\n hət ɪs nɔrmˈaːl\n ʋə vərˈɑndərən ɔns hˈeːlə lˈeːvən]",
-                "pt": "[a ʒˈeɪŋtʃj estˌa mˌudˈɐ̃ŋdʊ tˈodæ nˌɔsæ vˈidæ]",
-                "en": "[mˌiː tˈuː ɪts nˈɔːməl wiː ɑː tʃˈeɪndʒɪŋ aʊəɹ ɛntˈaɪə lˈaɪf]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-009",
-            "text": {
-                "fr": "Regarde le paysage, il est magnifique!",
-                "en": "Look at the landscape, it's beautiful!",
-                "de": "Schau dir die Landschaft an, sie ist wunderschön!",
-                "it": "Guarda il paesaggio, è magnifico!",
-                "es": "Mira el paisaje, ¡es precioso!",
-                "nl": "Kijk naar het landschap, het is prachtig!",
-                "pt": "Olha a paisagem, está linda!"
-            },
-            "ipa": {
-                "fr": "ʁəɡˈaʁd lə- pɛizˈaʒ il ɛ maɲifˈik",
-                "de": "[ʃaʊ̯ diːɐ̯ diː ˈlantʃaft an ziː ɪst ˈvʊndɐʃøːn]",
-                "it": "[ɡwˈaːrda ˌil pˌaezˈadʒːo\n ˌɛ maɲˈifiko]",
-                "es": "[ˈmiɾa el pajˈsaxe es pɾeˈθjoso]",
-                "nl": "[kˈɛɪk naːr hət lˈɑndsxˌɑp\n hət ɪs prˈɑxtəx]",
-                "pt": "[ˈɔljæ a pˌaɪzˈaʒeɪŋ\n estˌa lˈiŋdæ]",
-                "en": "[lˈʊk at ðə lˈandskeɪp ɪts bjˈuːtɪfəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-010",
-            "text": {
-                "fr": "J'ai apporté des sandwichs. Fromage et jambon.",
-                "en": "I brought sandwiches. Cheese and ham.",
-                "de": "Ich habe Sandwiches mitgebracht. Käse und Schinken.",
-                "it": "Ho portato dei panini. Formaggio e prosciutto.",
-                "es": "He traído bocadillos. De queso y jamón.",
-                "nl": "Ik heb broodjes meegenomen. Kaas en ham.",
-                "pt": "Trouxe sanduíches.",
-                "en_pt": "I brought sandwiches."
-            },
-            "ipa": {
-                "fr": "ʒe apɔʁtˈe de- sɑ̃dwˈitʃ fʁɔmˈaʒ e ʒɑ̃bˈɔ̃",
-                "de": "[ɪç haːbə ˈzandvɪçəs ˈmɪtɡəbʁaxt ˈkɛːzə ʊnt ˈʃɪŋkn̩]",
-                "it": "[ˌo portˈaːto dˌɛj panˈiːnɪ\n formˈadʒːo ˌe proʃˈutːo]",
-                "es": "[e tɾaˈiðo βokaˈðiʎos de ˈkeso i xaˈmon]",
-                "nl": "[ɪk hɛ prˈoːtjəs mˈeːɣənˌoːmən\n kˈaːs ɛn hˈɑm]",
-                "pt": "[trˈowsy sˌɐ̃ŋduˈiʃys]",
-                "en": "[aɪ bɹˈɔːt sˈandwɪtʃɪz tʃˈiːz and hˈam]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-011",
-            "text": {
-                "fr": "Excellente idée, j'ai faim.",
-                "en": "Excellent idea, I'm hungry.",
-                "de": "Ausgezeichnete Idee, ich habe Hunger.",
-                "it": "Ottima idea, ho fame.",
-                "es": "Buena idea, tengo hambre.",
-                "nl": "Uitstekend idee, ik heb honger.",
-                "pt": "Ótima ideia, estou com fome.",
-                "en_pt": "Great idea, I'm hungry."
-            },
-            "ipa": {
-                "fr": "ɛksɛlˈɑ̃t idˈe ʒe fˈɛ̃",
-                "de": "[ˈaʊ̯sɡətsaɪ̯çnətə ˈiːdeː ɪç haːbə ˈhʊŋɐ]",
-                "it": "[ˈotːima idˈɛːa\n ˌo fˈaːme]",
-                "es": "[ˈbwena iˈðea ˈteŋgo ˈambɾe]",
-                "nl": "[ˈœytstˌeːkənt idˈeː\n ɪk hɛp hˈɔŋər]",
-                "pt": "[ˈɔtʃimæ ˌidˈɛɪæ\n estˌow koŋ fˈomy]",
-                "en": "[ˈɛksələnt aɪdˈiə aɪm hˈʌŋɡɹi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-012",
-            "text": {
-                "fr": "Combien de temps dure le voyage?",
-                "en": "How long is the trip?",
-                "de": "Wie lange dauert die Fahrt?",
-                "it": "Quanto dura il viaggio?",
-                "es": "¿Cuánto dura el viaje?",
-                "nl": "Hoe lang duurt de reis?",
-                "pt": "Lucas pergunta: Quanto tempo dura a viagem?",
-                "en_pt": "Lucas asks: How long does the trip take?"
-            },
-            "ipa": {
-                "fr": "kɔ̃bjˈɛ̃ də- tˈɑ̃ dˈyʁ lə- vwajˈaʒ",
-                "de": "[viː ˈlaŋə ˈdaʊ̯ɐt diː faːɐ̯t]",
-                "it": "[kwˈanto dˈuːra ˌil vjˈadʒːo]",
-                "es": "[ˈkwanto ˈðuɾa el βiˈaxe]",
-                "nl": "[hˈu lˈɑŋ dˈyr tə rˈɛɪs]",
-                "pt": "[lˈukæs pˌeɾəɡˈũŋtæ\n kwˈɐ̃ŋtʊ tˈeɪmpʊ dˈuɾæ a vˌiˈaʒeɪŋ]",
-                "en": "[hˌaʊ lˈɒŋ ɪz ðə tɹˈɪp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-013",
-            "text": {
-                "fr": "Environ cinq heures. On arrive vers seize heures.",
-                "en": "About five hours. We'll arrive around four o'clock.",
-                "de": "Etwa fünf Stunden. Wir kommen gegen sechzehn Uhr an.",
-                "it": "Circa cinque ore. Arriviamo verso le sedici.",
-                "es": "Unas cinco horas. Llegaremos sobre las cuatro.",
-                "nl": "Ongeveer vijf uur. We komen rond vier uur aan."
-            },
-            "ipa": {
-                "fr": "ɑ̃viʁˈɔ̃ sˈɛ̃k ˈœʁ ɔ̃n aʁˈiv vɛʁ sˈɛz ˈœʁ",
-                "de": "[ˈɛtva ˈfʏnf ˈʃtʊndn̩ viːɐ̯ ˈkɔmən ˈɡeːɡn̩ zɛçˈtseːn uːɐ̯ an]",
-                "it": "[tʃˈiːrka tʃˈinkwe ˈoːre\n ˌarɾivjˈaːmo vˌɛrso lˌe sˈeditʃɪ]",
-                "es": "[ˈunas ˈθiŋko ˈoɾas ʎeɣaˈɾemos ˈsoβɾe las ˈkwatɾo]",
-                "nl": "[ˌɔnɣəvˈɪːr vˈɛɪf ˈyr\n ʋə kˈoːmən rˈɔnt vˈir ˈyr ˈaːn]",
-                "en": "[ɐbˌaʊt fˈaɪv ˈaʊəz wiːl ɐɹˈaɪv ɐɹˈaʊnd fˈɔːɹ əklˈɒk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-014",
-            "text": {
-                "fr": "Oh non! J'ai oublié mon livre!",
-                "en": "Oh no! I forgot my book!",
-                "de": "Oh nein! Ich habe mein Buch vergessen!",
-                "it": "Oh no! Ho dimenticato il mio libro!",
-                "es": "¡Oh no! ¡He olvidado mi libro!",
-                "nl": "Oh nee! Ik ben mijn boek vergeten!",
-                "pt": "Esqueci meu livro!",
-                "en_pt": "I forgot my book!"
-            },
-            "ipa": {
-                "fr": "ˈɔ nˈɔ̃ ʒe ubliˈe mɔ̃ lˈivʁ",
-                "de": "[oː ˈnaɪ̯n ɪç haːbə maɪ̯n buːx fɛɐ̯ˈɡɛsn̩]",
-                "it": "[ˈɔ nˈɔ\n ˌo dˌimentikˈaːto ˌil mˌio lˈiːbro]",
-                "es": "[o no e olβiˈðaðo mi ˈliβɾo]",
-                "nl": "[ˈɔh nˈeː\n ɪk bɛn mɛɪn bˈuk vərɣˈeːtən]",
-                "pt": "[ˌeskesˈi meʊ lˈivrʊ]",
-                "en": "[ˈəʊ nˈəʊ aɪ fəɡˈɒt maɪ bˈʊk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-015",
-            "text": {
-                "fr": "Ce n'est pas grave, on peut parler.",
-                "en": "It's okay, we can talk.",
-                "de": "Macht nichts, wir können reden.",
-                "it": "Non è grave, possiamo parlare.",
-                "es": "No pasa nada, podemos hablar.",
-                "nl": "Geeft niet, we kunnen praten.",
-                "pt": "Não tem problema, a gente pode conversar.",
-                "en_pt": "No problem, we can talk."
-            },
-            "ipa": {
-                "fr": "sə- nɛ pa ɡʁˈav ɔ̃ pˈø paʁlˈe",
-                "de": "[maxt nɪçts viːɐ̯ ˈkœnən ˈʁeːdn̩]",
-                "it": "[nˌon ˌɛ ɡrˈaːve\n possjˈaːmo parlˈaːre]",
-                "es": "[no ˈpasa ˈnaða poˈðemos aˈβlaɾ]",
-                "nl": "[ɣˈeːft nˈit\n ʋə kˌɵnən prˈaːtən]",
-                "pt": "[nˌɐ̃ʊ̃ teɪŋ prˌoblˈemæ\n a ʒˈeɪŋtʃy pˌɔdʒy kˌoŋveɾəsˈar]",
-                "en": "[ɪts əʊkˈeɪ wiː kan tˈɔːk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-016",
-            "text": {
-                "fr": "De quoi veux-tu parler?",
-                "en": "What do you want to talk about?",
-                "de": "Worüber möchtest du sprechen?",
-                "it": "Di cosa vuoi parlare?",
-                "es": "¿Sobre qué quieres hablar?",
-                "nl": "Waar wil je over praten?",
-                "pt": "Sobre o que você quer falar?"
-            },
-            "ipa": {
-                "fr": "də- kwˌa vˈøty paʁlˈe",
-                "de": "[voˈʁyːbɐ ˈmøːçtəst duː ˈʃpʁeːçn̩]",
-                "it": "[dˌɪ kˈɔːza vʊˈɔːɪ parlˈaːre]",
-                "es": "[ˈsoβɾe ke ˈkjeɾes aˈβlaɾ]",
-                "nl": "[ʋˈaːr ʋɪl jə ˈoːvər prˈaːtən]",
-                "pt": "[sˈobri ʊ ky vosˌe kˈɛr falˈar]",
-                "en": "[wˌɒt dˈuː juː wˈɒnt tə tˈɔːk ɐbˈaʊt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-017",
-            "text": {
-                "fr": "De nos rêves et de notre avenir",
-                "en": "About our dreams and our future",
-                "de": "Über unsere Träume und unsere Zukunft",
-                "it": "Dei nostri sogni e del nostro futuro",
-                "es": "Sobre nuestros sueños y nuestro futuro",
-                "nl": "Over onze dromen en onze toekomst",
-                "pt": "Sobre nossos sonhos e nosso futuro.",
-                "en_pt": "About our dreams and our future."
-            },
-            "ipa": {
-                "fr": "də- no ʁˈɛvz e də- nɔtʁ avnˈiʁ",
-                "de": "[ˈyːbɐ ˈʊnzəʁə ˈtʁɔɪ̯mə ʊnt ˈʊnzəʁə ˈtsʊkʊnft]",
-                "it": "[dˌɛj nˌɔstrɪ sˈoɲʲɪ ˌe dˌɛl nˌɔstro fʊtˈuːro]",
-                "es": "[ˈsoβɾe ˈnwestɾos ˈsweɲos i ˈnwestɾo fuˈtuɾo]",
-                "nl": "[ˈoːvər ɔnzˌə drˈoːmən ɛn ɔnzˌə tˈukˌɔmst]",
-                "pt": "[sˈobry nˌɔsʊs sˈoɲʊz i nˌɔsʊ fˌutˈuɾʊ]",
-                "en": "[ɐbˌaʊt aʊə dɹˈiːmz and aʊə fjˈuːtʃə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-018",
-            "text": {
-                "fr": "Qu'est-ce que tu veux vraiment dans la vie?",
-                "en": "What do you really want in life?",
-                "de": "Was willst du wirklich im Leben?",
-                "it": "Cosa vuoi veramente nella vita?",
-                "es": "¿Qué es lo que realmente quieres en la vida?",
-                "nl": "Wat wil je echt in het leven?",
-                "pt": "O que você realmente quer na vida?"
-            },
-            "ipa": {
-                "fr": "kɛskˌə ty vˈø vʁɛmˈɑ̃ dɑ̃ la- vˈi",
-                "de": "[vas ˈvɪlst duː ˈvɪʁklɪç ɪm ˈleːbn̩]",
-                "it": "[kˈɔːza vʊˈɔːɪ vˌɛramˈente nˌɛlla vˈiːta]",
-                "es": "[ke es lo ke reˈalmen̩te ˈkjeɾes en la ˈβiða]",
-                "nl": "[ʋɑt ʋɪl jə ˈɛxt ɪn hət lˈeːvən]",
-                "pt": "[ʊ ky vosˌe xˌeaʊmˈeɪŋtʃy kˈɛr na vˈidæ]",
-                "en": "[wˌɒt dˈuː juː ɹˈiəlɪ wˈɒnt ɪn lˈaɪf]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-019",
-            "text": {
-                "fr": "C'est une grande question",
-                "en": "That's a big question",
-                "de": "Das ist eine große Frage",
-                "it": "È una grande domanda",
-                "es": "Es una gran pregunta",
-                "nl": "Dat is een grote vraag",
-                "pt": "É uma grande pergunta.",
-                "en_pt": "That's a big question."
-            },
-            "ipa": {
-                "fr": "sɛt yn ɡʁˈɑ̃d kɛstjˈɔ̃",
-                "de": "[das ɪst ˈaɪ̯nə ˈɡʁoːsə ˈfʁaːɡə]",
-                "it": "[ˌɛ ˌʊna ɡrˈande domˈanda]",
-                "es": "[es ˈuna ɣɾan preˈɣunta]",
-                "nl": "[dɑt ɪs ən ɣrˈoːtə vrˈaːx]",
-                "pt": "[ɛ ˌumæ ɡrˈɐ̃ŋdʒy pˌeɾəɡˈũŋtæ]",
-                "en": "[ðats ɐ bˈɪɡ kwˈɛstʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-020",
-            "text": {
-                "fr": "Je veux me sentir vivante, je pense.",
-                "en": "I want to feel alive, I think.",
-                "de": "Ich möchte mich lebendig fühlen, denke ich.",
-                "it": "Voglio sentirmi viva, penso.",
-                "es": "Quiero sentirme viva, creo.",
-                "nl": "Ik wil me levend voelen, denk ik.",
-                "pt": "Eu quero me sentir viva, eu acho."
-            },
-            "ipa": {
-                "fr": "ʒə- vˈø mə- sɑ̃tˈiʁ vivˈɑ̃t ʒə- pˈɑ̃s",
-                "de": "[ɪç ˈmœçtə mɪç ˈleːbəndɪç ˈfyːlən ˈdɛŋkə ɪç]",
-                "it": "[vˈoːʎo sentˈiːrmɪ vˈiːva\n pˈɛnso]",
-                "es": "[ˈkjeɾo senˈtiɾme ˈβiβa ˈkɾeo]",
-                "nl": "[ɪk ʋɪl mə lˈeːvənt vˈulən\n dˈɛŋk ɪk]",
-                "pt": "[eʊ kˈɛɾʊ my seɪŋtʃˈir vˈivæ\n eʊ ˈaʃʊ]",
-                "en": "[aɪ wˈɒnt tə fˈiːl ɐlˈaɪv aɪ θˈɪŋk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-021",
-            "text": {
-                "fr": "Le train file à travers la campagne française.",
-                "en": "The train races through the Dutch countryside.",
-                "de": "Der Zug rast durch die deutsche Landschaft.",
-                "it": "Il treno sfreccia attraverso la campagna italiana.",
-                "es": "El metro corre por el campo madrileño.",
-                "nl": "De trein raast door het Nederlandse landschap."
-            },
-            "ipa": {
-                "fr": "lə- tʁˈɛ̃ fˈil a tʁavˈɛʁ la- kɑ̃pˈaɲ fʁɑ̃sˈɛz",
-                "de": "[deːɐ̯ tsuːk ʁast dʊʁç diː ˈdɔɪ̯tʃə ˈlantʃaft]",
-                "it": "[ˌil trˈɛːno sfrˈetʃːa ˌatːravˈɛːrso lˌa kampˈaɲɲa ˌitaliˈaːna]",
-                "es": "[el ˈmetɾo ˈkoɾe por el ˈkampo maðɾiˈleɲo]",
-                "nl": "[də trˈɛɪn rˈaːst doːr hət nˈeːdərlˌɑndsə lˈɑndsxˌɑp]",
-                "en": "[ðə tɹˈeɪn ɹˈeɪsɪz θɹuː ðə dˈʌtʃ kˈʌntɹɪsˌaɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-022",
-            "text": {
                 "fr": "Sophie et Lucas regardent le paysage qui défile par la fenêtre.",
-                "en": "Sophie and Lucas watch the passing landscape through the window.",
+                "en": "Sophie and Lucas look at the landscape passing by the window.",
                 "de": "Sophie und Lucas schauen die vorbeiziehende Landschaft an.",
                 "it": "Sophie e Lucas guardano il paesaggio che scorre dalla finestra.",
                 "es": "Sophie y Lucas miran el paisaje que pasa por la ventana.",
@@ -680,7 +62,7 @@
                 "es": "[ˈsofi i ˈlukas ˈmiɾan el pajˈsaxe ke ˈpasa por la βenˈtana]",
                 "nl": "[sɔphˈi ɛn lˈykɑs kˈɛɪkən naːr hət vˈɔːrbɛɪɣˌaːndə lˈɑndsxˌɑp doːr hət rˈaːm]",
                 "pt": "[sˌofˈij i lˈukæz ˈɔljɐ̃ʊ̃ a pˌaɪzˈaʒeɪŋ ky pˈasæ pˈelæ ʒˌænˈɛlæ]",
-                "en": "[sˈəʊfi and lˈuːkəz wˈɒtʃ ðə pˈasɪŋ lˈandskeɪp θɹuː ðə wˈɪndəʊ]"
+                "en": "[sˈəʊfi and lˈuːkəz lˈʊk at ðə lˈandskeɪp pˈasɪŋ baɪ ðə wˈɪndəʊ]"
             },
             "provenance": {
                 "fr": "original",
@@ -693,34 +75,22 @@
             }
         },
         {
-            "id": "scene-06-023",
+            "id": "scene-06-003",
             "text": {
-                "fr": "dit Sophie, presque incrédule.",
-                "en": "says Sophie, almost incredulously.",
-                "de": "sagt Sophie, fast ungläubig.",
-                "it": "dice Sophie, quasi incredula.",
-                "es": "dice Sophie, casi incrédula.",
-                "nl": "zegt Sophie, bijna ongelovig."
+                "pt": "Finalmente saímos de São Paulo, diz Sophie, quase incrédula.",
+                "en": "We finally left São Paulo, Sophie says, almost in disbelief."
             },
             "ipa": {
-                "fr": "dˈi sɔfˈi pʁˌɛskə ɛ̃kʁedˈyl",
-                "de": "[zaːkt ˈzɔfiː fast ˈʊnɡlɔɪ̯bɪç]",
-                "it": "[dˈiːtʃe sˈopje\n kwˈaːzɪ inkrˈɛdʊla]",
-                "es": "[ˈdiθe ˈsofi ˈkasi inˈkɾeðula]",
-                "nl": "[zˈɛxt sɔphˈi\n bˈɛɪnˌaː ˌɔnɣəlˈoːvəx]",
-                "en": "[sˈɛz sˈəʊfi ˈɔːlməʊst ɪnkɹˈɛdjʊləsli]"
+                "pt": "[fˌinaʊmˈeɪŋtʃy sˌaˈimʊz dʒy sɐ̃ʊ̃ pˈaʊlʊ\n dʒˈis sˌofˈiy\n kwˈazj ˌiŋkrˈɛdulæ]",
+                "en": "[wiː fˈaɪnəli lˈɛft sˈaʊ pˈɔːləʊ sˈəʊfi sˈɛz ˈɔːlməʊst ɪn dˌɪsbɪlˈiːf]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-06-024",
+            "id": "scene-06-004",
             "text": {
                 "fr": "Lucas vérifie son téléphone.",
                 "en": "Lucas checks his phone.",
@@ -751,25 +121,25 @@
             }
         },
         {
-            "id": "scene-06-025",
+            "id": "scene-06-005",
             "text": {
-                "fr": "Sophie se tourne vers Lucas.",
-                "en": "Sophie turns towards Lucas.",
-                "de": "Sophie wendet sich zu Lucas.",
-                "it": "Sophie si gira verso Lucas.",
-                "es": "Sophie se gira hacia Lucas.",
-                "nl": "Sophie draait zich naar Lucas toe.",
-                "pt": "Sophie se vira para Lucas.",
-                "en_pt": "Sophie turns to Lucas."
+                "fr": "As-tu fermé la porte à clé?",
+                "en": "Did you lock the door?",
+                "de": "Hast du die Tür abgeschlossen?",
+                "it": "Hai chiuso la porta a chiave?",
+                "es": "¿Has cerrado la puerta con llave?",
+                "nl": "Heb je de deur op slot gedaan?",
+                "pt": "Você trancou a porta direito?",
+                "en_pt": "Did you lock the door properly?"
             },
             "ipa": {
-                "fr": "sɔfˈi sə- tˈuʁn vɛʁ lykˈa",
-                "de": "[ˈzɔfiː ˈvɛndət zɪç tsuː ˈluːkas]",
-                "it": "[sˈopje sˌɪ dʒˈiːra vˌɛrso lˈuːkas]",
-                "es": "[ˈsofi se ˈxiɾa ˈaθja ˈlukas]",
-                "nl": "[sɔphˈi drˈaːjt zɪx naːr lˈykɑs tˈu]",
-                "pt": "[sˌofˈiy sy vˈiɾæ pˌaɾæ lˈukæs]",
-                "en": "[sˈəʊfi tˈɜːnz tʊwˈɔːdz lˈuːkəz]"
+                "fr": "atˈy fɛʁmˈe la- pˈɔʁt a klˈe",
+                "de": "[hast du diː tyːɐ̯ ˈapɡəʃlɔsn̩]",
+                "it": "[ˌaj kjˈuːzo lˌa pˈɔːrta ˌa kjˈaːve]",
+                "es": "[as θeˈraðo la ˈpweɾta kon ˈʎaβe]",
+                "nl": "[hɛp jə də dˈøːr ɔp slˈɔt ɣədˈaːn]",
+                "pt": "[vosˌe trɐ̃ŋkˈow a pˈɔɾətæ dʒˌiɾˈeɪtʊ]",
+                "en": "[dˈɪd juː lˈɒk ðə dˈɔː]"
             },
             "provenance": {
                 "fr": "original",
@@ -782,7 +152,252 @@
             }
         },
         {
-            "id": "scene-06-026",
+            "id": "scene-06-006",
+            "text": {
+                "fr": "Oui, j'ai vérifié trois fois",
+                "en": "Yes, I checked three times",
+                "de": "Ja, ich habe dreimal nachgeprüft",
+                "it": "Sì, ho controllato tre volte",
+                "es": "Sí, lo he comprobado tres veces",
+                "nl": "Ja, ik heb drie keer gecontroleerd",
+                "pt": "Sim, verifiquei três vezes.",
+                "en_pt": "Yes, I checked three times."
+            },
+            "ipa": {
+                "fr": "wˈi ʒe veʁifjˈe tʁwˈa fwˈa",
+                "de": "[jaː ɪç haːbə ˈdʁaɪ̯maːl ˈnaːxɡəˌpʁyːft]",
+                "it": "[sˈi\n ˌo kˌontrollˈaːto trˈe vˈɔlte]",
+                "es": "[si lo e kompɾoˈβaðo ˈtɾes ˈβeθes]",
+                "nl": "[jˈaː\n ɪk hɛp drˈi kˈɪːr ɣəkˌɔntroːlˈɪrt]",
+                "pt": "[sˈiŋ\n vˌeɾifikˈeɪ trˈez vˈezys]",
+                "en": "[jˈɛs aɪ tʃˈɛkt θɹˈiː tˈaɪmz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-007",
+            "text": {
+                "fr": "Et toi, tu as prévenu ton travail?",
+                "en": "And you, did you inform your work?",
+                "de": "Und du, hast du deiner Arbeit Bescheid gesagt?",
+                "it": "E tu, hai avvisato al lavoro?",
+                "es": "¿Y tú, has avisado en tu trabajo?",
+                "nl": "En jij, heb je je werk ingelicht?",
+                "pt": "E você, avisou seu trabalho?",
+                "en_pt": "And you, did you notify your work?"
+            },
+            "ipa": {
+                "fr": "e twˈa ty a pʁevnˈy tɔ̃ tʁavˈaj",
+                "de": "[ʊnt duː hast duː ˈdaɪ̯nɐ ˈaɐ̯baɪ̯t bəˈʃaɪ̯t ɡəˈzaːkt]",
+                "it": "[ˌe tˈu\n ˌaj ˌavvizˈaːto ˌal lavˈɔːro]",
+                "es": "[i tu as aβiˈsaðo en tu tɾaˈβaxo]",
+                "nl": "[ˈɛn jɛɪ\n hɛp jə jə ʋˈɛrk ˈɪnɣəlˌɪxt]",
+                "pt": "[i vosˈe\n ˌavizˈow seʊ trˌabˈaljʊ]",
+                "en": "[and jˈuː dˈɪd juː ɪnfˈɔːm jɔː wˈɜːk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-008",
+            "text": {
+                "fr": "Oui, j'ai envoyé un email hier soir.",
+                "en": "Yes, I sent an email last night.",
+                "de": "Ja, ich habe gestern Abend eine E-Mail geschickt.",
+                "it": "Sì, ho inviato una mail ieri sera.",
+                "es": "Sí, envié un correo anoche.",
+                "nl": "Ja, ik heb gisteravond een e-mail gestuurd.",
+                "pt": "Sim, mandei um email ontem à noite."
+            },
+            "ipa": {
+                "fr": "wˈi ʒe ɑ̃vwajˈe œ̃nˈiːmɛːjl jˈɛʁ swˈaʁ",
+                "de": "[jaː ɪç haːbə ˈɡɛstɐn ˈaːbm̩t ˈaɪ̯nə ˈiːmeɪ̯l ɡəˈʃɪkt]",
+                "it": "[sˈi\n ˌo ˌinvɪˈaːto ˌʊna mˈeːil jˈɛːrɪ sˈeːra]",
+                "es": "[si emˈbje un koˈrɛ.o aˈnoʧe]",
+                "nl": "[jˈaː\n ɪk hɛp ɣˈɪstɪːrˌaːvɔnt ən ˈiːmeːl ɣəstˈyrt]",
+                "pt": "[sˈiŋ\n mɐ̃ŋdˈeɪ ũŋ ˌemaˈiʊ ˈoŋteɪŋ ˌaː nˈoɪtʃy]",
+                "en": "[jˈɛs aɪ sˈɛnt ɐn ˈiːmeɪl lˈast nˈaɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-009",
+            "text": {
+                "fr": "Sophie se tourne vers Lucas.",
+                "en": "Sophie turns to Lucas.",
+                "de": "Sophie wendet sich zu Lucas.",
+                "it": "Sophie si gira verso Lucas.",
+                "es": "Sophie se gira hacia Lucas.",
+                "nl": "Sophie draait zich naar Lucas toe.",
+                "pt": "Sophie se vira para Lucas."
+            },
+            "ipa": {
+                "fr": "sɔfˈi sə- tˈuʁn vɛʁ lykˈa",
+                "de": "[ˈzɔfiː ˈvɛndət zɪç tsuː ˈluːkas]",
+                "it": "[sˈopje sˌɪ dʒˈiːra vˌɛrso lˈuːkas]",
+                "es": "[ˈsofi se ˈxiɾa ˈaθja ˈlukas]",
+                "nl": "[sɔphˈi drˈaːjt zɪx naːr lˈykɑs tˈu]",
+                "pt": "[sˌofˈiy sy vˈiɾæ pˌaɾæ lˈukæs]",
+                "en": "[sˈəʊfi tˈɜːnz tə lˈuːkəz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-010",
+            "text": {
+                "fr": "Qu'est-ce que tu ressens?",
+                "en": "What do you feel?",
+                "de": "Wie fühlst du dich?",
+                "it": "Come ti senti?",
+                "es": "¿Qué sientes?",
+                "nl": "Wat voel je?",
+                "pt": "O que você está sentindo?",
+                "en_pt": "What are you feeling?"
+            },
+            "ipa": {
+                "fr": "kɛskˌə ty ʁəsˈɛn",
+                "de": "[viː ˈfyːlst duː dɪç]",
+                "it": "[kˌome tˌɪ sˈɛntɪ]",
+                "es": "[ke ˈsjentes]",
+                "nl": "[ʋɑt vˈul jə]",
+                "pt": "[ʊ ky vosˌe estˌa sˌeɪŋtʃˈiŋdʊ]",
+                "en": "[wˌɒt dˈuː juː fˈiːl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-011",
+            "text": {
+                "fr": "Je me sens libre et un peu nerveux. C'est bizarre, non?",
+                "en": "I feel free and a little nervous. It's strange, isn't it?",
+                "de": "Ich fühle mich frei und ein bisschen nervös. Komisch, oder?",
+                "it": "Mi sento libero e un po' nervoso. È strano, vero?",
+                "es": "Me siento libre y un poco nervioso. ¿Es raro, verdad?",
+                "nl": "Ik voel me vrij en een beetje nerveus. Raar hè?",
+                "pt": "Me sinto livre e um pouco nervoso.",
+                "en_pt": "I feel free and a little nervous."
+            },
+            "ipa": {
+                "fr": "ʒə- mə- sˈɑ̃ lˈibʁ e œ̃ pø nɛʁvˈø sɛ bizˈaʁ nˈɔ̃",
+                "de": "[ɪç ˈfyːlə mɪç fʁaɪ̯ ʊnt aɪ̯n ˈbɪsn̩ ˈnɛʁvøːs ˈkɔmɪʃ ˈoːdɐ]",
+                "it": "[mˌɪ sˈɛnto lˈibero ˌe ˌʊn pˈo nervˈoːzo\n ˌɛ strˈaːno\n vˈeːro]",
+                "es": "[me ˈsjento ˈliβɾe i un ˈpoko nerˈβjoso es ˈraɾo βeɾˈðað]",
+                "nl": "[ɪk vˈul mə vrˈɛɪ ɛn ən bˈeːtʲə nˈɛrvøːs\n rˈaːr hˈeː]",
+                "pt": "[my sˈiŋtʊ lˈivri i ũŋ pˈowkʊ nˌeɾəvˈozʊ]",
+                "en": "[aɪ fˈiːl fɹˈiː and ɐ lˈɪtəl nˈɜːvəs ɪts stɹˈeɪndʒ ˈɪzənt ɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-012",
+            "text": {
+                "pt": "É estranho, né?",
+                "en": "It's strange, isn't it?"
+            },
+            "ipa": {
+                "pt": "[ɛ ˌestrˈɐ̃ɲʊ\n nˈɛ]",
+                "en": "[ɪts stɹˈeɪndʒ ˈɪzənt ɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-013",
+            "text": {
+                "pt": "Eu também, é normal.",
+                "en": "Me too, it's normal."
+            },
+            "ipa": {
+                "pt": "[eʊ tɐ̃mbˈeɪŋ\n ɛ noɾəmˈaʊ]",
+                "en": "[mˌiː tˈuː ɪts nˈɔːməl]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-014",
+            "text": {
+                "fr": "Moi aussi, c'est normal. On change toute notre vie.",
+                "en": "Me too, it's normal. We're changing our whole life.",
+                "de": "Ich auch, das ist normal. Wir ändern unser ganzes Leben.",
+                "it": "Anche io, è normale. Stiamo cambiando tutta la nostra vita.",
+                "es": "Yo también, es normal. Estamos cambiando toda nuestra vida.",
+                "nl": "Ik ook, het is normaal. We veranderen ons hele leven.",
+                "pt": "A gente está mudando toda nossa vida.",
+                "en_pt": "We're changing our whole life."
+            },
+            "ipa": {
+                "fr": "mwˌa osˈi sɛ nɔʁmˈal ɔ̃ ʃˈɑ̃ʒ tut nɔtʁ vˈi",
+                "de": "[ɪç aʊ̯x das ɪst noʁˈmaːl viːɐ̯ ˈɛndəʁn ˈʊnzɐ ˈɡantsəs ˈleːbn̩]",
+                "it": "[ˈanke ˈio\n ˌɛ normˈaːle\n stjˈaːmo kambjˈando tˈutːa lˌa nˌɔstra vˈiːta]",
+                "es": "[ʝo tamˈbjen es norˈmal esˈtamos kamˈβjando ˈtoða ˈnwes.tɾa ˈβiða]",
+                "nl": "[ɪk ˈoːk\n hət ɪs nɔrmˈaːl\n ʋə vərˈɑndərən ɔns hˈeːlə lˈeːvən]",
+                "pt": "[a ʒˈeɪŋtʃj estˌa mˌudˈɐ̃ŋdʊ tˈodæ nˌɔsæ vˈidæ]",
+                "en": "[mˌiː tˈuː ɪts nˈɔːməl wiə tʃˈeɪndʒɪŋ aʊə hˈəʊl lˈaɪf]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-015",
             "text": {
                 "fr": "Le paysage devient de plus en plus vallonné.",
                 "en": "The landscape becomes more and more hilly.",
@@ -813,25 +428,25 @@
             }
         },
         {
-            "id": "scene-06-027",
+            "id": "scene-06-016",
             "text": {
-                "fr": "Ils mangent en silence, admirant la vue.",
-                "en": "They eat in silence, enjoying the view.",
-                "de": "Sie essen schweigend und bewundern die Aussicht.",
-                "it": "Mangiano in silenzio, ammirando la vista.",
-                "es": "Comen en silencio, admirando la vista.",
-                "nl": "Ze eten in stilte, genietend van het uitzicht.",
-                "pt": "Eles comem em silêncio, admirando a vista.",
-                "en_pt": "They eat in silence, admiring the view."
+                "fr": "Regarde le paysage, il est magnifique!",
+                "en": "Look at the landscape, it's magnificent!",
+                "de": "Schau dir die Landschaft an, sie ist wunderschön!",
+                "it": "Guarda il paesaggio, è magnifico!",
+                "es": "Mira el paisaje, ¡es precioso!",
+                "nl": "Kijk naar het landschap, het is prachtig!",
+                "pt": "Olha a paisagem, está linda!",
+                "en_pt": "Look at the landscape, it's beautiful!"
             },
             "ipa": {
-                "fr": "il mˈɑ̃ʒt ɑ̃ silˈɑ̃s admiʁˈɑ̃ la- vˈy",
-                "de": "[ziː ˈɛsn̩ ˈʃvaɪ̯ɡn̩t ʊnt bəˈvʊndɐn diː ˈaʊ̯szɪçt]",
-                "it": "[mˈandʒano ˌin silˈɛntsio\n ˌammirˈando lˌa vˈista]",
-                "es": "[ˈkomen en siˈlenθjo aðmiˈɾando la ˈβista]",
-                "nl": "[zə ˈeːtən ɪn stˈɪltə\n ɣənˈitənt vɑn hət ˈœytzˌɪxt]",
-                "pt": "[ˌelys kˈomeɪŋ ˈeɪŋ sˌilˈeɪŋsjʊ\n ˌadmiɾˈɐ̃ŋdw a vˈistæ]",
-                "en": "[ðeɪ ˈiːt ɪn sˈaɪləns ɛndʒˈɔɪɪŋ ðə vjˈuː]"
+                "fr": "ʁəɡˈaʁd lə- pɛizˈaʒ il ɛ maɲifˈik",
+                "de": "[ʃaʊ̯ diːɐ̯ diː ˈlantʃaft an ziː ɪst ˈvʊndɐʃøːn]",
+                "it": "[ɡwˈaːrda ˌil pˌaezˈadʒːo\n ˌɛ maɲˈifiko]",
+                "es": "[ˈmiɾa el pajˈsaxe es pɾeˈθjoso]",
+                "nl": "[kˈɛɪk naːr hət lˈɑndsxˌɑp\n hət ɪs prˈɑxtəx]",
+                "pt": "[ˈɔljæ a pˌaɪzˈaʒeɪŋ\n estˌa lˈiŋdæ]",
+                "en": "[lˈʊk at ðə lˈandskeɪp ɪts maɡnˈɪfɪsənt]"
             },
             "provenance": {
                 "fr": "original",
@@ -844,67 +459,7 @@
             }
         },
         {
-            "id": "scene-06-028",
-            "text": {
-                "pt": "O ônibus viaja pela rodovia Dutra.",
-                "en": "The bus travels along the Dutra highway."
-            },
-            "ipa": {
-                "pt": "[u ˈonibuz vˌiˈaʒæ pˈelæ xˌodovˈiæ dˈutræ]",
-                "en": "[ðə bˈʌs tɹˈavəlz ɐlˈɒŋ ðə dˈʌtɹə hˈaɪweɪ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-029",
-            "text": {
-                "pt": "Finalmente saímos de São Paulo, diz Sophie, quase incrédula.",
-                "en": "We finally left São Paulo, Sophie says, almost in disbelief."
-            },
-            "ipa": {
-                "pt": "[fˌinaʊmˈeɪŋtʃy sˌaˈimʊz dʒy sɐ̃ʊ̃ pˈaʊlʊ\n dʒˈis sˌofˈiy\n kwˈazj ˌiŋkrˈɛdulæ]",
-                "en": "[wiː fˈaɪnəli lˈɛft sˈaʊ pˈɔːləʊ sˈəʊfi sˈɛz ˈɔːlməʊst ɪn dˌɪsbɪlˈiːf]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-030",
-            "text": {
-                "pt": "É estranho, né?",
-                "en": "It's strange, isn't it?"
-            },
-            "ipa": {
-                "pt": "[ɛ ˌestrˈɐ̃ɲʊ\n nˈɛ]",
-                "en": "[ɪts stɹˈeɪndʒ ˈɪzənt ɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-031",
-            "text": {
-                "pt": "Eu também, é normal.",
-                "en": "Me too, it's normal."
-            },
-            "ipa": {
-                "pt": "[eʊ tɐ̃mbˈeɪŋ\n ɛ noɾəmˈaʊ]",
-                "en": "[mˌiː tˈuː ɪts nˈɔːməl]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-06-032",
+            "id": "scene-06-017",
             "text": {
                 "pt": "Sophie abre sua mochila.",
                 "en": "Sophie opens her backpack."
@@ -919,7 +474,38 @@
             }
         },
         {
-            "id": "scene-06-033",
+            "id": "scene-06-018",
+            "text": {
+                "fr": "J'ai apporté des sandwichs. Fromage et jambon.",
+                "en": "I brought sandwiches. Cheese and ham.",
+                "de": "Ich habe Sandwiches mitgebracht. Käse und Schinken.",
+                "it": "Ho portato dei panini. Formaggio e prosciutto.",
+                "es": "He traído bocadillos. De queso y jamón.",
+                "nl": "Ik heb broodjes meegenomen. Kaas en ham.",
+                "pt": "Trouxe sanduíches.",
+                "en_pt": "I brought sandwiches."
+            },
+            "ipa": {
+                "fr": "ʒe apɔʁtˈe de- sɑ̃dwˈitʃ fʁɔmˈaʒ e ʒɑ̃bˈɔ̃",
+                "de": "[ɪç haːbə ˈzandvɪçəs ˈmɪtɡəbʁaxt ˈkɛːzə ʊnt ˈʃɪŋkn̩]",
+                "it": "[ˌo portˈaːto dˌɛj panˈiːnɪ\n formˈadʒːo ˌe proʃˈutːo]",
+                "es": "[e tɾaˈiðo βokaˈðiʎos de ˈkeso i xaˈmon]",
+                "nl": "[ɪk hɛ prˈoːtjəs mˈeːɣənˌoːmən\n kˈaːs ɛn hˈɑm]",
+                "pt": "[trˈowsy sˌɐ̃ŋduˈiʃys]",
+                "en": "[aɪ bɹˈɔːt sˈandwɪtʃɪz tʃˈiːz and hˈam]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-019",
             "text": {
                 "pt": "Queijo e presunto.",
                 "en": "Cheese and ham."
@@ -934,7 +520,99 @@
             }
         },
         {
-            "id": "scene-06-034",
+            "id": "scene-06-020",
+            "text": {
+                "fr": "Excellente idée, j'ai faim.",
+                "en": "Excellent idea, I'm hungry.",
+                "de": "Ausgezeichnete Idee, ich habe Hunger.",
+                "it": "Ottima idea, ho fame.",
+                "es": "Buena idea, tengo hambre.",
+                "nl": "Uitstekend idee, ik heb honger.",
+                "pt": "Ótima ideia, estou com fome.",
+                "en_pt": "Great idea, I'm hungry."
+            },
+            "ipa": {
+                "fr": "ɛksɛlˈɑ̃t idˈe ʒe fˈɛ̃",
+                "de": "[ˈaʊ̯sɡətsaɪ̯çnətə ˈiːdeː ɪç haːbə ˈhʊŋɐ]",
+                "it": "[ˈotːima idˈɛːa\n ˌo fˈaːme]",
+                "es": "[ˈbwena iˈðea ˈteŋgo ˈambɾe]",
+                "nl": "[ˈœytstˌeːkənt idˈeː\n ɪk hɛp hˈɔŋər]",
+                "pt": "[ˈɔtʃimæ ˌidˈɛɪæ\n estˌow koŋ fˈomy]",
+                "en": "[ˈɛksələnt aɪdˈiə aɪm hˈʌŋɡɹi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-021",
+            "text": {
+                "fr": "Ils mangent en silence, admirant la vue.",
+                "en": "They eat in silence, admiring the view.",
+                "de": "Sie essen schweigend und bewundern die Aussicht.",
+                "it": "Mangiano in silenzio, ammirando la vista.",
+                "es": "Comen en silencio, admirando la vista.",
+                "nl": "Ze eten in stilte, genietend van het uitzicht.",
+                "pt": "Eles comem em silêncio, admirando a vista."
+            },
+            "ipa": {
+                "fr": "il mˈɑ̃ʒt ɑ̃ silˈɑ̃s admiʁˈɑ̃ la- vˈy",
+                "de": "[ziː ˈɛsn̩ ˈʃvaɪ̯ɡn̩t ʊnt bəˈvʊndɐn diː ˈaʊ̯szɪçt]",
+                "it": "[mˈandʒano ˌin silˈɛntsio\n ˌammirˈando lˌa vˈista]",
+                "es": "[ˈkomen en siˈlenθjo aðmiˈɾando la ˈβista]",
+                "nl": "[zə ˈeːtən ɪn stˈɪltə\n ɣənˈitənt vɑn hət ˈœytzˌɪxt]",
+                "pt": "[ˌelys kˈomeɪŋ ˈeɪŋ sˌilˈeɪŋsjʊ\n ˌadmiɾˈɐ̃ŋdw a vˈistæ]",
+                "en": "[ðeɪ ˈiːt ɪn sˈaɪləns ɐdmˈaɪəɹɪŋ ðə vjˈuː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-022",
+            "text": {
+                "fr": "Combien de temps dure le voyage?",
+                "en": "How long does the trip last?",
+                "de": "Wie lange dauert die Fahrt?",
+                "it": "Quanto dura il viaggio?",
+                "es": "¿Cuánto dura el viaje?",
+                "nl": "Hoe lang duurt de reis?",
+                "pt": "Lucas pergunta: Quanto tempo dura a viagem?",
+                "en_pt": "Lucas asks: How long does the trip take?"
+            },
+            "ipa": {
+                "fr": "kɔ̃bjˈɛ̃ də- tˈɑ̃ dˈyʁ lə- vwajˈaʒ",
+                "de": "[viː ˈlaŋə ˈdaʊ̯ɐt diː faːɐ̯t]",
+                "it": "[kwˈanto dˈuːra ˌil vjˈadʒːo]",
+                "es": "[ˈkwanto ˈðuɾa el βiˈaxe]",
+                "nl": "[hˈu lˈɑŋ dˈyr tə rˈɛɪs]",
+                "pt": "[lˈukæs pˌeɾəɡˈũŋtæ\n kwˈɐ̃ŋtʊ tˈeɪmpʊ dˈuɾæ a vˌiˈaʒeɪŋ]",
+                "en": "[hˌaʊ lˈɒŋ dˈʌz ðə tɹˈɪp lˈast]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-023",
             "text": {
                 "pt": "Umas cinco horas.",
                 "en": "About five hours."
@@ -949,7 +627,7 @@
             }
         },
         {
-            "id": "scene-06-035",
+            "id": "scene-06-024",
             "text": {
                 "pt": "Chegamos por volta das quatro.",
                 "en": "We'll arrive around four."
@@ -964,7 +642,7 @@
             }
         },
         {
-            "id": "scene-06-036",
+            "id": "scene-06-025",
             "text": {
                 "pt": "Sophie procura em sua mochila.",
                 "en": "Sophie searches in her backpack."
@@ -979,7 +657,7 @@
             }
         },
         {
-            "id": "scene-06-037",
+            "id": "scene-06-026",
             "text": {
                 "pt": "Ah não!",
                 "en": "Oh no!"
@@ -994,7 +672,99 @@
             }
         },
         {
-            "id": "scene-06-038",
+            "id": "scene-06-027",
+            "text": {
+                "fr": "Oh non! J'ai oublié mon livre!",
+                "en": "Oh no! I forgot my book!  ",
+                "de": "Oh nein! Ich habe mein Buch vergessen!",
+                "it": "Oh no! Ho dimenticato il mio libro!",
+                "es": "¡Oh no! ¡He olvidado mi libro!",
+                "nl": "Oh nee! Ik ben mijn boek vergeten!",
+                "pt": "Esqueci meu livro!",
+                "en_pt": "I forgot my book!"
+            },
+            "ipa": {
+                "fr": "ˈɔ nˈɔ̃ ʒe ubliˈe mɔ̃ lˈivʁ",
+                "de": "[oː ˈnaɪ̯n ɪç haːbə maɪ̯n buːx fɛɐ̯ˈɡɛsn̩]",
+                "it": "[ˈɔ nˈɔ\n ˌo dˌimentikˈaːto ˌil mˌio lˈiːbro]",
+                "es": "[o no e olβiˈðaðo mi ˈliβɾo]",
+                "nl": "[ˈɔh nˈeː\n ɪk bɛn mɛɪn bˈuk vərɣˈeːtən]",
+                "pt": "[ˌeskesˈi meʊ lˈivrʊ]",
+                "en": "[ˈəʊ nˈəʊ aɪ fəɡˈɒt maɪ bˈʊk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-028",
+            "text": {
+                "fr": "Ce n'est pas grave, on peut parler.",
+                "en": "It's not a big deal, we can talk.",
+                "de": "Macht nichts, wir können reden.",
+                "it": "Non è grave, possiamo parlare.",
+                "es": "No pasa nada, podemos hablar.",
+                "nl": "Geeft niet, we kunnen praten.",
+                "pt": "Não tem problema, a gente pode conversar.",
+                "en_pt": "No problem, we can talk."
+            },
+            "ipa": {
+                "fr": "sə- nɛ pa ɡʁˈav ɔ̃ pˈø paʁlˈe",
+                "de": "[maxt nɪçts viːɐ̯ ˈkœnən ˈʁeːdn̩]",
+                "it": "[nˌon ˌɛ ɡrˈaːve\n possjˈaːmo parlˈaːre]",
+                "es": "[no ˈpasa ˈnaða poˈðemos aˈβlaɾ]",
+                "nl": "[ɣˈeːft nˈit\n ʋə kˌɵnən prˈaːtən]",
+                "pt": "[nˌɐ̃ʊ̃ teɪŋ prˌoblˈemæ\n a ʒˈeɪŋtʃy pˌɔdʒy kˌoŋveɾəsˈar]",
+                "en": "[ɪts nˌɒtə bˈɪɡ dˈiːl wiː kan tˈɔːk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-029",
+            "text": {
+                "fr": "De quoi veux-tu parler?",
+                "en": "What do you want to talk about?",
+                "de": "Worüber möchtest du sprechen?",
+                "it": "Di cosa vuoi parlare?",
+                "es": "¿Sobre qué quieres hablar?",
+                "nl": "Waar wil je over praten?",
+                "pt": "Sobre o que você quer falar?"
+            },
+            "ipa": {
+                "fr": "də- kwˌa vˈøty paʁlˈe",
+                "de": "[voˈʁyːbɐ ˈmøːçtəst duː ˈʃpʁeːçn̩]",
+                "it": "[dˌɪ kˈɔːza vʊˈɔːɪ parlˈaːre]",
+                "es": "[ˈsoβɾe ke ˈkjeɾes aˈβlaɾ]",
+                "nl": "[ʋˈaːr ʋɪl jə ˈoːvər prˈaːtən]",
+                "pt": "[sˈobri ʊ ky vosˌe kˈɛr falˈar]",
+                "en": "[wˌɒt dˈuː juː wˈɒnt tə tˈɔːk ɐbˈaʊt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-030",
             "text": {
                 "pt": "Lucas pensa.",
                 "en": "Lucas thinks."
@@ -1009,7 +779,68 @@
             }
         },
         {
-            "id": "scene-06-039",
+            "id": "scene-06-031",
+            "text": {
+                "fr": "De nos rêves et de notre avenir",
+                "en": "About our dreams and our future",
+                "de": "Über unsere Träume und unsere Zukunft",
+                "it": "Dei nostri sogni e del nostro futuro",
+                "es": "Sobre nuestros sueños y nuestro futuro",
+                "nl": "Over onze dromen en onze toekomst",
+                "pt": "Sobre nossos sonhos e nosso futuro.",
+                "en_pt": "About our dreams and our future."
+            },
+            "ipa": {
+                "fr": "də- no ʁˈɛvz e də- nɔtʁ avnˈiʁ",
+                "de": "[ˈyːbɐ ˈʊnzəʁə ˈtʁɔɪ̯mə ʊnt ˈʊnzəʁə ˈtsʊkʊnft]",
+                "it": "[dˌɛj nˌɔstrɪ sˈoɲʲɪ ˌe dˌɛl nˌɔstro fʊtˈuːro]",
+                "es": "[ˈsoβɾe ˈnwestɾos ˈsweɲos i ˈnwestɾo fuˈtuɾo]",
+                "nl": "[ˈoːvər ɔnzˌə drˈoːmən ɛn ɔnzˌə tˈukˌɔmst]",
+                "pt": "[sˈobry nˌɔsʊs sˈoɲʊz i nˌɔsʊ fˌutˈuɾʊ]",
+                "en": "[ɐbˌaʊt aʊə dɹˈiːmz and aʊə fjˈuːtʃə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-032",
+            "text": {
+                "fr": "Qu'est-ce que tu veux vraiment dans la vie?",
+                "en": "What do you really want in life?",
+                "de": "Was willst du wirklich im Leben?",
+                "it": "Cosa vuoi veramente nella vita?",
+                "es": "¿Qué es lo que realmente quieres en la vida?",
+                "nl": "Wat wil je echt in het leven?",
+                "pt": "O que você realmente quer na vida?"
+            },
+            "ipa": {
+                "fr": "kɛskˌə ty vˈø vʁɛmˈɑ̃ dɑ̃ la- vˈi",
+                "de": "[vas ˈvɪlst duː ˈvɪʁklɪç ɪm ˈleːbn̩]",
+                "it": "[kˈɔːza vʊˈɔːɪ vˌɛramˈente nˌɛlla vˈiːta]",
+                "es": "[ke es lo ke reˈalmen̩te ˈkjeɾes en la ˈβiða]",
+                "nl": "[ʋɑt ʋɪl jə ˈɛxt ɪn hət lˈeːvən]",
+                "pt": "[ʊ ky vosˌe xˌeaʊmˈeɪŋtʃy kˈɛr na vˈidæ]",
+                "en": "[wˌɒt dˈuː juː ɹˈiəlɪ wˈɒnt ɪn lˈaɪf]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-033",
             "text": {
                 "pt": "Sophie sorri.",
                 "en": "Sophie smiles."
@@ -1020,6 +851,175 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-034",
+            "text": {
+                "fr": "C'est une grande question",
+                "en": "It's a big question",
+                "de": "Das ist eine große Frage",
+                "it": "È una grande domanda",
+                "es": "Es una gran pregunta",
+                "nl": "Dat is een grote vraag",
+                "pt": "É uma grande pergunta.",
+                "en_pt": "That's a big question."
+            },
+            "ipa": {
+                "fr": "sɛt yn ɡʁˈɑ̃d kɛstjˈɔ̃",
+                "de": "[das ɪst ˈaɪ̯nə ˈɡʁoːsə ˈfʁaːɡə]",
+                "it": "[ˌɛ ˌʊna ɡrˈande domˈanda]",
+                "es": "[es ˈuna ɣɾan preˈɣunta]",
+                "nl": "[dɑt ɪs ən ɣrˈoːtə vrˈaːx]",
+                "pt": "[ɛ ˌumæ ɡrˈɐ̃ŋdʒy pˌeɾəɡˈũŋtæ]",
+                "en": "[ɪts ɐ bˈɪɡ kwˈɛstʃən]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-035",
+            "text": {
+                "fr": "Je veux me sentir vivante, je pense.",
+                "en": "I want to feel alive, I think.",
+                "de": "Ich möchte mich lebendig fühlen, denke ich.",
+                "it": "Voglio sentirmi viva, penso.",
+                "es": "Quiero sentirme viva, creo.",
+                "nl": "Ik wil me levend voelen, denk ik.",
+                "pt": "Eu quero me sentir viva, eu acho."
+            },
+            "ipa": {
+                "fr": "ʒə- vˈø mə- sɑ̃tˈiʁ vivˈɑ̃t ʒə- pˈɑ̃s",
+                "de": "[ɪç ˈmœçtə mɪç ˈleːbəndɪç ˈfyːlən ˈdɛŋkə ɪç]",
+                "it": "[vˈoːʎo sentˈiːrmɪ vˈiːva\n pˈɛnso]",
+                "es": "[ˈkjeɾo senˈtiɾme ˈβiβa ˈkɾeo]",
+                "nl": "[ɪk ʋɪl mə lˈeːvənt vˈulən\n dˈɛŋk ɪk]",
+                "pt": "[eʊ kˈɛɾʊ my seɪŋtʃˈir vˈivæ\n eʊ ˈaʃʊ]",
+                "en": "[aɪ wˈɒnt tə fˈiːl ɐlˈaɪv aɪ θˈɪŋk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-036",
+            "text": {
+                "fr": "Nous avons finalement quitté Paris,",
+                "en": "We finally left Paris,",
+                "de": "Wir haben schließlich Berlin verlassen,",
+                "it": "Abbiamo finalmente lasciato Roma,",
+                "es": "Finalmente hemos dejado Madrid,",
+                "nl": "We zijn eindelijk uit Amsterdam vertrokken,"
+            },
+            "ipa": {
+                "fr": "nuz avˈɔ̃ finalmˈɑ̃ kitˈe paʁˈi",
+                "de": "[viːɐ̯ haːbm̩ ʃliːslɪç ˈbɛɐ̯liːn fɛɐ̯ˈlasn̩]",
+                "it": "[abːjˌamo fˌinalmˈente laʃˈaːto rˈɔːma]",
+                "es": "[fiˈnalmen̩te eˈmos deˈxaðo maˈðɾið]",
+                "nl": "[ʋə zɛɪn ˈɛɪndələk œyt ˈɑmstərdˌɑm vərtrˌɔkən]",
+                "en": "[wiː fˈaɪnəli lˈɛft pˈaɹɪs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-037",
+            "text": {
+                "fr": "Environ cinq heures. On arrive vers seize heures.",
+                "en": "About five hours. We arrive around six o'clock.",
+                "de": "Etwa fünf Stunden. Wir kommen gegen sechzehn Uhr an.",
+                "it": "Circa cinque ore. Arriviamo verso le sedici.",
+                "es": "Unas cinco horas. Llegaremos sobre las cuatro.",
+                "nl": "Ongeveer vijf uur. We komen rond vier uur aan."
+            },
+            "ipa": {
+                "fr": "ɑ̃viʁˈɔ̃ sˈɛ̃k ˈœʁ ɔ̃n aʁˈiv vɛʁ sˈɛz ˈœʁ",
+                "de": "[ˈɛtva ˈfʏnf ˈʃtʊndn̩ viːɐ̯ ˈkɔmən ˈɡeːɡn̩ zɛçˈtseːn uːɐ̯ an]",
+                "it": "[tʃˈiːrka tʃˈinkwe ˈoːre\n ˌarɾivjˈaːmo vˌɛrso lˌe sˈeditʃɪ]",
+                "es": "[ˈunas ˈθiŋko ˈoɾas ʎeɣaˈɾemos ˈsoβɾe las ˈkwatɾo]",
+                "nl": "[ˌɔnɣəvˈɪːr vˈɛɪf ˈyr\n ʋə kˈoːmən rˈɔnt vˈir ˈyr ˈaːn]",
+                "en": "[ɐbˌaʊt fˈaɪv ˈaʊəz wiː ɐɹˈaɪv ɐɹˈaʊnd sˈɪks əklˈɒk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-038",
+            "text": {
+                "fr": "Le train file à travers la campagne française.",
+                "en": "The train speeds through the French countryside.",
+                "de": "Der Zug rast durch die deutsche Landschaft.",
+                "it": "Il treno sfreccia attraverso la campagna italiana.",
+                "es": "El metro corre por el campo madrileño.",
+                "nl": "De trein raast door het Nederlandse landschap."
+            },
+            "ipa": {
+                "fr": "lə- tʁˈɛ̃ fˈil a tʁavˈɛʁ la- kɑ̃pˈaɲ fʁɑ̃sˈɛz",
+                "de": "[deːɐ̯ tsuːk ʁast dʊʁç diː ˈdɔɪ̯tʃə ˈlantʃaft]",
+                "it": "[ˌil trˈɛːno sfrˈetʃːa ˌatːravˈɛːrso lˌa kampˈaɲɲa ˌitaliˈaːna]",
+                "es": "[el ˈmetɾo ˈkoɾe por el ˈkampo maðɾiˈleɲo]",
+                "nl": "[də trˈɛɪn rˈaːst doːr hət nˈeːdərlˌɑndsə lˈɑndsxˌɑp]",
+                "en": "[ðə tɹˈeɪn spˈiːdz θɹuː ðə fɹˈɛntʃ kˈʌntɹɪsˌaɪd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-06-039",
+            "text": {
+                "fr": "dit Sophie, presque incrédule.",
+                "en": "says Sophie, presque incrédule.",
+                "de": "sagt Sophie, fast ungläubig.",
+                "it": "dice Sophie, quasi incredula.",
+                "es": "dice Sophie, casi incrédula.",
+                "nl": "zegt Sophie, bijna ongelovig."
+            },
+            "ipa": {
+                "fr": "dˈi sɔfˈi pʁˌɛskə ɛ̃kʁedˈyl",
+                "de": "[zaːkt ˈzɔfiː fast ˈʊnɡlɔɪ̯bɪç]",
+                "it": "[dˈiːtʃe sˈopje\n kwˈaːzɪ inkrˈɛdʊla]",
+                "es": "[ˈdiθe ˈsofi ˈkasi inˈkɾeðula]",
+                "nl": "[zˈɛxt sɔphˈi\n bˈɛɪnˌaː ˌɔnɣəlˈoːvəx]",
+                "en": "[sˈɛz sˈəʊfi pɹɪsk ɪnkɹˈeɪdjuːl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-07.json
+++ b/language_materials/unified/stories/scene-07.json
@@ -24,12 +24,74 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-07-001",
+            "text": {
+                "fr": "Le train arrive en gare de Grenoble.",
+                "en": "The train arrives at Grenoble station.",
+                "de": "Der Zug erreicht den Bahnhof von Berlin.",
+                "it": "Il treno arriva alla stazione di Roma Termini.",
+                "es": "El tren llega a la estación de Atocha.",
+                "nl": "De trein komt aan op het station van Amsterdam.",
+                "pt": "O ônibus chega na rodoviária de Campos do Jordão.",
+                "en_pt": "The bus arrives at the Campos do Jordão bus station."
+            },
+            "ipa": {
+                "fr": "lə- tʁˈɛ̃ aʁˈiv ɑ̃ ɡˈaʁ də- ɡʁənˈɔbl",
+                "de": "[deːɐ̯ t͡suːk ɛɐ̯ˈʁaɪ̯çt deːn ˈbaːnhoːf fɔn bɛɐ̯ˈliːn]",
+                "it": "[ˌil trˈɛːno arɾˈiːva ˌalla stˌatsiˈɔːne dˌɪ rˈɔːma tˈɛrminɪ]",
+                "es": "[el tɾen ˈʎeɣa a la estaˈθjon de aˈtotʃa]",
+                "nl": "[də trˈɛɪn kˈɔmt aːn ɔp hət staːʃˈɔn vɑn ˈɑmstərdˌɑm]",
+                "pt": "[u ˈonibus ʃˈeɡæ na xˌodoviˈaɾjæ dʒy kˈɐ̃mpʊz dʊ ʒoɾədˈɐ̃ʊ̃]",
+                "en": "[ðə tɹˈeɪn ɐɹˈaɪvz at ɡɹˈɛnəʊbəl stˈeɪʃən]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-002",
+            "text": {
+                "fr": "Sophie et Lucas descendent et prennent un bus local vers un petit village alpin.",
+                "en": "Sophie and Lucas get off and take a local bus to a small alpine village.",
+                "de": "Sophie und Lucas steigen aus und nehmen einen lokalen Bus in ein kleines Bergdorf.",
+                "it": "Sophie e Lucas scendono e prendono un autobus locale verso un piccolo villaggio nelle Alpi.",
+                "es": "Sophie y Lucas bajan y cogen un bus local hacia un pequeño barrio.",
+                "nl": "Sophie en Lucas stappen uit en nemen een lokale bus naar een klein dorpje in de Ardennen.",
+                "pt": "Sophie e Lucas descem e pegam um ônibus local para um pequeno vilarejo nas montanhas.",
+                "en_pt": "Sophie and Lucas get off and take a local bus to a small village in the mountains."
+            },
+            "ipa": {
+                "fr": "sɔfˈi e lykˈa dɛsˈɑ̃dt e pʁˈɛnt œ̃ bˈys lɔkˈal vɛʁ œ̃ pətˈi vilˈaʒ alpˈɛ̃",
+                "de": "[ˈzoːfi ʔʊnt ˈluːkas ˈʃtaɪ̯ɡən ˈaʊ̯s ʔʊnt ˈneːmən ˈaɪ̯nən ˈloːkalən bʊs ɪn aɪ̯n ˈklaɪ̯nəs ˈbɛʁkˌdɔʁf]",
+                "it": "[sˈopje ˌe lˈuːkas ʃˈendono ˌe prˈendono ˌʊn ˈaʊtˌobʊs lokˈaːle vˌɛrso ˌʊn pˈikːolo villˈadʒːo nˌɛlle ˈalpɪ]",
+                "es": "[ˈsofi i ˈlukas ˈbaxan i ˈkoχen un bus loˈkal ˈaθja un peˈkeɲo 'βarjo]",
+                "nl": "[sɔphˈi ɛn lˈykɑ stˈɑpən œyt ɛn nˈeːmən ən loːkˈaːlə bˈɵs naːr ən klˈɛɪn dˈɔrpjə ɪn də ˈɑrdɛnən]",
+                "pt": "[sˌofˈij i lˈukæz dˈɛseɪŋ i pˈɛɡɐ̃ʊ̃ ũŋ ˈonibuz lokˈaʊ pˌaɾæ ũŋ pˌekˈenʊ vˌilaɾˈeʒʊ naz mˌoŋtˈɐ̃ɲæs]",
+                "en": "[sˈəʊfi and lˈuːkəz ɡɛt ˈɒf and tˈeɪk ɐ lˈəʊkəl bˈʌs tʊ ɐ smˈɔːl ˈalpaɪn vˈɪlɪdʒ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-003",
             "text": {
                 "fr": "Nous sommes enfin arrivés!",
                 "en": "We have finally arrived!",
@@ -60,7 +122,69 @@
             }
         },
         {
-            "id": "scene-07-002",
+            "id": "scene-07-004",
+            "text": {
+                "fr": "s'exclame Sophie en sortant du bus.",
+                "en": "exclaims Sophie as she gets off the bus.",
+                "de": "Sophie ruft aus, als sie aus dem Bus steigt.",
+                "it": "Sophie esclama uscendo dal bus.",
+                "es": "¡Qué bonito! exclama Sophie al bajar del bus.",
+                "nl": "Sophie roept uit als ze uit de bus stapt.",
+                "pt": "exclama Sophie saindo do ônibus.",
+                "en_pt": "Sophie exclaims as she gets off the bus."
+            },
+            "ipa": {
+                "fr": "sɛksklˈam sɔfˈi ɑ̃ sɔʁtˈɑ̃ dy- bˈys",
+                "de": "[ˈzoːfi ˈʁʊft aʊ̯s als ziː aʊ̯s deːm bʊs ˈʃtaɪ̯kt]",
+                "it": "[sˈopje esklˈaːma ʊʃˈɛndo dˌal bˈus]",
+                "es": "[ke boˈnito | eksˈklama ˈsofi al baˈxaɾ ðel bus]",
+                "nl": "[sɔphˈi rˈupt œyt ɑl sə œy tə bˈɵ stˈɑpt]",
+                "pt": "[ˌesklˈɐ̃mæ sˌofˈiy sˌaˈiŋdʊ dʊ ˈonibus]",
+                "en": "[ɛksklˈeɪmz sˈəʊfi az ʃiː ɡˈɛts ˈɒf ðə bˈʌs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-005",
+            "text": {
+                "fr": "Lucas regarde autour de lui.",
+                "en": "Lucas looks around him.",
+                "de": "Lucas schaut sich um.",
+                "it": "Lucas guarda intorno a sé.",
+                "es": "Lucas mira a su alrededor.",
+                "nl": "Lucas kijkt om zich heen.",
+                "pt": "Lucas olha ao redor.",
+                "en_pt": "Lucas looks around."
+            },
+            "ipa": {
+                "fr": "lykˈa ʁəɡˈaʁd otˌuʁ də- lyˈi",
+                "de": "[ˈluːkas ˈʃaʊ̯t zɪç ʔʊm]",
+                "it": "[lˈuːkas ɡwˈaːrda intˈoːrno ˌa sˈe]",
+                "es": "[ˈlukas ˈmiɾa a su alreðeˈðoɾ]",
+                "nl": "[lˈykɑs kˈɛɪkt ɔm zɪx hˈeːn]",
+                "pt": "[lˈukæz ˈɔljæ aʊ xedˈɔr]",
+                "en": "[lˈuːkəz lˈʊks ɐɹˈaʊnd hˌɪm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-006",
             "text": {
                 "fr": "C'est plus petit que je pensais.",
                 "en": "It's smaller than I thought.",
@@ -90,10 +214,10 @@
             }
         },
         {
-            "id": "scene-07-003",
+            "id": "scene-07-007",
             "text": {
                 "fr": "Mais c'est charmant et tranquille. Regarde ces montagnes!",
-                "en": "But it's charming and quiet. Look at those hills!",
+                "en": "But it's charming and quiet. Look at these mountains!",
                 "de": "Aber es ist charmant und ruhig. Schau dir diese Berge an!",
                 "it": "Ma è affascinante e tranquillo. Guarda quelle montagne!",
                 "es": "Pero es encantador y tranquilo. ¡Mira estos edificios!",
@@ -108,129 +232,7 @@
                 "es": "[ˈpeɾo es enkan̪ˈtaðoɾ i tɾanˈkilo | ˈmiɾa 'estos eðiˈfiθjos]",
                 "nl": "[maːr hət ɪs ʃɑrmˈɑnt ɛn rˈɵstəx\n kˈɛɪk naːr di hˈøːvəls]",
                 "pt": "[maz ɛ ˌeɪŋkɐ̃ŋtadˈoɾ i trˌɐ̃ŋkwˈilʊ]",
-                "en": "[bˌʌt ɪts tʃˈɑːmɪŋ and kwˈaɪət lˈʊk at ðəʊz hˈɪlz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-004",
-            "text": {
-                "fr": "Où allons-nous dormir ce soir?",
-                "en": "Where are we going to sleep tonight?",
-                "de": "Wo werden wir heute Nacht schlafen?",
-                "it": "Dove dormiremo stasera?",
-                "es": "¿Dónde vamos a dormir esta noche?",
-                "nl": "Waar gaan we vanavond slapen?",
-                "pt": "Onde vamos dormir hoje à noite?"
-            },
-            "ipa": {
-                "fr": "u alˈɔ̃nu dɔʁmˈiʁ sə- swˈaʁ",
-                "de": "[voː ˈveːɐ̯dən viːɐ̯ ˈhoɪ̯tə ˈnaxt ˈʃlaːfən]",
-                "it": "[dˈoːve dˌɔrmirˈɛːmo stazˈeːra]",
-                "es": "[ˈdonde ˈβamos a ðoɾˈmiɾ 'esta ˈnotʃe]",
-                "nl": "[ʋˈaːr ɣˈaːn ʋə vɑnˈaːvɔnt slˈaːpən]",
-                "pt": "[ˌoŋdʒy vˌɐ̃mʊz doɾəmˈiɾ ˈoʒj ˌaː nˈoɪtʃy]",
-                "en": "[wˌeəɹ ɑː wiː ɡˌəʊɪŋ tə slˈiːp tənˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-005",
-            "text": {
-                "fr": "Il y a une auberge là-bas.",
-                "en": "There's an inn over there.",
-                "de": "Da ist eine Pension da drüben.",
-                "it": "C'è un albergo lì.",
-                "es": "Hay un hostal allí.",
-                "nl": "Er is een herberg daar.",
-                "pt": "Tem uma pousada ali."
-            },
-            "ipa": {
-                "fr": "il i a yn obˈɛʁʒ lˈabˈa",
-                "de": "[daː ʔɪst ˈaɪ̯nə pɛnˈzi̯oːn daː ˈdrʏbən]",
-                "it": "[tʃˌɛ ˌʊn albˈɛːrɡo lˈi]",
-                "es": "[aj un osˈtal aˈʎi]",
-                "nl": "[ər ɪs ən hɛrbˈɛrx dˈaːr]",
-                "pt": "[teɪŋ ˌumæ pˌowzˈadæ alˈi]",
-                "en": "[ðeəz ɐn ˈɪn ˌəʊvə ðˈeə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-006",
-            "text": {
-                "fr": "Demandons s'ils ont des chambres.",
-                "en": "Let's ask if they have rooms available.",
-                "de": "Lass uns fragen, ob sie Zimmer haben.",
-                "it": "Chiediamo se hanno delle camere.",
-                "es": "Preguntemos si tienen habitaciones.",
-                "nl": "Laten we vragen of ze kamers vrij hebben.",
-                "pt": "Vamos perguntar se tem quartos.",
-                "en_pt": "Let's ask if they have rooms."
-            },
-            "ipa": {
-                "fr": "dəmɑ̃dˈɔ̃ silz ɔ̃ de- ʃˈɑ̃bʁ",
-                "de": "[las ʔʊns ˈfraːɡən ʔɔp ziː ˈtsɪmɐ ˈhaːbən]",
-                "it": "[kjedjˈaːmo sˌe ˌanno dˌɛlle kˈamere]",
-                "es": "[pɾeˈɣuntemos si 'tjeneŋ aβitaˈθjones]",
-                "nl": "[lˈaːtən ʋə vrˈaːɣən ɔf zə kˈaːmərs vrˈɛɪ hˌɛbən]",
-                "pt": "[vˌɐ̃mʊs pˌeɾəɡũŋtˈar sy teɪŋ kwˈaɾətʊs]",
-                "en": "[lˈɛts ˈask ɪf ðeɪ hav ɹˈuːmz ɐvˈeɪləbəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-007",
-            "text": {
-                "fr": "Bonjour, avez-vous deux chambres libres?",
-                "en": "Hello, do you have two rooms available?",
-                "de": "Guten Tag, haben Sie zwei freie Zimmer?",
-                "it": "Buongiorno, avete due camere libere?",
-                "es": "Hola, ¿tenéis dos habitaciones libres?",
-                "nl": "Hallo, hebben jullie twee vrije kamers?",
-                "pt": "Bom dia, vocês têm dois quartos disponíveis?",
-                "en_pt": "Good morning, do you have two rooms available?"
-            },
-            "ipa": {
-                "fr": "bɔ̃ʒˈuʁ avˈevu dˈø ʃˈɑ̃bʁ lˈibʁ",
-                "de": "[ˈɡuːtn̩ taːk ˈhaːbən ziː tsvaɪ̯ ˈfʁaɪ̯ə ˈtsɪmɐ]",
-                "it": "[bˌʊondʒˈɔːrno\n avˌete dˈuːe kˈamere lˈibere]",
-                "es": "[ˈola | teˈneis dos aβitaˈθjones 'liβɾes]",
-                "nl": "[hˈɑloː\n hˌɛbən jɵlˌi tʋˈeː vrˈɛɪə kˈaːmərs]",
-                "pt": "[bˈoŋ dʒˈiæ\n vosˌes teɪŋ dˈoɪs kwˈaɾətʊz dʒˌisponˈiveɪs]",
-                "en": "[həlˈəʊ dˈuː juː hav tˈuː ɹˈuːmz ɐvˈeɪləbəl]"
+                "en": "[bˌʌt ɪts tʃˈɑːmɪŋ and kwˈaɪət lˈʊk at ðiːz mˈaʊntɪnz]"
             },
             "provenance": {
                 "fr": "original",
@@ -245,405 +247,20 @@
         {
             "id": "scene-07-008",
             "text": {
-                "fr": "Oui, mais seulement pour ce soir",
-                "en": "Yes, but only for tonight",
-                "de": "Ja, aber nur für heute Nacht",
-                "it": "Sì, ma solo per stasera",
-                "es": "Sí, pero solo para esta noche",
-                "nl": "Ja, maar alleen voor vanavond",
-                "pt": "Sim, mas só para hoje à noite.",
-                "en_pt": "Yes, but only for tonight."
+                "pt": "Olha essas montanhas!",
+                "en": "Look at those mountains!"
             },
             "ipa": {
-                "fr": "wˈi mɛ sølmˈɑ̃ puʁ sə- swˈaʁ",
-                "de": "[jaː ˈaːbɐ nuːɐ̯ fyːɐ̯ ˈhoɪ̯tə ˈnaxt]",
-                "it": "[sˈi\n mˌa sˈoːlo pˌɛr stazˈeːra]",
-                "es": "[si | 'peɾo 'solo paɾa 'esta 'notʃe]",
-                "nl": "[jˈaː\n maːr ɑlˈeːn vɔːr vɑnˈaːvɔnt]",
-                "pt": "[sˈiŋ\n mas sˈɔ pˌaɾæ ˈoʒj ˌaː nˈoɪtʃy]",
-                "en": "[jˈɛs bˌʌt ˈəʊnli fɔː tənˈaɪt]"
+                "pt": "[ˈɔljæ ˈɛsæz mˌoŋtˈɐ̃ɲæs]",
+                "en": "[lˈʊk at ðəʊz mˈaʊntɪnz]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-07-009",
-            "text": {
-                "fr": "Demain, j'ai une réservation de groupe.",
-                "en": "Tomorrow, I have a group reservation.",
-                "de": "Morgen habe ich eine Gruppenreservierung.",
-                "it": "Domani ho una prenotazione di gruppo.",
-                "es": "Mañana tengo una reserva de grupo.",
-                "nl": "Morgen heb ik een groepsreservering.",
-                "pt": "Amanhã tenho uma reserva de grupo.",
-                "en_pt": "Tomorrow I have a group reservation."
-            },
-            "ipa": {
-                "fr": "dəmˈɛ̃ ʒe yn ʁezɛʁvasjˈɔ̃ də- ɡʁˈup",
-                "de": "[ˈmɔʁɡn̩ ˈhaːbə ʔɪç ˈaɪ̯nə ˈɡʁʊpn̩rezɛʁˈviːʁʊŋ]",
-                "it": "[domˈaːnɪ ˌo ˌʊna prˌenotˌatsiˈɔːne dˌɪ ɡrˈupːo]",
-                "es": "[maˈɲana 'teŋɡo una reˈserβa ðe 'ɡɾupo]",
-                "nl": "[mˈɔrɣən hɛp ɪk ən ɣrˌupsrəzərvˈɪːrɪŋ]",
-                "pt": "[ˌæmɐ̃ɲˈɐ̃ tˌeɲʊ ˌumæ xˌezˈɛɾəvæ dʒy ɡrˈupʊ]",
-                "en": "[təmˈɒɹəʊ aɪ hav ɐ ɡɹˈuːp ɹˌɛzəvˈeɪʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-010",
-            "text": {
-                "fr": "C'est parfait, nous les prenons.",
-                "en": "That's perfect, we'll take them.",
-                "de": "Das ist perfekt, wir nehmen sie.",
-                "it": "È perfetto, le prendiamo.",
-                "es": "Es perfecto, las cogemos.",
-                "nl": "Dat is perfect, we nemen ze.",
-                "pt": "Perfeito, a gente quer.",
-                "en_pt": "Perfect, we'll take them."
-            },
-            "ipa": {
-                "fr": "sɛ paʁfˈɛ nu le- pʁənˈɔ̃",
-                "de": "[das ɪst pɛʁˈfɛkt viːɐ̯ ˈneːmən ziː]",
-                "it": "[ˌɛ perfˈɛtːo\n lˌe prendjˈaːmo]",
-                "es": "[es peɾˈfekto | las koˈxemos]",
-                "nl": "[dɑt ɪs pˈɛrfɛkt\n ʋə nˈeːmən zə]",
-                "pt": "[pˌeɾəfˈeɪtʊ\n a ʒˈeɪŋtʃy kˈɛr]",
-                "en": "[ðats pˈɜːfɛkt wiːl tˈeɪk ðˌɛm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-011",
-            "text": {
-                "fr": "Combien coûte la nuit?",
-                "en": "How much does a night cost?",
-                "de": "Wie viel kostet die Nacht?",
-                "it": "Quanto costa la notte?",
-                "es": "¿Cuánto cuesta la noche?",
-                "nl": "Hoeveel kost een overnachting?",
-                "pt": "Quanto custa a diária?",
-                "en_pt": "How much is the daily rate?"
-            },
-            "ipa": {
-                "fr": "kɔ̃bjˈɛ̃ kˈut la- nyˈi",
-                "de": "[viː fiːl ˈkɔstət diː ˈnaxt]",
-                "it": "[kwˈanto kˈɔsta lˌa nˈɔtːe]",
-                "es": "[ˈkwanto 'kwesta la 'notʃe]",
-                "nl": "[huvˈeːl kˈɔst ən ˌoːvərnˈɑxtɪŋ]",
-                "pt": "[kwˈɐ̃ŋtʊ kˈustæ a dʒˌiˈaɾjæ]",
-                "en": "[hˌaʊ mˈʌtʃ dˈʌz ɐ nˈaɪt kˈɒst]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-012",
-            "text": {
-                "fr": "Soixante euros par chambre, avec le petit-déjeuner.",
-                "en": "Sixty euros per room, including breakfast.",
-                "de": "Sechzig Euro pro Zimmer, mit Frühstück.",
-                "it": "Sessanta euro a camera, con colazione inclusa.",
-                "es": "Sesenta euros por habitación, con desayuno.",
-                "nl": "Zestig euro per kamer, inclusief ontbijt.",
-                "pt": "Cento e vinte reais por quarto, com café da manhã.",
-                "en_pt": "One hundred and twenty reais per room, with breakfast included."
-            },
-            "ipa": {
-                "fr": "swasˈɑ̃t øʁˈo paʁ ʃˈɑ̃bʁ avˌɛk lə- pətˈideʒønˈe",
-                "de": "[ˈzɛçtsɪç ˈɔɪ̯ʁo pʁoː ˈtsɪmɐ mɪt ˈfʁyːˌʃtʏk]",
-                "it": "[sessˈanta ˈɛʊro ˌa kˈamera\n kˌon kˌolatsiˈɔːne inklˈuːza]",
-                "es": "[sesen̪ˈta 'ewɾos poɾ aβitaˈθjon | kon desaˈʝuno]",
-                "nl": "[zˈɛstəx ˈøːroː pˈɛr kˈaːmər\n ˈɪnklyzˌif ɔntbˈɛɪt]",
-                "pt": "[sˈeɪŋtw i vˈiŋtʃy xeˈaɪs por kwˈaɾətʊ\n koŋ kafˈɛ da mɐ̃ɲˈɐ̃]",
-                "en": "[sˈɪksti jˈʊəɹəʊz pɜː ɹˈuːm ɪnklˈuːdɪŋ bɹˈɛkfəst]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-013",
-            "text": {
-                "fr": "D'accord, nous payons maintenant.",
-                "en": "Okay, we'll pay now.",
-                "de": "Okay, wir zahlen jetzt.",
-                "it": "Va bene, paghiamo ora.",
-                "es": "De acuerdo, pagamos ahora.",
-                "nl": "Oké, we betalen nu.",
-                "pt": "Tá bom, vamos pagar agora."
-            },
-            "ipa": {
-                "fr": "dakˈɔʁ nu pɛjˈɔ̃ mɛ̃tnˈɑ̃",
-                "de": "[oˈkaɪ̯ viːɐ̯ ˈtsaːlən ˈjɛtst]",
-                "it": "[vˈa bˈɛːne\n paɡjˈaːmo ˈɔːra]",
-                "es": "[de aˈkweɾðo | paˈɣamos aˈoɾa]",
-                "nl": "[oːkˈeː\n ʋə bətˈaːlən nˈy]",
-                "pt": "[tˈa bˈoŋ\n vˌɐ̃mʊs paɡˈaɾ ˌaɡˈɔɾæ]",
-                "en": "[əʊkˈeɪ wiːl pˈeɪ nˈaʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-014",
-            "text": {
-                "fr": "Le dîner est servi à sept heures dans la salle à manger,",
-                "en": "Dinner is served at seven o'clock in the dining room.",
-                "de": "Das Abendessen wird um sieben Uhr im Speisesaal serviert.",
-                "it": "La cena viene servita alle sette nella sala da pranzo,",
-                "es": "La cena se sirve a las siete en el comedor,",
-                "nl": "Het diner wordt om zeven uur geserveerd in de eetzaal.",
-                "pt": "O jantar é servido às sete horas na sala de jantar, explica a dona da pousada.",
-                "en_pt": "Dinner is served at seven o'clock in the dining room, the inn owner explains."
-            },
-            "ipa": {
-                "fr": "lə- dinˈe ɛ sɛʁvˈi a sˈɛt ˈœʁ dɑ̃ la- sˈal a mɑ̃ʒˈe",
-                "de": "[das ˈaːbm̩ˌʔɛsən vɪʁt ʔʊm ˈziːbm̩ ˈuːɐ̯ ɪm ˈʃpaɪ̯zəˌzaːl zeːɐ̯ˈviːɐ̯t]",
-                "it": "[lˌa tʃˈeːna vjˈɛːne servˈiːta ˌalle sˈɛtːe nˌɛlla sˈaːla dˌa prˈantso]",
-                "es": "[la 'θena se 'siɾβe a las 'sjete en el ko'meðoɾ]",
-                "nl": "[hə tinˈeː ʋɔrt ɔm zˈeːvən ˈyr ɣəsɛrvˈɪrd ɪn də eːtzˈaːl]",
-                "pt": "[ʊ ʒɐ̃ŋtˈaɾ ɛ sˌeɾəvˈidw aːs sˈɛtʃy ˈɔɾæz na sˈalæ dʒy ʒɐ̃ŋtˈar\n ˌesplˈikæ a dˈonæ da pˌowzˈadæ]",
-                "en": "[dˈɪnəɹ ɪz sˈɜːvd at sˈɛvən əklˈɒk ɪnðə dˈaɪnɪŋ ɹˈuːm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-015",
-            "text": {
-                "fr": "Merci beaucoup pour votre aide.",
-                "en": "Thank you very much for your help.",
-                "de": "Vielen Dank für Ihre Hilfe.",
-                "it": "Grazie mille per il tuo aiuto.",
-                "es": "Muchas gracias por tu ayuda.",
-                "nl": "Hartelijk dank voor je hulp.",
-                "pt": "Muito obrigada pela ajuda.",
-                "en_pt": "Thank you so much for your help."
-            },
-            "ipa": {
-                "fr": "mɛʁsˈi bokˌu puʁ vɔtʁ ˈɛd",
-                "de": "[ˈfiːlən daŋk fyːɐ̯ ˈiːʁə ˈhɪlfə]",
-                "it": "[ɡrˈatsje mˈille pˌɛr ˌil tˌʊo ajˈuːto]",
-                "es": "[ˈmutʃas ˈɣɾaθjas poɾ tu aˈʝuða]",
-                "nl": "[hˈɑrtələk dˈɑŋk vɔːr jə hˈɵlp]",
-                "pt": "[mwˈiŋtw ˌobriɡˈadæ pˈelæ ˌaʒˈudæ]",
-                "en": "[θˈaŋk juː vˈɛɹɪ mˈʌtʃ fɔː jɔː hˈɛlp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-016",
-            "text": {
-                "fr": "Allons explorer le village!",
-                "en": "Let's go explore the village!",
-                "de": "Lass uns das Dorf erkunden!",
-                "it": "Andiamo a esplorare il villaggio!",
-                "es": "¡Vamos a explorar el barrio!",
-                "nl": "Laten we het dorp gaan verkennen!",
-                "pt": "Vamos explorar o vilarejo!",
-                "en_pt": "Let's explore the village!"
-            },
-            "ipa": {
-                "fr": "alˈɔ̃z ɛksplɔʁˈe lə- vilˈaʒ",
-                "de": "[las ʔʊns das dɔʁf ʔɛɐ̯ˈkʊndən]",
-                "it": "[andjˈaːmo ˌa ˌesplorˈaːre ˌil villˈadʒːo]",
-                "es": "[ˈbamos a eksploˈɾaɾ el 'βarjo]",
-                "nl": "[lˈaːtən ʋə hə tˈɔrp ɣˈaːn vərkˈɛnən]",
-                "pt": "[vˌɐ̃mʊz ˌesploɾˈaɾ ʊ vˌilaɾˈeʒʊ]",
-                "en": "[lˈɛts ɡˌəʊ ɛksplˈɔː ðə vˈɪlɪdʒ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-017",
-            "text": {
-                "fr": "Le train arrive en gare de Grenoble.",
-                "en": "The train arrives at Amsterdam station.",
-                "de": "Der Zug erreicht den Bahnhof von Berlin.",
-                "it": "Il treno arriva alla stazione di Roma Termini.",
-                "es": "El tren llega a la estación de Atocha.",
-                "nl": "De trein komt aan op het station van Amsterdam.",
-                "pt": "O ônibus chega na rodoviária de Campos do Jordão.",
-                "en_pt": "The bus arrives at the Campos do Jordão bus station."
-            },
-            "ipa": {
-                "fr": "lə- tʁˈɛ̃ aʁˈiv ɑ̃ ɡˈaʁ də- ɡʁənˈɔbl",
-                "de": "[deːɐ̯ t͡suːk ɛɐ̯ˈʁaɪ̯çt deːn ˈbaːnhoːf fɔn bɛɐ̯ˈliːn]",
-                "it": "[ˌil trˈɛːno arɾˈiːva ˌalla stˌatsiˈɔːne dˌɪ rˈɔːma tˈɛrminɪ]",
-                "es": "[el tɾen ˈʎeɣa a la estaˈθjon de aˈtotʃa]",
-                "nl": "[də trˈɛɪn kˈɔmt aːn ɔp hət staːʃˈɔn vɑn ˈɑmstərdˌɑm]",
-                "pt": "[u ˈonibus ʃˈeɡæ na xˌodoviˈaɾjæ dʒy kˈɐ̃mpʊz dʊ ʒoɾədˈɐ̃ʊ̃]",
-                "en": "[ðə tɹˈeɪn ɐɹˈaɪvz at ˈamstədˌam stˈeɪʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-018",
-            "text": {
-                "fr": "Sophie et Lucas descendent et prennent un bus local vers un petit village alpin.",
-                "en": "Sophie and Lucas get off and take a local bus to a small village in the Ardennes.",
-                "de": "Sophie und Lucas steigen aus und nehmen einen lokalen Bus in ein kleines Bergdorf.",
-                "it": "Sophie e Lucas scendono e prendono un autobus locale verso un piccolo villaggio nelle Alpi.",
-                "es": "Sophie y Lucas bajan y cogen un bus local hacia un pequeño barrio.",
-                "nl": "Sophie en Lucas stappen uit en nemen een lokale bus naar een klein dorpje in de Ardennen.",
-                "pt": "Sophie e Lucas descem e pegam um ônibus local para um pequeno vilarejo nas montanhas.",
-                "en_pt": "Sophie and Lucas get off and take a local bus to a small village in the mountains."
-            },
-            "ipa": {
-                "fr": "sɔfˈi e lykˈa dɛsˈɑ̃dt e pʁˈɛnt œ̃ bˈys lɔkˈal vɛʁ œ̃ pətˈi vilˈaʒ alpˈɛ̃",
-                "de": "[ˈzoːfi ʔʊnt ˈluːkas ˈʃtaɪ̯ɡən ˈaʊ̯s ʔʊnt ˈneːmən ˈaɪ̯nən ˈloːkalən bʊs ɪn aɪ̯n ˈklaɪ̯nəs ˈbɛʁkˌdɔʁf]",
-                "it": "[sˈopje ˌe lˈuːkas ʃˈendono ˌe prˈendono ˌʊn ˈaʊtˌobʊs lokˈaːle vˌɛrso ˌʊn pˈikːolo villˈadʒːo nˌɛlle ˈalpɪ]",
-                "es": "[ˈsofi i ˈlukas ˈbaxan i ˈkoχen un bus loˈkal ˈaθja un peˈkeɲo 'βarjo]",
-                "nl": "[sɔphˈi ɛn lˈykɑ stˈɑpən œyt ɛn nˈeːmən ən loːkˈaːlə bˈɵs naːr ən klˈɛɪn dˈɔrpjə ɪn də ˈɑrdɛnən]",
-                "pt": "[sˌofˈij i lˈukæz dˈɛseɪŋ i pˈɛɡɐ̃ʊ̃ ũŋ ˈonibuz lokˈaʊ pˌaɾæ ũŋ pˌekˈenʊ vˌilaɾˈeʒʊ naz mˌoŋtˈɐ̃ɲæs]",
-                "en": "[sˈəʊfi and lˈuːkəz ɡɛt ˈɒf and tˈeɪk ɐ lˈəʊkəl bˈʌs tʊ ɐ smˈɔːl vˈɪlɪdʒ ɪnðɪ ˈɑːdənz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-019",
-            "text": {
-                "fr": "s'exclame Sophie en sortant du bus.",
-                "en": "Sophie exclaims as she gets off the bus.",
-                "de": "Sophie ruft aus, als sie aus dem Bus steigt.",
-                "it": "Sophie esclama uscendo dal bus.",
-                "es": "¡Qué bonito! exclama Sophie al bajar del bus.",
-                "nl": "Sophie roept uit als ze uit de bus stapt.",
-                "pt": "exclama Sophie saindo do ônibus."
-            },
-            "ipa": {
-                "fr": "sɛksklˈam sɔfˈi ɑ̃ sɔʁtˈɑ̃ dy- bˈys",
-                "de": "[ˈzoːfi ˈʁʊft aʊ̯s als ziː aʊ̯s deːm bʊs ˈʃtaɪ̯kt]",
-                "it": "[sˈopje esklˈaːma ʊʃˈɛndo dˌal bˈus]",
-                "es": "[ke boˈnito | eksˈklama ˈsofi al baˈxaɾ ðel bus]",
-                "nl": "[sɔphˈi rˈupt œyt ɑl sə œy tə bˈɵ stˈɑpt]",
-                "pt": "[ˌesklˈɐ̃mæ sˌofˈiy sˌaˈiŋdʊ dʊ ˈonibus]",
-                "en": "[sˈəʊfi ɛksklˈeɪmz az ʃiː ɡˈɛts ˈɒf ðə bˈʌs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-020",
-            "text": {
-                "fr": "Lucas regarde autour de lui.",
-                "en": "Lucas looks around.",
-                "de": "Lucas schaut sich um.",
-                "it": "Lucas guarda intorno a sé.",
-                "es": "Lucas mira a su alrededor.",
-                "nl": "Lucas kijkt om zich heen.",
-                "pt": "Lucas olha ao redor."
-            },
-            "ipa": {
-                "fr": "lykˈa ʁəɡˈaʁd otˌuʁ də- lyˈi",
-                "de": "[ˈluːkas ˈʃaʊ̯t zɪç ʔʊm]",
-                "it": "[lˈuːkas ɡwˈaːrda intˈoːrno ˌa sˈe]",
-                "es": "[ˈlukas ˈmiɾa a su alreðeˈðoɾ]",
-                "nl": "[lˈykɑs kˈɛɪkt ɔm zɪx hˈeːn]",
-                "pt": "[lˈukæz ˈɔljæ aʊ xedˈɔr]",
-                "en": "[lˈuːkəz lˈʊks ɐɹˈaʊnd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-07-021",
             "text": {
                 "fr": "Le village est pittoresque avec ses maisons en pierre et ses volets en bois.",
                 "en": "The village is picturesque with its stone houses and wooden shutters.",
@@ -674,10 +291,40 @@
             }
         },
         {
-            "id": "scene-07-022",
+            "id": "scene-07-010",
+            "text": {
+                "fr": "Où allons-nous dormir ce soir?",
+                "en": "Where are we going to sleep tonight?",
+                "de": "Wo werden wir heute Nacht schlafen?",
+                "it": "Dove dormiremo stasera?",
+                "es": "¿Dónde vamos a dormir esta noche?",
+                "nl": "Waar gaan we vanavond slapen?",
+                "pt": "Onde vamos dormir hoje à noite?"
+            },
+            "ipa": {
+                "fr": "u alˈɔ̃nu dɔʁmˈiʁ sə- swˈaʁ",
+                "de": "[voː ˈveːɐ̯dən viːɐ̯ ˈhoɪ̯tə ˈnaxt ˈʃlaːfən]",
+                "it": "[dˈoːve dˌɔrmirˈɛːmo stazˈeːra]",
+                "es": "[ˈdonde ˈβamos a ðoɾˈmiɾ 'esta ˈnotʃe]",
+                "nl": "[ʋˈaːr ɣˈaːn ʋə vɑnˈaːvɔnt slˈaːpən]",
+                "pt": "[ˌoŋdʒy vˌɐ̃mʊz doɾəmˈiɾ ˈoʒj ˌaː nˈoɪtʃy]",
+                "en": "[wˌeəɹ ɑː wiː ɡˌəʊɪŋ tə slˈiːp tənˈaɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-011",
             "text": {
                 "fr": "Sophie pointe du doigt.",
-                "en": "Sophie points somewhere.",
+                "en": "Sophie points with her finger.",
                 "de": "Sophie zeigt darauf.",
                 "it": "Sophie indica con il dito.",
                 "es": "Sophie señala con el dedo.",
@@ -692,7 +339,7 @@
                 "es": "[ˈsofi seˈɲala kon el ˈðeðo]",
                 "nl": "[sɔphˈi ʋˈɛɪst ˈɛrɣəns nˈaːr]",
                 "pt": "[sˌofˈij ˌapˈoŋtæ]",
-                "en": "[sˈəʊfi pˈɔɪnts sˈʌmweə]"
+                "en": "[sˈəʊfi pˈɔɪnts wɪð hɜː fˈɪŋɡə]"
             },
             "provenance": {
                 "fr": "original",
@@ -705,7 +352,98 @@
             }
         },
         {
-            "id": "scene-07-023",
+            "id": "scene-07-012",
+            "text": {
+                "fr": "Il y a une auberge là-bas.",
+                "en": "There is an inn over there.",
+                "de": "Da ist eine Pension da drüben.",
+                "it": "C'è un albergo lì.",
+                "es": "Hay un hostal allí.",
+                "nl": "Er is een herberg daar.",
+                "pt": "Tem uma pousada ali.",
+                "en_pt": "There's an inn over there."
+            },
+            "ipa": {
+                "fr": "il i a yn obˈɛʁʒ lˈabˈa",
+                "de": "[daː ʔɪst ˈaɪ̯nə pɛnˈzi̯oːn daː ˈdrʏbən]",
+                "it": "[tʃˌɛ ˌʊn albˈɛːrɡo lˈi]",
+                "es": "[aj un osˈtal aˈʎi]",
+                "nl": "[ər ɪs ən hɛrbˈɛrx dˈaːr]",
+                "pt": "[teɪŋ ˌumæ pˌowzˈadæ alˈi]",
+                "en": "[ðeəɹ ɪz ɐn ˈɪn ˌəʊvə ðˈeə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-013",
+            "text": {
+                "pt": "\"Pousada da Serra.\"",
+                "en": "\"Pousada da Serra.\""
+            },
+            "ipa": {
+                "pt": "[pˌowzˈadæ da sˈɛxæ]",
+                "en": "[paʊsˈɑːdə dˈɑː sˈɛɹə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-014",
+            "text": {
+                "fr": "Demandons s'ils ont des chambres.",
+                "en": "Let's ask if they have rooms.",
+                "de": "Lass uns fragen, ob sie Zimmer haben.",
+                "it": "Chiediamo se hanno delle camere.",
+                "es": "Preguntemos si tienen habitaciones.",
+                "nl": "Laten we vragen of ze kamers vrij hebben.",
+                "pt": "Vamos perguntar se tem quartos."
+            },
+            "ipa": {
+                "fr": "dəmɑ̃dˈɔ̃ silz ɔ̃ de- ʃˈɑ̃bʁ",
+                "de": "[las ʔʊns ˈfraːɡən ʔɔp ziː ˈtsɪmɐ ˈhaːbən]",
+                "it": "[kjedjˈaːmo sˌe ˌanno dˌɛlle kˈamere]",
+                "es": "[pɾeˈɣuntemos si 'tjeneŋ aβitaˈθjones]",
+                "nl": "[lˈaːtən ʋə vrˈaːɣən ɔf zə kˈaːmərs vrˈɛɪ hˌɛbən]",
+                "pt": "[vˌɐ̃mʊs pˌeɾəɡũŋtˈar sy teɪŋ kwˈaɾətʊs]",
+                "en": "[lˈɛts ˈask ɪf ðeɪ hav ɹˈuːmz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-015",
+            "text": {
+                "pt": "Eles entram na pousada.",
+                "en": "They enter the inn."
+            },
+            "ipa": {
+                "pt": "[ˌelyz ˈeɪŋtrɐ̃ʊ̃ na pˌowzˈadæ]",
+                "en": "[ðeɪ ˈɛntə ðɪ ˈɪn]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-016",
             "text": {
                 "fr": "Une femme d'âge moyen les accueille avec un sourire chaleureux.",
                 "en": "A middle-aged woman welcomes them with a warm smile.",
@@ -736,7 +474,193 @@
             }
         },
         {
-            "id": "scene-07-024",
+            "id": "scene-07-017",
+            "text": {
+                "fr": "Bonjour, avez-vous deux chambres libres?",
+                "en": "Hello, do you have two free rooms?",
+                "de": "Guten Tag, haben Sie zwei freie Zimmer?",
+                "it": "Buongiorno, avete due camere libere?",
+                "es": "Hola, ¿tenéis dos habitaciones libres?",
+                "nl": "Hallo, hebben jullie twee vrije kamers?",
+                "pt": "Bom dia, vocês têm dois quartos disponíveis?",
+                "en_pt": "Good morning, do you have two rooms available?"
+            },
+            "ipa": {
+                "fr": "bɔ̃ʒˈuʁ avˈevu dˈø ʃˈɑ̃bʁ lˈibʁ",
+                "de": "[ˈɡuːtn̩ taːk ˈhaːbən ziː tsvaɪ̯ ˈfʁaɪ̯ə ˈtsɪmɐ]",
+                "it": "[bˌʊondʒˈɔːrno\n avˌete dˈuːe kˈamere lˈibere]",
+                "es": "[ˈola | teˈneis dos aβitaˈθjones 'liβɾes]",
+                "nl": "[hˈɑloː\n hˌɛbən jɵlˌi tʋˈeː vrˈɛɪə kˈaːmərs]",
+                "pt": "[bˈoŋ dʒˈiæ\n vosˌes teɪŋ dˈoɪs kwˈaɾətʊz dʒˌisponˈiveɪs]",
+                "en": "[həlˈəʊ dˈuː juː hav tˈuː fɹˈiː ɹˈuːmz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-018",
+            "text": {
+                "fr": "Oui, mais seulement pour ce soir",
+                "en": "Yes, but only for tonight",
+                "de": "Ja, aber nur für heute Nacht",
+                "it": "Sì, ma solo per stasera",
+                "es": "Sí, pero solo para esta noche",
+                "nl": "Ja, maar alleen voor vanavond",
+                "pt": "Sim, mas só para hoje à noite.",
+                "en_pt": "Yes, but only for tonight."
+            },
+            "ipa": {
+                "fr": "wˈi mɛ sølmˈɑ̃ puʁ sə- swˈaʁ",
+                "de": "[jaː ˈaːbɐ nuːɐ̯ fyːɐ̯ ˈhoɪ̯tə ˈnaxt]",
+                "it": "[sˈi\n mˌa sˈoːlo pˌɛr stazˈeːra]",
+                "es": "[si | 'peɾo 'solo paɾa 'esta 'notʃe]",
+                "nl": "[jˈaː\n maːr ɑlˈeːn vɔːr vɑnˈaːvɔnt]",
+                "pt": "[sˈiŋ\n mas sˈɔ pˌaɾæ ˈoʒj ˌaː nˈoɪtʃy]",
+                "en": "[jˈɛs bˌʌt ˈəʊnli fɔː tənˈaɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-019",
+            "text": {
+                "fr": "Demain, j'ai une réservation de groupe.",
+                "en": "Tomorrow, I have a group reservation.",
+                "de": "Morgen habe ich eine Gruppenreservierung.",
+                "it": "Domani ho una prenotazione di gruppo.",
+                "es": "Mañana tengo una reserva de grupo.",
+                "nl": "Morgen heb ik een groepsreservering.",
+                "pt": "Amanhã tenho uma reserva de grupo.",
+                "en_pt": "Tomorrow I have a group reservation."
+            },
+            "ipa": {
+                "fr": "dəmˈɛ̃ ʒe yn ʁezɛʁvasjˈɔ̃ də- ɡʁˈup",
+                "de": "[ˈmɔʁɡn̩ ˈhaːbə ʔɪç ˈaɪ̯nə ˈɡʁʊpn̩rezɛʁˈviːʁʊŋ]",
+                "it": "[domˈaːnɪ ˌo ˌʊna prˌenotˌatsiˈɔːne dˌɪ ɡrˈupːo]",
+                "es": "[maˈɲana 'teŋɡo una reˈserβa ðe 'ɡɾupo]",
+                "nl": "[mˈɔrɣən hɛp ɪk ən ɣrˌupsrəzərvˈɪːrɪŋ]",
+                "pt": "[ˌæmɐ̃ɲˈɐ̃ tˌeɲʊ ˌumæ xˌezˈɛɾəvæ dʒy ɡrˈupʊ]",
+                "en": "[təmˈɒɹəʊ aɪ hav ɐ ɡɹˈuːp ɹˌɛzəvˈeɪʃən]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-020",
+            "text": {
+                "fr": "C'est parfait, nous les prenons.",
+                "en": "That's perfect, we'll take them.",
+                "de": "Das ist perfekt, wir nehmen sie.",
+                "it": "È perfetto, le prendiamo.",
+                "es": "Es perfecto, las cogemos.",
+                "nl": "Dat is perfect, we nemen ze.",
+                "pt": "Perfeito, a gente quer.",
+                "en_pt": "Perfect, we'll take them."
+            },
+            "ipa": {
+                "fr": "sɛ paʁfˈɛ nu le- pʁənˈɔ̃",
+                "de": "[das ɪst pɛʁˈfɛkt viːɐ̯ ˈneːmən ziː]",
+                "it": "[ˌɛ perfˈɛtːo\n lˌe prendjˈaːmo]",
+                "es": "[es peɾˈfekto | las koˈxemos]",
+                "nl": "[dɑt ɪs pˈɛrfɛkt\n ʋə nˈeːmən zə]",
+                "pt": "[pˌeɾəfˈeɪtʊ\n a ʒˈeɪŋtʃy kˈɛr]",
+                "en": "[ðats pˈɜːfɛkt wiːl tˈeɪk ðˌɛm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-021",
+            "text": {
+                "fr": "Combien coûte la nuit?",
+                "en": "How much does the night cost?",
+                "de": "Wie viel kostet die Nacht?",
+                "it": "Quanto costa la notte?",
+                "es": "¿Cuánto cuesta la noche?",
+                "nl": "Hoeveel kost een overnachting?",
+                "pt": "Quanto custa a diária?",
+                "en_pt": "How much is the daily rate?"
+            },
+            "ipa": {
+                "fr": "kɔ̃bjˈɛ̃ kˈut la- nyˈi",
+                "de": "[viː fiːl ˈkɔstət diː ˈnaxt]",
+                "it": "[kwˈanto kˈɔsta lˌa nˈɔtːe]",
+                "es": "[ˈkwanto 'kwesta la 'notʃe]",
+                "nl": "[huvˈeːl kˈɔst ən ˌoːvərnˈɑxtɪŋ]",
+                "pt": "[kwˈɐ̃ŋtʊ kˈustæ a dʒˌiˈaɾjæ]",
+                "en": "[hˌaʊ mˈʌtʃ dˈʌz ðə nˈaɪt kˈɒst]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-022",
+            "text": {
+                "fr": "Soixante euros par chambre, avec le petit-déjeuner.",
+                "en": "Sixty euros per room, with breakfast.",
+                "de": "Sechzig Euro pro Zimmer, mit Frühstück.",
+                "it": "Sessanta euro a camera, con colazione inclusa.",
+                "es": "Sesenta euros por habitación, con desayuno.",
+                "nl": "Zestig euro per kamer, inclusief ontbijt.",
+                "pt": "Cento e vinte reais por quarto, com café da manhã.",
+                "en_pt": "One hundred and twenty reais per room, with breakfast included."
+            },
+            "ipa": {
+                "fr": "swasˈɑ̃t øʁˈo paʁ ʃˈɑ̃bʁ avˌɛk lə- pətˈideʒønˈe",
+                "de": "[ˈzɛçtsɪç ˈɔɪ̯ʁo pʁoː ˈtsɪmɐ mɪt ˈfʁyːˌʃtʏk]",
+                "it": "[sessˈanta ˈɛʊro ˌa kˈamera\n kˌon kˌolatsiˈɔːne inklˈuːza]",
+                "es": "[sesen̪ˈta 'ewɾos poɾ aβitaˈθjon | kon desaˈʝuno]",
+                "nl": "[zˈɛstəx ˈøːroː pˈɛr kˈaːmər\n ˈɪnklyzˌif ɔntbˈɛɪt]",
+                "pt": "[sˈeɪŋtw i vˈiŋtʃy xeˈaɪs por kwˈaɾətʊ\n koŋ kafˈɛ da mɐ̃ɲˈɐ̃]",
+                "en": "[sˈɪksti jˈʊəɹəʊz pɜː ɹˈuːm wɪð bɹˈɛkfəst]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-023",
             "text": {
                 "fr": "Lucas sort son portefeuille.",
                 "en": "Lucas takes out his wallet.",
@@ -766,25 +690,55 @@
             }
         },
         {
-            "id": "scene-07-025",
+            "id": "scene-07-024",
             "text": {
-                "fr": "Sophie et Lucas montent leurs sacs dans les chambres, puis redescendent.",
-                "en": "Sophie and Lucas take their bags to the rooms and then come back down.",
-                "de": "Sophie und Lucas bringen ihre Taschen in die Zimmer und kommen dann wieder runter.",
-                "it": "Sophie e Lucas portano i loro bagagli nelle camere, poi scendono.",
-                "es": "Sophie y Lucas suben sus maletas a las habitaciones y luego bajan.",
-                "nl": "Sophie en Lucas brengen hun tassen naar de kamers en komen dan weer naar beneden.",
-                "pt": "Sophie e Lucas sobem com as mochilas para os quartos, depois descem.",
-                "en_pt": "Sophie and Lucas go up with their backpacks to the rooms, then come back down."
+                "fr": "D'accord, nous payons maintenant.",
+                "en": "Okay, we'll pay now.",
+                "de": "Okay, wir zahlen jetzt.",
+                "it": "Va bene, paghiamo ora.",
+                "es": "De acuerdo, pagamos ahora.",
+                "nl": "Oké, we betalen nu.",
+                "pt": "Tá bom, vamos pagar agora."
             },
             "ipa": {
-                "fr": "sɔfˈi e lykˈa mˈɔ̃t lœʁ sˈak dɑ̃ le- ʃˈɑ̃bʁ pyˈi ʁədɛsˈɑ̃d",
-                "de": "[ˈzoːfi ʔʊnt ˈluːkas ˈbʁɪŋən ˈiːʁə ˈtaʃən ɪn diː ˈtsɪmɐ ʔʊnt ˈkɔmən dan ˈviːdɐ ˈʁʊntɐ]",
-                "it": "[sˈopje ˌe lˈuːkas pˈɔrtano ˌɪ lˌɔro baɡˈaːʎɪ nˌɛlle kˈamere\n pˈɔːɪ ʃˈendono]",
-                "es": "[ˈsofi i ˈlukas ˈsuβen sus maˈletas a las aβitaˈθjones i ˈlweɣo ˈbaxan]",
-                "nl": "[sɔphˈi ɛn lˈykɑs brˈɛŋən hɵn tˈɑsən naːr də kˈaːmərs ɛn kˈoːmən dˈɑn ʋˈɪːr naːr bənˈeːdən]",
-                "pt": "[sˌofˈij i lˈukæs sˈɔbeɪŋ koŋ az mˌoʃˈilæs pˌaɾæ ʊs kwˈaɾətʊs\n depˈoɪz dˈɛseɪŋ]",
-                "en": "[sˈəʊfi and lˈuːkəz tˈeɪk ðeə bˈaɡz tə ðə ɹˈuːmz and ðˈɛn kˈʌm bˈak dˈaʊn]"
+                "fr": "dakˈɔʁ nu pɛjˈɔ̃ mɛ̃tnˈɑ̃",
+                "de": "[oˈkaɪ̯ viːɐ̯ ˈtsaːlən ˈjɛtst]",
+                "it": "[vˈa bˈɛːne\n paɡjˈaːmo ˈɔːra]",
+                "es": "[de aˈkweɾðo | paˈɣamos aˈoɾa]",
+                "nl": "[oːkˈeː\n ʋə bətˈaːlən nˈy]",
+                "pt": "[tˈa bˈoŋ\n vˌɐ̃mʊs paɡˈaɾ ˌaɡˈɔɾæ]",
+                "en": "[əʊkˈeɪ wiːl pˈeɪ nˈaʊ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-07-025",
+            "text": {
+                "fr": "Le dîner est servi à sept heures dans la salle à manger,",
+                "en": "Dinner is served at seven o'clock in the dining room,",
+                "de": "Das Abendessen wird um sieben Uhr im Speisesaal serviert.",
+                "it": "La cena viene servita alle sette nella sala da pranzo,",
+                "es": "La cena se sirve a las siete en el comedor,",
+                "nl": "Het diner wordt om zeven uur geserveerd in de eetzaal.",
+                "pt": "O jantar é servido às sete horas na sala de jantar, explica a dona da pousada.",
+                "en_pt": "Dinner is served at seven o'clock in the dining room, the inn owner explains."
+            },
+            "ipa": {
+                "fr": "lə- dinˈe ɛ sɛʁvˈi a sˈɛt ˈœʁ dɑ̃ la- sˈal a mɑ̃ʒˈe",
+                "de": "[das ˈaːbm̩ˌʔɛsən vɪʁt ʔʊm ˈziːbm̩ ˈuːɐ̯ ɪm ˈʃpaɪ̯zəˌzaːl zeːɐ̯ˈviːɐ̯t]",
+                "it": "[lˌa tʃˈeːna vjˈɛːne servˈiːta ˌalle sˈɛtːe nˌɛlla sˈaːla dˌa prˈantso]",
+                "es": "[la 'θena se 'siɾβe a las 'sjete en el ko'meðoɾ]",
+                "nl": "[hə tinˈeː ʋɔrt ɔm zˈeːvən ˈyr ɣəsɛrvˈɪrd ɪn də eːtzˈaːl]",
+                "pt": "[ʊ ʒɐ̃ŋtˈaɾ ɛ sˌeɾəvˈidw aːs sˈɛtʃy ˈɔɾæz na sˈalæ dʒy ʒɐ̃ŋtˈar\n ˌesplˈikæ a dˈonæ da pˌowzˈadæ]",
+                "en": "[dˈɪnəɹ ɪz sˈɜːvd at sˈɛvən əklˈɒk ɪnðə dˈaɪnɪŋ ɹˈuːm]"
             },
             "provenance": {
                 "fr": "original",
@@ -799,14 +753,30 @@
         {
             "id": "scene-07-026",
             "text": {
-                "pt": "Olha essas montanhas!",
-                "en": "Look at those mountains!"
+                "fr": "Merci beaucoup pour votre aide.",
+                "en": "Thank you very much for your help.",
+                "de": "Vielen Dank für Ihre Hilfe.",
+                "it": "Grazie mille per il tuo aiuto.",
+                "es": "Muchas gracias por tu ayuda.",
+                "nl": "Hartelijk dank voor je hulp.",
+                "pt": "Muito obrigada pela ajuda.",
+                "en_pt": "Thank you so much for your help."
             },
             "ipa": {
-                "pt": "[ˈɔljæ ˈɛsæz mˌoŋtˈɐ̃ɲæs]",
-                "en": "[lˈʊk at ðəʊz mˈaʊntɪnz]"
+                "fr": "mɛʁsˈi bokˌu puʁ vɔtʁ ˈɛd",
+                "de": "[ˈfiːlən daŋk fyːɐ̯ ˈiːʁə ˈhɪlfə]",
+                "it": "[ɡrˈatsje mˈille pˌɛr ˌil tˌʊo ajˈuːto]",
+                "es": "[ˈmutʃas ˈɣɾaθjas poɾ tu aˈʝuða]",
+                "nl": "[hˈɑrtələk dˈɑŋk vɔːr jə hˈɵlp]",
+                "pt": "[mwˈiŋtw ˌobriɡˈadæ pˈelæ ˌaʒˈudæ]",
+                "en": "[θˈaŋk juː vˈɛɹɪ mˈʌtʃ fɔː jɔː hˈɛlp]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -814,14 +784,30 @@
         {
             "id": "scene-07-027",
             "text": {
-                "pt": "\"Pousada da Serra.\"",
-                "en": "\"Pousada da Serra.\""
+                "fr": "Sophie et Lucas montent leurs sacs dans les chambres, puis redescendent.",
+                "en": "Sophie and Lucas take their bags to the rooms, then come back down.",
+                "de": "Sophie und Lucas bringen ihre Taschen in die Zimmer und kommen dann wieder runter.",
+                "it": "Sophie e Lucas portano i loro bagagli nelle camere, poi scendono.",
+                "es": "Sophie y Lucas suben sus maletas a las habitaciones y luego bajan.",
+                "nl": "Sophie en Lucas brengen hun tassen naar de kamers en komen dan weer naar beneden.",
+                "pt": "Sophie e Lucas sobem com as mochilas para os quartos, depois descem.",
+                "en_pt": "Sophie and Lucas go up with their backpacks to the rooms, then come back down."
             },
             "ipa": {
-                "pt": "[pˌowzˈadæ da sˈɛxæ]",
-                "en": "[paʊsˈɑːdə dˈɑː sˈɛɹə]"
+                "fr": "sɔfˈi e lykˈa mˈɔ̃t lœʁ sˈak dɑ̃ le- ʃˈɑ̃bʁ pyˈi ʁədɛsˈɑ̃d",
+                "de": "[ˈzoːfi ʔʊnt ˈluːkas ˈbʁɪŋən ˈiːʁə ˈtaʃən ɪn diː ˈtsɪmɐ ʔʊnt ˈkɔmən dan ˈviːdɐ ˈʁʊntɐ]",
+                "it": "[sˈopje ˌe lˈuːkas pˈɔrtano ˌɪ lˌɔro baɡˈaːʎɪ nˌɛlle kˈamere\n pˈɔːɪ ʃˈendono]",
+                "es": "[ˈsofi i ˈlukas ˈsuβen sus maˈletas a las aβitaˈθjones i ˈlweɣo ˈbaxan]",
+                "nl": "[sɔphˈi ɛn lˈykɑs brˈɛŋən hɵn tˈɑsən naːr də kˈaːmərs ɛn kˈoːmən dˈɑn ʋˈɪːr naːr bənˈeːdən]",
+                "pt": "[sˌofˈij i lˈukæs sˈɔbeɪŋ koŋ az mˌoʃˈilæs pˌaɾæ ʊs kwˈaɾətʊs\n depˈoɪz dˈɛseɪŋ]",
+                "en": "[sˈəʊfi and lˈuːkəz tˈeɪk ðeə bˈaɡz tə ðə ɹˈuːmz ðˈɛn kˈʌm bˈak dˈaʊn]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -829,14 +815,29 @@
         {
             "id": "scene-07-028",
             "text": {
-                "pt": "Eles entram na pousada.",
-                "en": "They enter the inn."
+                "fr": "Allons explorer le village!",
+                "en": "Let's explore the village!",
+                "de": "Lass uns das Dorf erkunden!",
+                "it": "Andiamo a esplorare il villaggio!",
+                "es": "¡Vamos a explorar el barrio!",
+                "nl": "Laten we het dorp gaan verkennen!",
+                "pt": "Vamos explorar o vilarejo!"
             },
             "ipa": {
-                "pt": "[ˌelyz ˈeɪŋtrɐ̃ʊ̃ na pˌowzˈadæ]",
-                "en": "[ðeɪ ˈɛntə ðɪ ˈɪn]"
+                "fr": "alˈɔ̃z ɛksplɔʁˈe lə- vilˈaʒ",
+                "de": "[las ʔʊns das dɔʁf ʔɛɐ̯ˈkʊndən]",
+                "it": "[andjˈaːmo ˌa ˌesplorˈaːre ˌil villˈadʒːo]",
+                "es": "[ˈbamos a eksploˈɾaɾ el 'βarjo]",
+                "nl": "[lˈaːtən ʋə hə tˈɔrp ɣˈaːn vərkˈɛnən]",
+                "pt": "[vˌɐ̃mʊz ˌesploɾˈaɾ ʊ vˌilaɾˈeʒʊ]",
+                "en": "[lˈɛts ɛksplˈɔː ðə vˈɪlɪdʒ]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }

--- a/language_materials/unified/stories/scene-08.json
+++ b/language_materials/unified/stories/scene-08.json
@@ -24,12 +24,74 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-08-001",
+            "text": {
+                "fr": "Sophie et Lucas se promènent dans les rues étroites du village.",
+                "en": "Sophie and Lucas are walking through the narrow streets of the village.",
+                "de": "Sophie und Lucas schlendern durch die engen Gassen des Viertels.",
+                "it": "Sophie e Lucas camminano per le stradine strette del quartiere.",
+                "es": "Sophie y Lucas pasean por las calles estrechas del barrio.",
+                "nl": "Sophie en Lucas lopen door de smalle straatjes van het dorp.",
+                "pt": "Sophie e Lucas passeiam pelas ruas estreitas do vilarejo.",
+                "en_pt": "Sophie and Lucas stroll through the narrow streets of the village."
+            },
+            "ipa": {
+                "fr": "sɔfˈi e lykˈa sə- pʁɔmˈɛn dɑ̃ le- ʁˈyz etʁwˈat dy- vilˈaʒ",
+                "de": "[ˈzoːfiː ʊnt ˈluːkas ˈʃlɛndɐn dʊʁç diː ˈɛŋən ˈɡasən dɛs ˈfiːɐtəls.]",
+                "it": "[sˈopje ˌe lˈuːkas kˌamminˈaːno pˌɛr lˌe strˈadine strˈetːe dˌɛl kwˌartiˈɛːre]",
+                "es": "[ˈsofi i ˈlukas paˈse.an poɾ las ˈkaʎes esˈtɾetʃas ðel ˈβarjo]",
+                "nl": "[sɔphˈi ɛn lˈykɑs lˈoːpən doːr də smˈɑlə strˈaːtʲəs vɑn hə tˈɔrp]",
+                "pt": "[sˌofˈij i lˈukæs pˌasˈeɪɐ̃ʊ̃ pˈelæz xˈuæz ˌestrˈeɪtæz dʊ vˌilaɾˈeʒʊ]",
+                "en": "[sˈəʊfi and lˈuːkəz ɑː wˈɔːkɪŋ θɹuː ðə nˈaɹəʊ stɹˈiːts ɒvðə vˈɪlɪdʒ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-002",
+            "text": {
+                "fr": "Ils croisent un vieil homme qui promène son chien.",
+                "en": "They meet an old man walking his dog.",
+                "de": "Sie treffen einen alten Mann, der seinen Hund ausführt.",
+                "it": "Incontrano un vecchio che passeggia con il suo cane.",
+                "es": "Se cruzan con un anciano que pasea su perro.",
+                "nl": "Ze komen een oude man tegen die zijn hond uitlaat.",
+                "pt": "Eles encontram um senhor idoso que passeia com seu cachorro.",
+                "en_pt": "They meet an elderly man walking his dog."
+            },
+            "ipa": {
+                "fr": "il kʁwˈazt œ̃ vjˈɛj ˈɔm ki pʁɔmˈɛn sɔ̃ ʃjˈɛ̃",
+                "de": "[ziː ˈtʁɛfən ˈaɪ̯nən ˈaltən man, deːɐ̯ ˈzaɪ̯nən hʊnt ˈaʊ̯sfyːɐ̯t.]",
+                "it": "[inkˈontrano ˌʊn vˈekːio kˌe passˈedʒːa kˌon ˌil sˌʊo kˈaːne]",
+                "es": "[se kɾuˈθan kon un anˈθjano ke paˈsea su ˈpero]",
+                "nl": "[zə kˈoːmən ən ˈʌʊdə mˈɑn tˈeːɣən di zɛɪn hˈɔnt ˈœytlˌaːt]",
+                "pt": "[ˌelyz ˌeɪŋkˈoŋtrɐ̃ʊ̃ ũŋ seɲˈoɾ ˌidˈozʊ ky pˌasˈeɪæ koŋ seʊ kˌaʃˈoxʊ]",
+                "en": "[ðeɪ mˈiːt ɐn ˈəʊld mˈan wˈɔːkɪŋ hɪz dˈɒɡ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-003",
             "text": {
                 "fr": "Excusez-moi, où est la boulangerie?",
                 "en": "Excuse me, where is the bakery?",
@@ -59,7 +121,22 @@
             }
         },
         {
-            "id": "scene-08-002",
+            "id": "scene-08-004",
+            "text": {
+                "pt": "pergunta Sophie.",
+                "en": "Sophie asks."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ sˌofˈiy]",
+                "en": "[sˈəʊfi ˈasks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-005",
             "text": {
                 "fr": "Tournez à droite après l'église",
                 "en": "Turn right after the church",
@@ -90,7 +167,7 @@
             }
         },
         {
-            "id": "scene-08-003",
+            "id": "scene-08-006",
             "text": {
                 "fr": "Vous ne pouvez pas la manquer.",
                 "en": "You can't miss it.",
@@ -120,7 +197,38 @@
             }
         },
         {
-            "id": "scene-08-004",
+            "id": "scene-08-007",
+            "text": {
+                "fr": "L'homme les observe avec curiosité.",
+                "en": "The man watches them with curiosity.",
+                "de": "Der Mann betrachtet sie neugierig.",
+                "it": "L'uomo li osserva con curiosità.",
+                "es": "El hombre los mira con curiosidad.",
+                "nl": "De man kijkt hen nieuwsgierig aan.",
+                "pt": "O homem os observa com curiosidade.",
+                "en_pt": "The man observes them with curiosity."
+            },
+            "ipa": {
+                "fr": "lˈɔm le-z ɔbsˈɛʁv avˌɛk kyʁjozitˈe",
+                "de": "[deːɐ̯ man bəˈtʁaxtət ziː ˈnɔɪ̯ɡiːʁɪç.]",
+                "it": "[lwˈɔːmo lˌɪ ossˈɛːrva kˌon kˌʊriˌɔzitˈa]",
+                "es": "[el ˈom.bɾe los ˈmiɾa kon kuɾjoˈsiðað]",
+                "nl": "[də mˈɑn kˈɛɪkt hɛn nˈiwsɣˌirəx ˈaːn]",
+                "pt": "[ʊ ˈomeɪŋ ʊz ˌobsˈɛɾəvæ koŋ kˌuɾiˌozidˈadʒy]",
+                "en": "[ðə mˈan wˈɒtʃɪz ðˌɛm wɪð kjˌʊɹɪˈɒsɪti]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-008",
             "text": {
                 "fr": "Vous êtes nouveaux ici?",
                 "en": "Are you new here?",
@@ -150,7 +258,7 @@
             }
         },
         {
-            "id": "scene-08-005",
+            "id": "scene-08-009",
             "text": {
                 "fr": "Oui, nous venons de Paris,",
                 "en": "Yes, we come from Paris,",
@@ -181,22 +289,69 @@
             }
         },
         {
-            "id": "scene-08-006",
+            "id": "scene-08-010",
             "text": {
-                "fr": "Paris! Bienvenue dans notre village! Ici, c'est plus calme qu'à Paris.",
-                "en": "Paris! Welcome to our village! It's quieter here than in Paris.",
-                "de": "Berlin! Willkommen in unserem Kiez! Hier ist es ruhiger als in Berlin.",
-                "it": "Parigi! Benvenuti nel nostro quartiere! Qui è più tranquillo rispetto a Parigi.",
-                "es": "¡Madrid! Bienvenidos a nuestro barrio, aquí es más tranquilo que en Madrid.",
-                "nl": "Parijs! Welkom in ons dorp! Hier is het rustiger dan in Parijs."
+                "pt": "São Paulo!",
+                "en": "São Paulo!"
             },
             "ipa": {
-                "fr": "paʁˈi bjɛ̃vnˈy dɑ̃ nɔtʁ vilˈaʒ isˈi sɛ ply kˈalm ka paʁˈi",
-                "de": "[ˈbɛʁliːn! ˈvɪlkɔmən ɪn ˈʊnzəʁəm ˈkiːts! hiːɐ̯ ɪst ɛs ˈʁuːɪɡɐ als ɪn ˈbɛʁliːn.]",
-                "it": "[parˈiːdʒɪ\n bˌenvenˈuːtɪ nˌɛl nˌɔstro kwˌartiˈɛːre\n kwˈi ˌɛ pjˌʊ trankwˈillo rispˈɛtːo ˌa parˈiːdʒɪ]",
-                "es": "[maˈðɾið | ˌβjenβeˈniðos a ˈnwestɾo βaˈrjo | aˈki es mas tɾaŋˈki.lo ke en maˈðɾið]",
-                "nl": "[paːrˈɛɪs\n ʋˈɛlkɔm ɪn ɔns dˈɔrp\n hˈir ɪs hət rˈɵstəɣər dˈɑn ɪn paːrˈɛɪs]",
-                "en": "[pˈaɹɪs wˈɛlkʌm tʊ aʊə vˈɪlɪdʒ ɪts kwˈaɪətə hˈiə ðɐn ɪn pˈaɹɪs]"
+                "pt": "[sɐ̃ʊ̃ pˈaʊlʊ]",
+                "en": "[sˈaʊ pˈɔːləʊ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-011",
+            "text": {
+                "pt": "Bem-vindos ao nosso vilarejo!",
+                "en": "Welcome to our village!"
+            },
+            "ipa": {
+                "pt": "[bˈeɪŋvˈiŋdʊz aʊ nˌɔsʊ vˌilaɾˈeʒʊ]",
+                "en": "[wˈɛlkʌm tʊ aʊə vˈɪlɪdʒ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-012",
+            "text": {
+                "pt": "Aqui é mais calmo que em São Paulo.",
+                "en": "It's calmer here than in São Paulo."
+            },
+            "ipa": {
+                "pt": "[akˈi ɛ mˈaɪs kˈaʊmʊ ky ˈeɪŋ sɐ̃ʊ̃ pˈaʊlʊ]",
+                "en": "[ɪts kˈɑːmə hˈiə ðɐn ɪn sˈaʊ pˈɔːləʊ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-013",
+            "text": {
+                "fr": "Ils continuent leur promenade.",
+                "en": "They continue their walk.",
+                "de": "Sie setzen ihren Spaziergang fort.",
+                "it": "Continuano la loro passeggiata.",
+                "es": "Siguen su paseo.",
+                "nl": "Ze vervolgen hun wandeling.",
+                "pt": "Eles continuam o passeio."
+            },
+            "ipa": {
+                "fr": "il kɔ̃tinˈy lœʁ pʁɔmnˈad",
+                "de": "[ziː ˈzɛtsən ˈiːʁən ʃpaˈtsiːɐ̯ɡaŋ fɔʁt.]",
+                "it": "[kontˈinʊˌano lˌa lˌɔro pˌassedʒːˈaːta]",
+                "es": "[ˈsiɣen su paˈseo]",
+                "nl": "[zə vərvˈɔlɣən hɵn ʋˈɑndəlˌɪŋ]",
+                "pt": "[ˌelys kˌoŋtʃinˈuɐ̃ʊ̃ ʊ pˌasˈeɪʊ]",
+                "en": "[ðeɪ kəntˈɪnjuː ðeə wˈɔːk]"
             },
             "provenance": {
                 "fr": "original",
@@ -204,14 +359,15 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-08-007",
+            "id": "scene-08-014",
             "text": {
                 "fr": "Les gens sont très gentils ici.",
-                "en": "People are very kind here.",
+                "en": "The people are very kind here.",
                 "de": "Die Leute sind hier sehr nett.",
                 "it": "Le persone sono molto gentili qui.",
                 "es": "La gente es muy maja por aquí.",
@@ -226,7 +382,7 @@
                 "es": "[la ˈxente es mwi ˈmaxa poɾ aˈki]",
                 "nl": "[də mˈɛnsən zɛɪn hˈir ˈɛrx ˈaːrdəx]",
                 "pt": "[sˌofˈij ˌobsˈɛɾəvæ\n as pˌesˈoæs sɐ̃ʊ̃ mwˈiŋtʊ ʒeɪŋtʃˈiz akˈi]",
-                "en": "[pˈiːpəl ɑː vˈɛɹɪ kˈaɪnd hˈiə]"
+                "en": "[ðə pˈiːpəl ɑː vˈɛɹɪ kˈaɪnd hˈiə]"
             },
             "provenance": {
                 "fr": "original",
@@ -239,7 +395,7 @@
             }
         },
         {
-            "id": "scene-08-008",
+            "id": "scene-08-015",
             "text": {
                 "fr": "Oui, c'est différent de la grande ville",
                 "en": "Yes, it's different from the big city",
@@ -270,16 +426,15 @@
             }
         },
         {
-            "id": "scene-08-009",
+            "id": "scene-08-016",
             "text": {
                 "fr": "Tout le monde se parle.",
-                "en": "Everyone talks to each other here.",
+                "en": "Everyone talks to each other.",
                 "de": "Hier spricht jeder mit jedem.",
                 "it": "Qui tutti si parlano.",
                 "es": "Aquí todo el mundo se habla.",
                 "nl": "Iedereen praat hier met elkaar.",
-                "pt": "Todo mundo conversa.",
-                "en_pt": "Everyone talks to each other."
+                "pt": "Todo mundo conversa."
             },
             "ipa": {
                 "fr": "tulmˈɔ̃d sə- pˈaʁl",
@@ -288,220 +443,7 @@
                 "es": "[aˈki ˈtoðo el ˈmun.do se ˈaβla]",
                 "nl": "[ˌidɪːrˈeːn prˈaːt hˈir mɛt ˈɛlkaːr]",
                 "pt": "[tˈodʊ mˈũŋdʊ kˌoŋvˈɛɾəsæ]",
-                "en": "[ˈɛvɹɪwˌɒn tˈɔːks tʊ ˈiːtʃ ˈʌðə hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-010",
-            "text": {
-                "fr": "Qu'est-ce qu'on peut faire ici?",
-                "en": "What can we do here?",
-                "de": "Was kann man hier machen?",
-                "it": "Cosa si può fare qui?",
-                "es": "¿Qué se puede hacer por aquí?",
-                "nl": "Wat kunnen we hier doen?",
-                "pt": "O que dá para fazer aqui?",
-                "en_pt": "What can you do here?"
-            },
-            "ipa": {
-                "fr": "kɛs kɔ̃ pˈø fˈɛʁ isˈi",
-                "de": "[vas kan man hiːɐ̯ ˈmaxən?]",
-                "it": "[kˈɔːza sˌɪ pʊˈɔ fˌare kwˈi]",
-                "es": "[ˈke se ˈpweðe aˈθeɾ poɾ aˈki]",
-                "nl": "[ʋɑt kˌɵnən ʋə hˈir dˈun]",
-                "pt": "[ʊ ky dˈa pˌaɾæ fazˌeɾ akˈi]",
-                "en": "[wˌɒt kan wiː dˈuː hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-011",
-            "text": {
-                "fr": "Il y a beaucoup de randonnées",
-                "en": "There are a lot of hikes",
-                "de": "Es gibt viele Wandermöglichkeiten.",
-                "it": "Ci sono molte escursioni",
-                "es": "Hay muchas rutas de senderismo.",
-                "nl": "Er zijn veel wandelingen",
-                "pt": "Tem muitas trilhas.",
-                "en_pt": "There are many trails."
-            },
-            "ipa": {
-                "fr": "il i a bokˌu də- ʁɑ̃dɔnˈe",
-                "de": "[ɛs ɡiːpt ˈfiːlə ˈvandɐˌmøːɡlɪçkaɪ̯tən.]",
-                "it": "[tʃˌɪ sˌono mˈolte ˌeskʊrsiˈoːnɪ]",
-                "es": "[aj ˈmutʃas ˈrutas ðe senðeˈɾismo]",
-                "nl": "[ər zɛɪn vˈeːl ʋˈɑndəlˌɪŋən]",
-                "pt": "[teɪŋ mwˈiŋtæs trˈiljæs]",
-                "en": "[ðeəɹˌɑːɹ ɐ lˈɒt ɒv hˈaɪks]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-012",
-            "text": {
-                "fr": "Les montagnes sont magnifiques.",
-                "en": "The hills are beautiful.",
-                "de": "Die Berge sind wunderschön.",
-                "it": "Le montagne sono splendide.",
-                "es": "Las montañas son preciosas.",
-                "nl": "De heuvels zijn prachtig.",
-                "pt": "As montanhas são lindas.",
-                "en_pt": "The mountains are beautiful."
-            },
-            "ipa": {
-                "fr": "le- mɔ̃tˈanj sˈɔ̃ maɲifˈik",
-                "de": "[diː ˈbɛʁɡə zɪnt ˈvʊndɐʃøːn.]",
-                "it": "[lˌe montˈaɲɲe sˌono splˈɛndide]",
-                "es": "[las monˈtaɲas son pɾeˈθjosas]",
-                "nl": "[də hˈøːvəl sɛɪn prˈɑxtəx]",
-                "pt": "[az mˌoŋtˈɐ̃ɲæs sɐ̃ʊ̃ lˈiŋdæs]",
-                "en": "[ðə hˈɪlz ɑː bjˈuːtɪfəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-013",
-            "text": {
-                "fr": "Vous aimez la montagne?",
-                "en": "Do you like the hills?",
-                "de": "Magst du die Berge?",
-                "it": "Vi piace la montagna?",
-                "es": "¿Os gusta la montaña?",
-                "nl": "Hou je van de heuvels?",
-                "pt": "Vocês gostam de montanha?",
-                "en_pt": "Do you like mountains?"
-            },
-            "ipa": {
-                "fr": "vuz ɛmˈe la- mɔ̃tˈaɲ",
-                "de": "[maːkst duː diː ˈbɛʁɡə?]",
-                "it": "[vˌɪ pjˈaːtʃe lˌa montˈaɲɲa]",
-                "es": "[ˈos ˈɣusta la monˈtaɲa]",
-                "nl": "[hˈʌʊ jə vɑn də hˈøːvəls]",
-                "pt": "[vosˌez ɡˈɔstɐ̃ʊ̃ dʒy mˌoŋtˈɐ̃ɲæ]",
-                "en": "[dˈuː juː lˈaɪk ðə hˈɪlz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-014",
-            "text": {
-                "fr": "Oui, nous adorons la nature. C'est pour ça qu'on est venus.",
-                "en": "Yes, we love nature. That's why we came here.",
-                "de": "Ja, wir lieben die Natur. Deshalb sind wir hierher gekommen.",
-                "it": "Sì, adoriamo la natura. È per questo che siamo venuti.",
-                "es": "Sí, nos encanta la naturaleza, por eso hemos venido.",
-                "nl": "Ja, we houden van de natuur. Daarom zijn we hier gekomen.",
-                "pt": "Sim, adoramos a natureza.",
-                "en_pt": "Yes, we love nature."
-            },
-            "ipa": {
-                "fr": "wˈi nuz adɔʁˈɔ̃ la- natˈyʁ sɛ puʁ sa kɔ̃n ɛ vənˈy",
-                "de": "[jaː viːɐ̯ ˈliːbən diː naˈtuːɐ̯. ˈdɛshalp zɪnt viːɐ̯ ˈhiːɐhɛɐ̯ gəˈkɔmən.]",
-                "it": "[sˈi\n ˌadoriˈaːmo lˌa natˈuːra\n ˌɛ pˌɛr kwˌɛsto kˌe sjˌamo venˈuːtɪ]",
-                "es": "[si | nos enˈkanta la natuˈɾaleθa | poɾ ˈeso ˈemos ˈbeniðo]",
-                "nl": "[jˈaː\n ʋə hˈʌʊdən vɑn də naːtˈyr\n dˈaːrɔm zɛɪn ʋə hˈir ɣəkˈoːmən]",
-                "pt": "[sˈiŋ\n ˌadoɾˈɐ̃mʊz a nˌatuɾˈezæ]",
-                "en": "[jˈɛs wiː lˈʌv nˈeɪtʃə ðats wˌaɪ wiː kˈeɪm hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-015",
-            "text": {
-                "fr": "Demain, nous irons faire une randonnée.",
-                "en": "Tomorrow, we will go hiking.",
-                "de": "Morgen werden wir wandern gehen.",
-                "it": "Domani andremo a fare un'escursione.",
-                "es": "Mañana, iremos a hacer una ruta de senderismo.",
-                "nl": "Morgen gaan we wandelen."
-            },
-            "ipa": {
-                "fr": "dəmˈɛ̃ nuz iʁˈɔ̃ fˈɛʁ yn ʁɑ̃dɔnˈe",
-                "de": "[ˈmɔʁɡən ˈvɛʁdən viːɐ̯ ˈvandɐn ˈɡeːən.]",
-                "it": "[domˈaːnɪ andrˈɛːmo ˌa fˌare ʊnˌeskʊrsiˈoːne]",
-                "es": "[maˈɲana | iˈɾemos a aˈθeɾ ˈuna ˈruta ðe senðeˈɾismo]",
-                "nl": "[mˈɔrɣən ɣˈaːn ʋə ʋˈɑndələn]",
-                "en": "[təmˈɒɹəʊ wiː wɪl ɡˌəʊ hˈaɪkɪŋ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-016",
-            "text": {
-                "fr": "Attention, la météo change vite ici",
-                "en": "Be careful, the weather changes quickly here",
-                "de": "Achtung, das Wetter ändert sich schnell hier.",
-                "it": "Attenzione, il tempo cambia velocemente qui",
-                "es": "Cuidado, el tiempo cambia rápido aquí.",
-                "nl": "Pas op, het weer kan hier snel veranderen",
-                "pt": "Cuidado, o tempo muda rápido aqui.",
-                "en_pt": "Be careful, the weather changes quickly here."
-            },
-            "ipa": {
-                "fr": "atɑ̃sjˈɔ̃ la- meteˈo ʃˈɑ̃ʒ vˈit isˈi",
-                "de": "[ˈaxtʊŋ das ˈvɛtɐ ˈɛndɐt zɪç ʃnɛl hiːɐ̯.]",
-                "it": "[ˌatːentsiˈɔːne\n ˌil tˈɛmpo kˈambia vˌɛlotʃemˈente kwˈi]",
-                "es": "[kwiˈðaðo | el ˈtjempo ˈkambja ˈrapido aˈki]",
-                "nl": "[pˈɑs ˈɔp\n hət ʋˈɪːr kɑn hˈir snˈɛl vərˈɑndərən]",
-                "pt": "[kˌuɪdˈadʊ\n ʊ tˈeɪmpʊ mˈudæ xˈapidw akˈi]",
-                "en": "[biː kˈeəfəl ðə wˈɛðə tʃˈeɪndʒɪz kwˈɪkli hˈiə]"
+                "en": "[ˈɛvɹɪwˌɒn tˈɔːks tʊ ˈiːtʃ ˈʌðə]"
             },
             "provenance": {
                 "fr": "original",
@@ -516,221 +458,20 @@
         {
             "id": "scene-08-017",
             "text": {
-                "fr": "Prenez toujours des vêtements chauds.",
-                "en": "Always take warm clothes.",
-                "de": "Nimm immer warme Kleidung mit.",
-                "it": "Portate sempre con voi vestiti caldi.",
-                "es": "Lleva siempre ropa abrigada.",
-                "nl": "Neem altijd warme kleren mee.",
-                "pt": "Sempre levem roupas quentes.",
-                "en_pt": "Always bring warm clothes."
+                "pt": "Eles chegam na frente da padaria.",
+                "en": "They arrive in front of the bakery."
             },
             "ipa": {
-                "fr": "pʁənˈe tuʒˌuʁ de- vɛtmˈɑ̃ ʃˈo",
-                "de": "[nɪm ˈɪmɐ ˈvaʁmə ˈklaɪ̯dʊŋ mɪt.]",
-                "it": "[portˈaːte sˈɛmpre kˌon vˌɔɪ vestˈiːtɪ kˈaldɪ]",
-                "es": "[ˈʎeβa ˈsjempɾe ˈropa aˈβɾiɣaða]",
-                "nl": "[nˈeːm ˈɑltɛɪt ʋˈɑrmə klˈɪːrən mˈeː]",
-                "pt": "[sˌeɪmpry lˈɛveɪŋ xˈowpæs kˈeɪŋtʃys]",
-                "en": "[ˈɔːlweɪz tˈeɪk wˈɔːm klˈəʊðz]"
+                "pt": "[ˌelys ʃˈeɡɐ̃ʊ̃ na frˈeɪŋtʃy da pˌadaɾˈiæ]",
+                "en": "[ðeɪ ɐɹˈaɪv ɪn fɹˈʌnt ɒvðə bˈeɪkəɹɪ]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-08-018",
-            "text": {
-                "fr": "Merci pour le conseil,",
-                "en": "Thank you for the advice,",
-                "de": "Danke für den Tipp,",
-                "it": "Grazie per il consiglio,",
-                "es": "Gracias por el consejo,",
-                "nl": "Bedankt voor de tip,",
-                "pt": "Obrigado pelo conselho, diz Lucas.",
-                "en_pt": "Thanks for the advice, Lucas says."
-            },
-            "ipa": {
-                "fr": "mɛʁsˈi puʁ lə- kɔ̃sˈɛj",
-                "de": "[ˈdaŋkə fyːɐ̯ deːn ˈtɪp,]",
-                "it": "[ɡrˈatsje pˌɛr ˌil konsˈiːʎo]",
-                "es": "[ˈɣraθjas poɾ el konˈsexo]",
-                "nl": "[bədˈɑŋkt vɔːr də tˈɪp]",
-                "pt": "[ˌobriɡˈadʊ pˈelʊ kˌoŋsˈeljʊ\n dʒˈiz lˈukæs]",
-                "en": "[θˈaŋk juː fəðɪ ɐdvˈaɪs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-019",
-            "text": {
-                "fr": "Bonne soirée et bonne chance!",
-                "en": "Have a good evening and good luck!",
-                "de": "Schönen Abend noch und viel Glück!",
-                "it": "Buona serata e buona fortuna!",
-                "es": "Buena noche y buena suerte.",
-                "nl": "Fijne avond en succes!",
-                "pt": "Boa noite e boa sorte!",
-                "en_pt": "Good night and good luck!"
-            },
-            "ipa": {
-                "fr": "bˈɔn swaʁˈe e bˈɔn ʃˈɑ̃s",
-                "de": "[ˈʃøːnən ˈaːbənt nɔx ʊnt fiːl ˈɡlʏk!]",
-                "it": "[bʊˌona serˈaːta ˌe bʊˌona fortˈuːna]",
-                "es": "[ˈbwena ˈnotʃe i ˈbwena ˈswerte]",
-                "nl": "[fˈɛɪnə ˈaːvɔnd ɛn sɵksˈɛs]",
-                "pt": "[bˈoæ nˈoɪtʃj i bˈoæ sˈɔɾətʃy]",
-                "en": "[hav ɐ ɡˈʊd ˈiːvnɪŋ and ɡˈʊd lˈʌk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-020",
-            "text": {
-                "fr": "Sophie et Lucas se promènent dans les rues étroites du village.",
-                "en": "Sophie and Lucas walk through the narrow streets of the village.",
-                "de": "Sophie und Lucas schlendern durch die engen Gassen des Viertels.",
-                "it": "Sophie e Lucas camminano per le stradine strette del quartiere.",
-                "es": "Sophie y Lucas pasean por las calles estrechas del barrio.",
-                "nl": "Sophie en Lucas lopen door de smalle straatjes van het dorp.",
-                "pt": "Sophie e Lucas passeiam pelas ruas estreitas do vilarejo.",
-                "en_pt": "Sophie and Lucas stroll through the narrow streets of the village."
-            },
-            "ipa": {
-                "fr": "sɔfˈi e lykˈa sə- pʁɔmˈɛn dɑ̃ le- ʁˈyz etʁwˈat dy- vilˈaʒ",
-                "de": "[ˈzoːfiː ʊnt ˈluːkas ˈʃlɛndɐn dʊʁç diː ˈɛŋən ˈɡasən dɛs ˈfiːɐtəls.]",
-                "it": "[sˈopje ˌe lˈuːkas kˌamminˈaːno pˌɛr lˌe strˈadine strˈetːe dˌɛl kwˌartiˈɛːre]",
-                "es": "[ˈsofi i ˈlukas paˈse.an poɾ las ˈkaʎes esˈtɾetʃas ðel ˈβarjo]",
-                "nl": "[sɔphˈi ɛn lˈykɑs lˈoːpən doːr də smˈɑlə strˈaːtʲəs vɑn hə tˈɔrp]",
-                "pt": "[sˌofˈij i lˈukæs pˌasˈeɪɐ̃ʊ̃ pˈelæz xˈuæz ˌestrˈeɪtæz dʊ vˌilaɾˈeʒʊ]",
-                "en": "[sˈəʊfi and lˈuːkəz wˈɔːk θɹuː ðə nˈaɹəʊ stɹˈiːts ɒvðə vˈɪlɪdʒ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-021",
-            "text": {
-                "fr": "Ils croisent un vieil homme qui promène son chien.",
-                "en": "They come across an old man walking his dog.",
-                "de": "Sie treffen einen alten Mann, der seinen Hund ausführt.",
-                "it": "Incontrano un vecchio che passeggia con il suo cane.",
-                "es": "Se cruzan con un anciano que pasea su perro.",
-                "nl": "Ze komen een oude man tegen die zijn hond uitlaat.",
-                "pt": "Eles encontram um senhor idoso que passeia com seu cachorro.",
-                "en_pt": "They meet an elderly man walking his dog."
-            },
-            "ipa": {
-                "fr": "il kʁwˈazt œ̃ vjˈɛj ˈɔm ki pʁɔmˈɛn sɔ̃ ʃjˈɛ̃",
-                "de": "[ziː ˈtʁɛfən ˈaɪ̯nən ˈaltən man, deːɐ̯ ˈzaɪ̯nən hʊnt ˈaʊ̯sfyːɐ̯t.]",
-                "it": "[inkˈontrano ˌʊn vˈekːio kˌe passˈedʒːa kˌon ˌil sˌʊo kˈaːne]",
-                "es": "[se kɾuˈθan kon un anˈθjano ke paˈsea su ˈpero]",
-                "nl": "[zə kˈoːmən ən ˈʌʊdə mˈɑn tˈeːɣən di zɛɪn hˈɔnt ˈœytlˌaːt]",
-                "pt": "[ˌelyz ˌeɪŋkˈoŋtrɐ̃ʊ̃ ũŋ seɲˈoɾ ˌidˈozʊ ky pˌasˈeɪæ koŋ seʊ kˌaʃˈoxʊ]",
-                "en": "[ðeɪ kˈʌm əkɹˌɒs ɐn ˈəʊld mˈan wˈɔːkɪŋ hɪz dˈɒɡ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-022",
-            "text": {
-                "fr": "L'homme les observe avec curiosité.",
-                "en": "The man looks at them curiously.",
-                "de": "Der Mann betrachtet sie neugierig.",
-                "it": "L'uomo li osserva con curiosità.",
-                "es": "El hombre los mira con curiosidad.",
-                "nl": "De man kijkt hen nieuwsgierig aan.",
-                "pt": "O homem os observa com curiosidade.",
-                "en_pt": "The man observes them with curiosity."
-            },
-            "ipa": {
-                "fr": "lˈɔm le-z ɔbsˈɛʁv avˌɛk kyʁjozitˈe",
-                "de": "[deːɐ̯ man bəˈtʁaxtət ziː ˈnɔɪ̯ɡiːʁɪç.]",
-                "it": "[lwˈɔːmo lˌɪ ossˈɛːrva kˌon kˌʊriˌɔzitˈa]",
-                "es": "[el ˈom.bɾe los ˈmiɾa kon kuɾjoˈsiðað]",
-                "nl": "[də mˈɑn kˈɛɪkt hɛn nˈiwsɣˌirəx ˈaːn]",
-                "pt": "[ʊ ˈomeɪŋ ʊz ˌobsˈɛɾəvæ koŋ kˌuɾiˌozidˈadʒy]",
-                "en": "[ðə mˈan lˈʊks at ðˌɛm kjˈʊɹɪəsli]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-023",
-            "text": {
-                "fr": "Ils continuent leur promenade.",
-                "en": "They continue their walk.",
-                "de": "Sie setzen ihren Spaziergang fort.",
-                "it": "Continuano la loro passeggiata.",
-                "es": "Siguen su paseo.",
-                "nl": "Ze vervolgen hun wandeling.",
-                "pt": "Eles continuam o passeio."
-            },
-            "ipa": {
-                "fr": "il kɔ̃tinˈy lœʁ pʁɔmnˈad",
-                "de": "[ziː ˈzɛtsən ˈiːʁən ʃpaˈtsiːɐ̯ɡaŋ fɔʁt.]",
-                "it": "[kontˈinʊˌano lˌa lˌɔro pˌassedʒːˈaːta]",
-                "es": "[ˈsiɣen su paˈseo]",
-                "nl": "[zə vərvˈɔlɣən hɵn ʋˈɑndəlˌɪŋ]",
-                "pt": "[ˌelys kˌoŋtʃinˈuɐ̃ʊ̃ ʊ pˌasˈeɪʊ]",
-                "en": "[ðeɪ kəntˈɪnjuː ðeə wˈɔːk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-024",
             "text": {
                 "fr": "L'odeur du pain frais les accueille.",
                 "en": "The smell of fresh bread welcomes them.",
@@ -761,16 +502,15 @@
             }
         },
         {
-            "id": "scene-08-025",
+            "id": "scene-08-019",
             "text": {
                 "fr": "La boulangère est bavarde.",
-                "en": "The female baker is chatty.",
+                "en": "The baker is talkative.",
                 "de": "Die Bäckerin ist gesprächig.",
                 "it": "La panettiera è molto chiacchierona.",
                 "es": "La churrera es muy habladora.",
                 "nl": "De bakkerin is praatgraag.",
-                "pt": "A padeira é falante.",
-                "en_pt": "The baker is talkative."
+                "pt": "A padeira é falante."
             },
             "ipa": {
                 "fr": "la- bulɑ̃ʒˈɛʁ ɛ bavˈaʁd",
@@ -779,7 +519,7 @@
                 "es": "[la tʃuˈreɾa es mwi aβlaˈðoɾa]",
                 "nl": "[də bˈɑkɪːrˌɪn ɪs praːtɣrˈaːx]",
                 "pt": "[a pˌadˈeɪɾæ ɛ fˌalˈɐ̃ŋtʃy]",
-                "en": "[ðə fˈiːmeɪl bˈeɪkəɹ ɪz tʃˈati]"
+                "en": "[ðə bˈeɪkəɹ ɪz tˈɔːkətˌɪv]"
             },
             "provenance": {
                 "fr": "original",
@@ -792,25 +532,25 @@
             }
         },
         {
-            "id": "scene-08-026",
+            "id": "scene-08-020",
             "text": {
-                "fr": "Sophie achète du pain et des pâtisseries.",
-                "en": "Sophie buys some bread and pastries.",
-                "de": "Sophie kauft Brot und Gebäck.",
-                "it": "Sophie compra del pane e delle paste.",
-                "es": "Sophie compra pan y unos churros.",
-                "nl": "Sophie koopt brood en wat gebakjes.",
-                "pt": "Sophie compra pão e bolos.",
-                "en_pt": "Sophie buys bread and cakes."
+                "fr": "Qu'est-ce qu'on peut faire ici?",
+                "en": "  What can we do here?",
+                "de": "Was kann man hier machen?",
+                "it": "Cosa si può fare qui?",
+                "es": "¿Qué se puede hacer por aquí?",
+                "nl": "Wat kunnen we hier doen?",
+                "pt": "O que dá para fazer aqui?",
+                "en_pt": "What can you do here?"
             },
             "ipa": {
-                "fr": "sɔfˈi aʃˈɛt dy- pˈɛ̃ e de- patisəʁˈi",
-                "de": "[ˈzoːfiː kaʊ̯ft bʁoːt ʊnt gəˈbɛk.]",
-                "it": "[sˈopje kˈompra dˌɛl pˈaːne ˌe dˌɛlle pˈaste]",
-                "es": "[ˈsofi ˈkom.pɾa pan i ˈunos ˈtʃur.os]",
-                "nl": "[sɔphˈi kˈoːpt brˈoːd ɛn ʋɑt ɣəbˈɑkjəs]",
-                "pt": "[sˌofˈiy kˈompræ pˈɐ̃ʊ̃ i bˈolʊs]",
-                "en": "[sˈəʊfi bˈaɪz sˌʌm bɹˈɛd and pˈeɪstɹiz]"
+                "fr": "kɛs kɔ̃ pˈø fˈɛʁ isˈi",
+                "de": "[vas kan man hiːɐ̯ ˈmaxən?]",
+                "it": "[kˈɔːza sˌɪ pʊˈɔ fˌare kwˈi]",
+                "es": "[ˈke se ˈpweðe aˈθeɾ poɾ aˈki]",
+                "nl": "[ʋɑt kˌɵnən ʋə hˈir dˈun]",
+                "pt": "[ʊ ky dˈa pˌaɾæ fazˌeɾ akˈi]",
+                "en": "[wˌɒt kan wiː dˈuː hˈiə]"
             },
             "provenance": {
                 "fr": "original",
@@ -823,82 +563,7 @@
             }
         },
         {
-            "id": "scene-08-027",
-            "text": {
-                "pt": "pergunta Sophie.",
-                "en": "Sophie asks."
-            },
-            "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ sˌofˈiy]",
-                "en": "[sˈəʊfi ˈasks]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-028",
-            "text": {
-                "pt": "São Paulo!",
-                "en": "São Paulo!"
-            },
-            "ipa": {
-                "pt": "[sɐ̃ʊ̃ pˈaʊlʊ]",
-                "en": "[sˈaʊ pˈɔːləʊ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-029",
-            "text": {
-                "pt": "Bem-vindos ao nosso vilarejo!",
-                "en": "Welcome to our village!"
-            },
-            "ipa": {
-                "pt": "[bˈeɪŋvˈiŋdʊz aʊ nˌɔsʊ vˌilaɾˈeʒʊ]",
-                "en": "[wˈɛlkʌm tʊ aʊə vˈɪlɪdʒ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-030",
-            "text": {
-                "pt": "Aqui é mais calmo que em São Paulo.",
-                "en": "It's calmer here than in São Paulo."
-            },
-            "ipa": {
-                "pt": "[akˈi ɛ mˈaɪs kˈaʊmʊ ky ˈeɪŋ sɐ̃ʊ̃ pˈaʊlʊ]",
-                "en": "[ɪts kˈɑːmə hˈiə ðɐn ɪn sˈaʊ pˈɔːləʊ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-031",
-            "text": {
-                "pt": "Eles chegam na frente da padaria.",
-                "en": "They arrive in front of the bakery."
-            },
-            "ipa": {
-                "pt": "[ˌelys ʃˈeɡɐ̃ʊ̃ na frˈeɪŋtʃy da pˌadaɾˈiæ]",
-                "en": "[ðeɪ ɐɹˈaɪv ɪn fɹˈʌnt ɒvðə bˈeɪkəɹɪ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-08-032",
+            "id": "scene-08-021",
             "text": {
                 "pt": "pergunta Lucas.",
                 "en": "Lucas asks."
@@ -913,7 +578,100 @@
             }
         },
         {
-            "id": "scene-08-033",
+            "id": "scene-08-022",
+            "text": {
+                "fr": "Il y a beaucoup de randonnées",
+                "en": "There are many hikes",
+                "de": "Es gibt viele Wandermöglichkeiten.",
+                "it": "Ci sono molte escursioni",
+                "es": "Hay muchas rutas de senderismo.",
+                "nl": "Er zijn veel wandelingen",
+                "pt": "Tem muitas trilhas.",
+                "en_pt": "There are many trails."
+            },
+            "ipa": {
+                "fr": "il i a bokˌu də- ʁɑ̃dɔnˈe",
+                "de": "[ɛs ɡiːpt ˈfiːlə ˈvandɐˌmøːɡlɪçkaɪ̯tən.]",
+                "it": "[tʃˌɪ sˌono mˈolte ˌeskʊrsiˈoːnɪ]",
+                "es": "[aj ˈmutʃas ˈrutas ðe senðeˈɾismo]",
+                "nl": "[ər zɛɪn vˈeːl ʋˈɑndəlˌɪŋən]",
+                "pt": "[teɪŋ mwˈiŋtæs trˈiljæs]",
+                "en": "[ðeəɹˌɑː mˈɛni hˈaɪks]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-023",
+            "text": {
+                "fr": "Les montagnes sont magnifiques.",
+                "en": "The mountains are magnificent.",
+                "de": "Die Berge sind wunderschön.",
+                "it": "Le montagne sono splendide.",
+                "es": "Las montañas son preciosas.",
+                "nl": "De heuvels zijn prachtig.",
+                "pt": "As montanhas são lindas.",
+                "en_pt": "The mountains are beautiful."
+            },
+            "ipa": {
+                "fr": "le- mɔ̃tˈanj sˈɔ̃ maɲifˈik",
+                "de": "[diː ˈbɛʁɡə zɪnt ˈvʊndɐʃøːn.]",
+                "it": "[lˌe montˈaɲɲe sˌono splˈɛndide]",
+                "es": "[las monˈtaɲas son pɾeˈθjosas]",
+                "nl": "[də hˈøːvəl sɛɪn prˈɑxtəx]",
+                "pt": "[az mˌoŋtˈɐ̃ɲæs sɐ̃ʊ̃ lˈiŋdæs]",
+                "en": "[ðə mˈaʊntɪnz ɑː maɡnˈɪfɪsənt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-024",
+            "text": {
+                "fr": "Vous aimez la montagne?",
+                "en": "Do you like the mountains?",
+                "de": "Magst du die Berge?",
+                "it": "Vi piace la montagna?",
+                "es": "¿Os gusta la montaña?",
+                "nl": "Hou je van de heuvels?",
+                "pt": "Vocês gostam de montanha?",
+                "en_pt": "Do you like mountains?"
+            },
+            "ipa": {
+                "fr": "vuz ɛmˈe la- mɔ̃tˈaɲ",
+                "de": "[maːkst duː diː ˈbɛʁɡə?]",
+                "it": "[vˌɪ pjˈaːtʃe lˌa montˈaɲɲa]",
+                "es": "[ˈos ˈɣusta la monˈtaɲa]",
+                "nl": "[hˈʌʊ jə vɑn də hˈøːvəls]",
+                "pt": "[vosˌez ɡˈɔstɐ̃ʊ̃ dʒy mˌoŋtˈɐ̃ɲæ]",
+                "en": "[dˈuː juː lˈaɪk ðə mˈaʊntɪnz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-025",
             "text": {
                 "pt": "ela pergunta.",
                 "en": "she asks."
@@ -928,7 +686,38 @@
             }
         },
         {
-            "id": "scene-08-034",
+            "id": "scene-08-026",
+            "text": {
+                "fr": "Oui, nous adorons la nature. C'est pour ça qu'on est venus.",
+                "en": "Yes, we love nature. That's why we came.",
+                "de": "Ja, wir lieben die Natur. Deshalb sind wir hierher gekommen.",
+                "it": "Sì, adoriamo la natura. È per questo che siamo venuti.",
+                "es": "Sí, nos encanta la naturaleza, por eso hemos venido.",
+                "nl": "Ja, we houden van de natuur. Daarom zijn we hier gekomen.",
+                "pt": "Sim, adoramos a natureza.",
+                "en_pt": "Yes, we love nature."
+            },
+            "ipa": {
+                "fr": "wˈi nuz adɔʁˈɔ̃ la- natˈyʁ sɛ puʁ sa kɔ̃n ɛ vənˈy",
+                "de": "[jaː viːɐ̯ ˈliːbən diː naˈtuːɐ̯. ˈdɛshalp zɪnt viːɐ̯ ˈhiːɐhɛɐ̯ gəˈkɔmən.]",
+                "it": "[sˈi\n ˌadoriˈaːmo lˌa natˈuːra\n ˌɛ pˌɛr kwˌɛsto kˌe sjˌamo venˈuːtɪ]",
+                "es": "[si | nos enˈkanta la natuˈɾaleθa | poɾ ˈeso ˈemos ˈbeniðo]",
+                "nl": "[jˈaː\n ʋə hˈʌʊdən vɑn də naːtˈyr\n dˈaːrɔm zɛɪn ʋə hˈir ɣəkˈoːmən]",
+                "pt": "[sˈiŋ\n ˌadoɾˈɐ̃mʊz a nˌatuɾˈezæ]",
+                "en": "[jˈɛs wiː lˈʌv nˈeɪtʃə ðats wˌaɪ wiː kˈeɪm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-027",
             "text": {
                 "pt": "É por isso que viemos.",
                 "en": "That's why we came."
@@ -943,7 +732,38 @@
             }
         },
         {
-            "id": "scene-08-035",
+            "id": "scene-08-028",
+            "text": {
+                "fr": "Sophie achète du pain et des pâtisseries.",
+                "en": "Sophie buys bread and pastries.",
+                "de": "Sophie kauft Brot und Gebäck.",
+                "it": "Sophie compra del pane e delle paste.",
+                "es": "Sophie compra pan y unos churros.",
+                "nl": "Sophie koopt brood en wat gebakjes.",
+                "pt": "Sophie compra pão e bolos.",
+                "en_pt": "Sophie buys bread and cakes."
+            },
+            "ipa": {
+                "fr": "sɔfˈi aʃˈɛt dy- pˈɛ̃ e de- patisəʁˈi",
+                "de": "[ˈzoːfiː kaʊ̯ft bʁoːt ʊnt gəˈbɛk.]",
+                "it": "[sˈopje kˈompra dˌɛl pˈaːne ˌe dˌɛlle pˈaste]",
+                "es": "[ˈsofi ˈkom.pɾa pan i ˈunos ˈtʃur.os]",
+                "nl": "[sɔphˈi kˈoːpt brˈoːd ɛn ʋɑt ɣəbˈɑkjəs]",
+                "pt": "[sˌofˈiy kˈompræ pˈɐ̃ʊ̃ i bˈolʊs]",
+                "en": "[sˈəʊfi bˈaɪz bɹˈɛd and pˈeɪstɹiz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-029",
             "text": {
                 "pt": "Ao sair, ela diz: Amanhã vamos fazer uma trilha.",
                 "en": "As they leave, she says: Tomorrow we're going to do a trail."
@@ -958,7 +778,7 @@
             }
         },
         {
-            "id": "scene-08-036",
+            "id": "scene-08-030",
             "text": {
                 "pt": "A padeira os acompanha até a porta.",
                 "en": "The baker walks them to the door."
@@ -969,6 +789,184 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-031",
+            "text": {
+                "fr": "Attention, la météo change vite ici",
+                "en": "Be careful, the weather changes quickly here",
+                "de": "Achtung, das Wetter ändert sich schnell hier.",
+                "it": "Attenzione, il tempo cambia velocemente qui",
+                "es": "Cuidado, el tiempo cambia rápido aquí.",
+                "nl": "Pas op, het weer kan hier snel veranderen",
+                "pt": "Cuidado, o tempo muda rápido aqui.",
+                "en_pt": "Be careful, the weather changes quickly here."
+            },
+            "ipa": {
+                "fr": "atɑ̃sjˈɔ̃ la- meteˈo ʃˈɑ̃ʒ vˈit isˈi",
+                "de": "[ˈaxtʊŋ das ˈvɛtɐ ˈɛndɐt zɪç ʃnɛl hiːɐ̯.]",
+                "it": "[ˌatːentsiˈɔːne\n ˌil tˈɛmpo kˈambia vˌɛlotʃemˈente kwˈi]",
+                "es": "[kwiˈðaðo | el ˈtjempo ˈkambja ˈrapido aˈki]",
+                "nl": "[pˈɑs ˈɔp\n hət ʋˈɪːr kɑn hˈir snˈɛl vərˈɑndərən]",
+                "pt": "[kˌuɪdˈadʊ\n ʊ tˈeɪmpʊ mˈudæ xˈapidw akˈi]",
+                "en": "[biː kˈeəfəl ðə wˈɛðə tʃˈeɪndʒɪz kwˈɪkli hˈiə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-032",
+            "text": {
+                "fr": "Prenez toujours des vêtements chauds.",
+                "en": "Always wear warm clothes.",
+                "de": "Nimm immer warme Kleidung mit.",
+                "it": "Portate sempre con voi vestiti caldi.",
+                "es": "Lleva siempre ropa abrigada.",
+                "nl": "Neem altijd warme kleren mee.",
+                "pt": "Sempre levem roupas quentes.",
+                "en_pt": "Always bring warm clothes."
+            },
+            "ipa": {
+                "fr": "pʁənˈe tuʒˌuʁ de- vɛtmˈɑ̃ ʃˈo",
+                "de": "[nɪm ˈɪmɐ ˈvaʁmə ˈklaɪ̯dʊŋ mɪt.]",
+                "it": "[portˈaːte sˈɛmpre kˌon vˌɔɪ vestˈiːtɪ kˈaldɪ]",
+                "es": "[ˈʎeβa ˈsjempɾe ˈropa aˈβɾiɣaða]",
+                "nl": "[nˈeːm ˈɑltɛɪt ʋˈɑrmə klˈɪːrən mˈeː]",
+                "pt": "[sˌeɪmpry lˈɛveɪŋ xˈowpæs kˈeɪŋtʃys]",
+                "en": "[ˈɔːlweɪz wˈeə wˈɔːm klˈəʊðz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-033",
+            "text": {
+                "fr": "Merci pour le conseil,",
+                "en": "Thank you for the advice,",
+                "de": "Danke für den Tipp,",
+                "it": "Grazie per il consiglio,",
+                "es": "Gracias por el consejo,",
+                "nl": "Bedankt voor de tip,",
+                "pt": "Obrigado pelo conselho, diz Lucas.",
+                "en_pt": "Thanks for the advice, Lucas says."
+            },
+            "ipa": {
+                "fr": "mɛʁsˈi puʁ lə- kɔ̃sˈɛj",
+                "de": "[ˈdaŋkə fyːɐ̯ deːn ˈtɪp,]",
+                "it": "[ɡrˈatsje pˌɛr ˌil konsˈiːʎo]",
+                "es": "[ˈɣraθjas poɾ el konˈsexo]",
+                "nl": "[bədˈɑŋkt vɔːr də tˈɪp]",
+                "pt": "[ˌobriɡˈadʊ pˈelʊ kˌoŋsˈeljʊ\n dʒˈiz lˈukæs]",
+                "en": "[θˈaŋk juː fəðɪ ɐdvˈaɪs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-034",
+            "text": {
+                "fr": "Bonne soirée et bonne chance!",
+                "en": "Have a good evening and good luck!",
+                "de": "Schönen Abend noch und viel Glück!",
+                "it": "Buona serata e buona fortuna!",
+                "es": "Buena noche y buena suerte.",
+                "nl": "Fijne avond en succes!",
+                "pt": "Boa noite e boa sorte!",
+                "en_pt": "Good night and good luck!"
+            },
+            "ipa": {
+                "fr": "bˈɔn swaʁˈe e bˈɔn ʃˈɑ̃s",
+                "de": "[ˈʃøːnən ˈaːbənt nɔx ʊnt fiːl ˈɡlʏk!]",
+                "it": "[bʊˌona serˈaːta ˌe bʊˌona fortˈuːna]",
+                "es": "[ˈbwena ˈnotʃe i ˈbwena ˈswerte]",
+                "nl": "[fˈɛɪnə ˈaːvɔnd ɛn sɵksˈɛs]",
+                "pt": "[bˈoæ nˈoɪtʃj i bˈoæ sˈɔɾətʃy]",
+                "en": "[hav ɐ ɡˈʊd ˈiːvnɪŋ and ɡˈʊd lˈʌk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-035",
+            "text": {
+                "fr": "Paris! Bienvenue dans notre village! Ici, c'est plus calme qu'à Paris.",
+                "en": "Paris! Welcome to our village! Here, it's calmer than in Paris.",
+                "de": "Berlin! Willkommen in unserem Kiez! Hier ist es ruhiger als in Berlin.",
+                "it": "Parigi! Benvenuti nel nostro quartiere! Qui è più tranquillo rispetto a Parigi.",
+                "es": "¡Madrid! Bienvenidos a nuestro barrio, aquí es más tranquilo que en Madrid.",
+                "nl": "Parijs! Welkom in ons dorp! Hier is het rustiger dan in Parijs."
+            },
+            "ipa": {
+                "fr": "paʁˈi bjɛ̃vnˈy dɑ̃ nɔtʁ vilˈaʒ isˈi sɛ ply kˈalm ka paʁˈi",
+                "de": "[ˈbɛʁliːn! ˈvɪlkɔmən ɪn ˈʊnzəʁəm ˈkiːts! hiːɐ̯ ɪst ɛs ˈʁuːɪɡɐ als ɪn ˈbɛʁliːn.]",
+                "it": "[parˈiːdʒɪ\n bˌenvenˈuːtɪ nˌɛl nˌɔstro kwˌartiˈɛːre\n kwˈi ˌɛ pjˌʊ trankwˈillo rispˈɛtːo ˌa parˈiːdʒɪ]",
+                "es": "[maˈðɾið | ˌβjenβeˈniðos a ˈnwestɾo βaˈrjo | aˈki es mas tɾaŋˈki.lo ke en maˈðɾið]",
+                "nl": "[paːrˈɛɪs\n ʋˈɛlkɔm ɪn ɔns dˈɔrp\n hˈir ɪs hət rˈɵstəɣər dˈɑn ɪn paːrˈɛɪs]",
+                "en": "[pˈaɹɪs wˈɛlkʌm tʊ aʊə vˈɪlɪdʒ hˈiə ɪts kˈɑːmə ðɐn ɪn pˈaɹɪs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-08-036",
+            "text": {
+                "fr": "Demain, nous irons faire une randonnée.",
+                "en": "Tomorrow, we will go for a hike.",
+                "de": "Morgen werden wir wandern gehen.",
+                "it": "Domani andremo a fare un'escursione.",
+                "es": "Mañana, iremos a hacer una ruta de senderismo.",
+                "nl": "Morgen gaan we wandelen."
+            },
+            "ipa": {
+                "fr": "dəmˈɛ̃ nuz iʁˈɔ̃ fˈɛʁ yn ʁɑ̃dɔnˈe",
+                "de": "[ˈmɔʁɡən ˈvɛʁdən viːɐ̯ ˈvandɐn ˈɡeːən.]",
+                "it": "[domˈaːnɪ andrˈɛːmo ˌa fˌare ʊnˌeskʊrsiˈoːne]",
+                "es": "[maˈɲana | iˈɾemos a aˈθeɾ ˈuna ˈruta ðe senðeˈɾismo]",
+                "nl": "[mˈɔrɣən ɣˈaːn ʋə ʋˈɑndələn]",
+                "en": "[təmˈɒɹəʊ wiː wɪl ɡˌəʊ fəɹə hˈaɪk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-09.json
+++ b/language_materials/unified/stories/scene-09.json
@@ -24,535 +24,12 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-09-001",
-            "text": {
-                "fr": "Nous marchions depuis trois heures quand les nuages sont arrivés,",
-                "en": "We had been walking for three hours when the clouds arrived,",
-                "de": "Wir waren drei Stunden unterwegs, als die Wolken aufzogen,",
-                "it": "Camminavamo da tre ore quando sono arrivati i nuvoloni,",
-                "es": "Llevábamos tres horas caminando cuando llegaron las nubes,",
-                "nl": "We liepen al drie uur toen de wolken kwamen,",
-                "pt": "Estávamos caminhando há três horas quando as nuvens chegaram, contará Sophie mais tarde.",
-                "en_pt": "We had been walking for three hours when the clouds arrived, Sophie would later recount."
-            },
-            "ipa": {
-                "fr": "nu maʁʃjˈɔ̃ dəpyˌi tʁwˈaz ˈœʁ kɑ̃ le- nyˈaʒ sˈɔ̃t aʁivˈe",
-                "de": "[viːɐ̯ vaːʁən dʁaɪ̯ ˈʃtʊndən ˈʊntɐveːks, als diː ˈvɔlkən ˈaʊ̯ftsoːɡən,]",
-                "it": "[kˌamminavˈaːmo dˌa trˈe ˈoːre kwˈando sˌono ˌarɾivˈaːtɪ ˌɪ nˌʊvolˈoːnɪ]",
-                "es": "[ʎeˈβaβamos ˈtɾes ˈoɾas kamˈjando ˈkwando ʎeˈɣaɾon las ˈnubes]",
-                "nl": "[ʋə lˈipən ˈɑl drˈi ˈyr tˈun də ʋˈɔlkən kʋˈaːmən]",
-                "pt": "[estˌavæmʊs kˌæmiɲˈɐ̃ŋdw a trˈes ˈɔɾæs kwˈɐ̃ŋdw az nˈuveɪŋs ʃˌeɡˈaɾɐ̃ʊ̃\n kˌoŋtaɾˈa sˌofˈiy mˈaɪs tˈaɾədʒy]",
-                "en": "[wiː hɐdbɪn wˈɔːkɪŋ fɔː θɹˈiː ˈaʊəz wɛn ðə klˈaʊdz ɐɹˈaɪvd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-002",
-            "text": {
-                "fr": "Il faisait de plus en plus froid.",
-                "en": "It was getting colder and colder.",
-                "de": "Es wurde immer kälter.",
-                "it": "Stava diventando sempre più freddo.",
-                "es": "Empezaba a hacer cada vez más frío.",
-                "nl": "Het werd steeds kouder.",
-                "pt": "Estava ficando cada vez mais frio."
-            },
-            "ipa": {
-                "fr": "il fəzˈɛ də- plyz ɑ̃ ply fʁwˈa",
-                "de": "[ɛs ˈvʊrdə ˈɪmɐ ˈkɛltɐ]",
-                "it": "[stˈaːva dˌiventˈando sˈɛmpre pjˌʊ frˈedːo]",
-                "es": "[empeˈθaβa a aˈθeɾ ˈkaða βeθ ˈmas ˈfɾio]",
-                "nl": "[hət ʋɛrt stˈeːts kˈʌʊdər]",
-                "pt": "[estˌavæ fˌikˈɐ̃ŋdʊ kˈadæ vˈez mˈaɪs frˈiʊ]",
-                "en": "[ɪt wɒz ɡˌɛtɪŋ kˈəʊldə and kˈəʊldə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-003",
-            "text": {
-                "fr": "Si j'avais su, j'aurais apporté un pull plus chaud.",
-                "en": "If I had known, I would have brought a warmer sweater.",
-                "de": "Hätte ich das gewusst, hätte ich einen wärmeren Pullover mitgebracht.",
-                "it": "Se l'avessi saputo, avrei portato un maglione più caldo.",
-                "es": "Si lo hubiera sabido, habría traído un jersey más abrigado.",
-                "nl": "Als ik het had geweten, had ik een warmere trui meegenomen.",
-                "pt": "Se eu soubesse, teria trazido um casaco mais quente.",
-                "en_pt": "If I had known, I would have brought a warmer jacket."
-            },
-            "ipa": {
-                "fr": "sˈi ʒavˈɛ sˈy ʒoʁˈɛz apɔʁtˈe œ̃pˈul ply ʃˈo",
-                "de": "[ˈhɛtə ɪç das ɡəˈvʊst, ˈhɛtə ɪç ˈaɪ̯nən ˈvɛrməʁən ˈpʊlovɐ ˈmɪtɡəbʁaxt]",
-                "it": "[sˌe lavˌɛssɪ sapˈuːto\n avrˈeːɪ portˈaːto ˌʊn maʎˈoːne pjˌʊ kˈaldo]",
-                "es": "[si lo uˈβjeɾa saˈβiðo, aˈβɾia tɾaˈiðo un ˈxeɾsei mas aβɾiˈɣaðo]",
-                "nl": "[ɑls ɪk hət hˈɑt ɣəʋˈeːtən\n hˈɑt ɪk ən ʋˈɑrmərə trˈœy mˈeːɣənˌoːmən]",
-                "pt": "[sj eʊ sˌowbˈɛsy\n tˌeɾˈiæ trˌazˈidw ũŋ kˌazˈakʊ mˈaɪs kˈeɪŋtʃy]",
-                "en": "[ɪf aɪ hɐd nˈəʊn aɪ wʊdhɐv bɹˈɔːt ɐ wˈɔːmə swˈɛtə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-004",
-            "text": {
-                "fr": "Nous devrions peut-être faire demi-tour.",
-                "en": "Maybe we should turn back.",
-                "de": "Vielleicht sollten wir umkehren.",
-                "it": "Forse dovremmo tornare indietro.",
-                "es": "Quizás deberíamos dar la vuelta.",
-                "nl": "Misschien moeten we terugkeren.",
-                "pt": "Talvez a gente devesse voltar."
-            },
-            "ipa": {
-                "fr": "nu dəvʁiˈɔ̃ pˈøtˈɛtʁ fˈɛʁ dəmˈitˈuʁ",
-                "de": "[fiˈlaɪ̯çt ˈzɔldən viːɐ̯ ˈʊmkɛːʁən]",
-                "it": "[fˈoːrse dovrˈɛmmo tornˈaːre indjˈɛːtro]",
-                "es": "[kiˈθas deβeˈɾiamos ðaɾ la ˈβwelta]",
-                "nl": "[mɪsxˈin mˈutən ʋə tərˈɵxkˌɪːrən]",
-                "pt": "[taʊvˈez a ʒˈeɪŋtʃy dˌevˈesy vowtˈar]",
-                "en": "[mˈeɪbiː wiː ʃˌʊd tˈɜːn bˈak]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-005",
-            "text": {
-                "fr": "Non, le refuge n'est pas loin. Regarde la carte.",
-                "en": "No, the shelter is not far. Look at the map.",
-                "de": "Nein, die Schutzhütte ist nicht weit. Schau auf die Karte.",
-                "it": "No, il rifugio non è lontano. Guarda la mappa.",
-                "es": "No, el refugio no está lejos. Mira el mapa.",
-                "nl": "Nee, de schuilplaats is niet ver. Kijk op de kaart.",
-                "pt": "Não, o refúgio não está longe.",
-                "en_pt": "No, the refuge isn't far."
-            },
-            "ipa": {
-                "fr": "nˈɔ̃ lə- ʁəfˈyʒ nɛ pa lwˈɛ̃ ʁəɡˈaʁd la- kˈaʁt",
-                "de": "[naɪ̯n, diː ˈʃʊtst͡sʏtə ɪst nɪçt vaɪ̯t. ʃaʊ̯ aʊ̯f diː ˈkaʁtə]",
-                "it": "[nˈɔ\n ˌil rifˈuːdʒo nˌon ˌɛ lontˈaːno\n ɡwˈaːrda lˌa mˈapːa]",
-                "es": "[no, el reˈfuχjo no esˈta ˈlexos. ˈmiɾa el ˈmapa]",
-                "nl": "[nˈeː\n də sxœylplˈaːts ɪs nˌit vˈɛr\n kˈɛɪk ɔp də kˈaːrt]",
-                "pt": "[nˈɐ̃ʊ̃\n ʊ xˌefˈuʒjʊ nˌɐ̃ʊ̃ estˌa lˈoŋʒy]",
-                "en": "[nˈəʊ ðə ʃˈɛltəɹ ɪz nˌɒt fˈɑː lˈʊk at ðə mˈap]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-006",
-            "text": {
-                "fr": "Tu es trop optimiste parfois!",
-                "en": "You are too optimistic sometimes!",
-                "de": "Du bist manchmal zu optimistisch!",
-                "it": "Sei troppo ottimista a volte!",
-                "es": "¡A veces eres demasiado optimista!",
-                "nl": "Je bent soms te optimistisch!",
-                "pt": "Você é otimista demais às vezes!",
-                "en_pt": "You're too optimistic sometimes!"
-            },
-            "ipa": {
-                "fr": "ty ɛ tʁop ɔptimˈist paʁfwˈa",
-                "de": "[duː bɪst ˈmançmaːl t͡suː optimɪsˈtɪʃ]",
-                "it": "[sˌɛj trˈɔpːo ˌotːimˈista ˌa vˈɔlte]",
-                "es": "[a ˈβeθes ˈeɾes ðemaˈsjaðo optiˈmista]",
-                "nl": "[jə bɛnt sˈɔms tə ˈɔptimˌɪstis]",
-                "pt": "[vosˌe ɛ ˌotʃimˈistæ demˈaɪz aːz vˈezys]",
-                "en": "[juː ɑː tˈuː ˌɒptɪmˈɪstɪk sˈʌmtaɪmz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-007",
-            "text": {
-                "fr": "Et toi, tu t'inquiètes toujours trop.",
-                "en": "And you, you always worry too much.",
-                "de": "Und du machst dir immer zu viele Sorgen.",
-                "it": "E tu, ti preoccupi sempre troppo.",
-                "es": "Y tú, siempre te preocupas demasiado.",
-                "nl": "En jij maakt je altijd te veel zorgen.",
-                "pt": "E você sempre se preocupa demais.",
-                "en_pt": "And you always worry too much."
-            },
-            "ipa": {
-                "fr": "e twˈa ty tɛ̃kjˈɛt tuʒˌuʁ tʁˈo",
-                "de": "[ʊnt duː maxst diːɐ̯ ˈɪmɐ t͡suː ˈfiːlə ˈzɔʁɡən]",
-                "it": "[ˌe tˈu\n tˌɪ preˈokːʊpɪ sˈɛmpre trˈɔpːo]",
-                "es": "[i ˈtu, ˈsjempɾe te pɾeokuˈpas ðemaˈsjaðo]",
-                "nl": "[ɛn jɛɪ mˈaːkt jə ˈɑltɛɪd tə vˈeːl zˈɔrɣən]",
-                "pt": "[i vosˌe sˌeɪmpry sy prˌeokˈupæ demˈaɪs]",
-                "en": "[and jˈuː juː ˈɔːlweɪz wˈʌɹi tˈuː mʌtʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-008",
-            "text": {
-                "fr": "Ce n'est pas le moment de se disputer.",
-                "en": "This is not the time to argue.",
-                "de": "Jetzt ist nicht die Zeit zu streiten.",
-                "it": "Non è il momento di litigare.",
-                "es": "Ahora no es momento de discutir.",
-                "nl": "Dit is niet het moment om te ruziën.",
-                "pt": "Não é hora de brigar.",
-                "en_pt": "This is no time to argue."
-            },
-            "ipa": {
-                "fr": "sə- nɛ pa lə- mɔmˈɑ̃ də- sə- dispytˈe",
-                "de": "[jɛt͡st ɪst nɪçt diː t͡saɪ̯t t͡suː ˈʃtʁaɪ̯tən]",
-                "it": "[nˌon ˌɛ ˌil momˈento dˌɪ lˌitiɡˈaːre]",
-                "es": "[aˈoɾa no es moˈmento ðe ðiskuˈtiɾ]",
-                "nl": "[dɪt ɪs nˌit hət moːmˈɛnt ɔm tə ryzˈiən]",
-                "pt": "[nˌɐ̃ʊ̃ ɛ ˈɔɾæ dʒy briɡˈar]",
-                "en": "[ðɪs ɪz nˌɒt ðə tˈaɪm tʊ ˈɑːɡjuː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-009",
-            "text": {
-                "fr": "Je suis désolé, j'ai juste peur.",
-                "en": "I'm sorry, I'm just scared.",
-                "de": "Es tut mir leid, ich habe nur Angst.",
-                "it": "Mi dispiace, ho solo paura.",
-                "es": "Lo siento, es que tengo miedo.",
-                "nl": "Sorry, ik ben gewoon bang.",
-                "pt": "Desculpa, estou com medo.",
-                "en_pt": "Sorry, I'm scared."
-            },
-            "ipa": {
-                "fr": "ʒə- syˌi dezɔlˈe ʒe ʒˈyst pˈœʁ",
-                "de": "[ɛs tuːt miːɐ̯ laɪ̯t, ɪç haːbə nuːɐ̯ ˈaŋst]",
-                "it": "[mˌɪ dˌispiˈaːtʃe\n ˌo sˈoːlo paˈuːra]",
-                "es": "[lo ˈsjento, es ke ˈteŋɡo ˈmjeðo]",
-                "nl": "[sˈɔɾri\n ɪk bɛn ɣəʋˈoːn bˈɑŋ]",
-                "pt": "[dˌeskˈuwpæ\n estˌow koŋ mˈedʊ]",
-                "en": "[aɪm sˈɒɹi aɪm dʒˈʌst skˈeəd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-010",
-            "text": {
-                "fr": "Moi aussi, mais il faut continuer",
-                "en": "Me too, but we must keep going",
-                "de": "Ich auch, aber wir müssen weitermachen",
-                "it": "Anche io, ma dobbiamo andare avanti",
-                "es": "Yo también, pero tenemos que seguir",
-                "nl": "Ik ook, maar we moeten doorgaan",
-                "pt": "Eu também, mas temos que continuar.",
-                "en_pt": "Me too, but we have to keep going."
-            },
-            "ipa": {
-                "fr": "mwˌa osˈi mɛz il fo kɔ̃tinyˈe",
-                "de": "[ɪç aʊ̯x, ˈabɐ viːɐ̯ ˈmʏsn̩ ˈvaɪ̯tɐmaxən]",
-                "it": "[ˈanke ˈio\n mˌa dobːjˈaːmo andˈaːre avˈantɪ]",
-                "es": "[ʝo tamˈbjen, ˈpeɾo teˈnemos ke seˈɣiɾ]",
-                "nl": "[ɪk ˈoːk\n maːr ʋə mˈutən dɔːrɣˈaːn]",
-                "pt": "[eʊ tɐ̃mbˈeɪŋ\n mas tˌemʊs ky kˌoŋtʃinuˈar]",
-                "en": "[mˌiː tˈuː bˌʌt wiː mˈʌst kˈiːp ɡˈəʊɪŋ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-011",
-            "text": {
-                "fr": "On ne peut pas rester ici.",
-                "en": "We can't stay here.",
-                "de": "Wir können hier nicht bleiben.",
-                "it": "Non possiamo restare qui.",
-                "es": "No podemos quedarnos aquí.",
-                "nl": "We kunnen hier niet blijven.",
-                "pt": "Não podemos ficar aqui."
-            },
-            "ipa": {
-                "fr": "ɔ̃ nə- pˈø pa ʁɛstˈe isˈi",
-                "de": "[viːɐ̯ ˈkœnən hiːɐ̯ nɪçt ˈblaɪ̯bən]",
-                "it": "[nˌon possjˈaːmo restˈaːre kwˈi]",
-                "es": "[no poˈðemos keˈðaɾnos aˈki]",
-                "nl": "[ʋə kˌɵnən hˈir nˌit blˈɛɪvən]",
-                "pt": "[nˌɐ̃ʊ̃ podˌemʊs fikˈaɾ akˈi]",
-                "en": "[wiː kˈɑːnt stˈeɪ hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-012",
-            "text": {
-                "fr": "Le brouillard devient très épais.",
-                "en": "The fog is getting very thick.",
-                "de": "Der Nebel wird sehr dicht.",
-                "it": "La nebbia si sta addensando molto.",
-                "es": "La niebla se está haciendo muy densa.",
-                "nl": "De mist wordt erg dik.",
-                "pt": "A neblina está ficando muito densa."
-            },
-            "ipa": {
-                "fr": "lə- bʁujˈaʁ dəvjˈɛ̃ tʁɛz epˈɛ",
-                "de": "[deːɐ̯ ˈneːbəl vɪʁt zeːɐ̯ ˈdɪçt]",
-                "it": "[lˌa nˈebːia sˌɪ stˈa ˌadːensˈando mˈolto]",
-                "es": "[la ˈnjeβla se esˈta aˈθjendo ˈmuj ˈðensa]",
-                "nl": "[də mˈɪst ʋɔrt ˈɛrx dˈɪk]",
-                "pt": "[a nˌeblˈinæ estˌa fˌikˈɐ̃ŋdʊ mwˈiŋtʊ dˈeɪŋsæ]",
-                "en": "[ðə fˈɒɡ ɪz ɡˌɛtɪŋ vˈɛɹɪ θˈɪk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-013",
-            "text": {
-                "fr": "Je ne vois presque plus le sentier.",
-                "en": "I can hardly see the trail anymore.",
-                "de": "Ich sehe den Weg fast nicht mehr.",
-                "it": "Vedo a malapena il sentiero.",
-                "es": "Casi no veo el camino.",
-                "nl": "Ik zie het pad bijna niet meer.",
-                "pt": "Quase não consigo ver a trilha.",
-                "en_pt": "I can barely see the trail."
-            },
-            "ipa": {
-                "fr": "ʒə- nə- vwˈa pʁˌɛskə ply lə- sɑ̃tjˈe",
-                "de": "[ɪç zeːə deːn veːk fast nɪçt meːɐ̯]",
-                "it": "[vˈeːdo ˌa mˌalapˈeːna ˌil sˌentiˈɛːro]",
-                "es": "[ˈkasi no ˈβeo el kaˈmino]",
-                "nl": "[ɪk zˈi hət pˈɑt bˈɛɪnˌaː nˈit mˌeːr]",
-                "pt": "[kwˈazy nˌɐ̃ʊ̃ kˌoŋsˈiɡʊ vˈeɾ a trˈiljæ]",
-                "en": "[aɪ kan hˈɑːdli sˈiː ðə tɹˈeɪl ˌɛnɪmˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-014",
-            "text": {
-                "fr": "Restons ensemble, ne nous séparons pas,",
-                "en": "Let's stay together, let's not separate,",
-                "de": "Bleiben wir zusammen, trennen wir uns nicht,",
-                "it": "Restiamo insieme, non separiamoci,",
-                "es": "Quedémonos juntos, no nos separemos,",
-                "nl": "Laten we bij elkaar blijven, laten we niet uit elkaar gaan,",
-                "pt": "Vamos ficar juntos, não nos separemos, insiste Sophie.",
-                "en_pt": "Let's stay together, let's not separate, Sophie insists."
-            },
-            "ipa": {
-                "fr": "ʁɛstˈɔ̃z ɑ̃sˈɑ̃bl nə- nu sepaʁˈɔ̃ pˈa",
-                "de": "[ˈblaɪ̯bən viːɐ̯ t͡suˈzamən, ˈtʁɛnən viːɐ̯ ʊns nɪçt]",
-                "it": "[restjˈaːmo insjˈɛːme\n nˌon sˌepariˈamotʃɪ]",
-                "es": "[keˈðemonos ˈxuntos, no nos sepaˈɾemos]",
-                "nl": "[lˈaːtən ʋə bɛɪ ˈɛlkaːr blˈɛɪvən\n lˈaːtən ʋə nˌit œyt ˈɛlkaːr ɣˈaːn]",
-                "pt": "[vˌɐ̃mʊs fikˈar ʒˈũŋtʊs\n nˌɐ̃ʊ̃ nʊs sˌepaɾˈemʊs\n ˌiŋsˈistʃy sˌofˈiy]",
-                "en": "[lˈɛts stˈeɪ təɡˈɛðə lˈɛts nˌɒt sˈɛpɹət]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-015",
-            "text": {
-                "fr": "Attends, j'ai perdu mon sac! Il était juste là!",
-                "en": "Wait, I have lost my bag! It was right here!",
-                "de": "Warte, ich habe meinen Rucksack verloren! Er war gerade hier!",
-                "it": "Aspetta, ho perso il mio zaino! Era proprio qui!",
-                "es": "Espera, ¡he perdido mi mochila! Estaba justo aquí.",
-                "nl": "Wacht, ik ben mijn tas kwijt! Hij was net hier!",
-                "pt": "Estava aqui!",
-                "en_pt": "It was right here!"
-            },
-            "ipa": {
-                "fr": "atˈɑ̃ ʒe pɛʁdˈy mɔ̃ sˈak il etˈɛ ʒˈyst lˈa",
-                "de": "[ˈvaʁtə, ɪç haːbə ˈmaɪ̯nən ˈʁʊksak fɛɐ̯ˈloːʁən! ɛɐ̯ vaːɐ̯ ɡəˈʁaːdə hiːɐ̯]",
-                "it": "[aspˈɛtːa\n ˌo pˈɛːrso ˌil mˌio dzˈaɪːno\n ˌɛra prˈɔprio kwˈi]",
-                "es": "[esˈpeɾa, e peɾˈðiðo mi moˈtʃila! esˈtaβa ˈxusto aˈki]",
-                "nl": "[ʋˈɑxt\n ɪk bɛn mɛɪn tˈɑs kʋˈɛɪt\n hɛɪ ʋˈɑs nˈɛt hˈir]",
-                "pt": "[estˌavæ akˈi]",
-                "en": "[wˈeɪt aɪ hav lˈɒst maɪ bˈaɡ ɪt wɒz ɹˈaɪt hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-016",
-            "text": {
-                "fr": "Je reviens le chercher, toi, continue! Suis le sentier!",
-                "en": "I'll go back to look for it, you continue! Follow the trail!",
-                "de": "Ich gehe ihn holen, du geh weiter! Folge dem Weg!",
-                "it": "Torno indietro a prenderlo, tu continua! Segui il sentiero!",
-                "es": "Voy a buscarla, tú sigue el camino.",
-                "nl": "Ik ga terug om hem te zoeken, jij gaat door! Volg het pad!",
-                "pt": "Vou voltar para procurar, você continua!",
-                "en_pt": "I'll go back to look for it, you keep going!"
-            },
-            "ipa": {
-                "fr": "ʒə- ʁəvjˈɛ̃ lə- ʃɛʁʃˈe twˈa kɔ̃tinˈy syˈi lə- sɑ̃tjˈe",
-                "de": "[ɪç ɡeːə ɪn ˈhoːlən, duː geː ˈvaɪ̯tɐ! ˈfɔlɡə deːm veːk]",
-                "it": "[tˈoːrno indjˈɛːtro ˌa prˈenderlo\n tˌʊ kontˈinʊa\n sˈeɡwɪ ˌil sˌentiˈɛːro]",
-                "es": "[boj a busˈkaɾla, ˈtu ˈsiɣe el kaˈmino]",
-                "nl": "[ɪk ɣˈaː tərˈɵx ɔm hˈɛm tə zˈukən\n jɛɪ ɣˈaː tˈoːr\n vˈɔlx hət pˈɑt]",
-                "pt": "[vow vowtˈar pˌaɾæ prˌokuɾˈar\n vosˌe kˌoŋtʃinˈuæ]",
-                "en": "[aɪl ɡˌəʊ bˈak tə lˈʊk fɔːɹ ɪt juː kəntˈɪnjuː fˈɒləʊ ðə tɹˈeɪl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-017",
-            "text": {
-                "fr": "Non, Lucas, attendons ensemble!",
-                "en": "No, Lucas, let's wait together!",
-                "de": "Nein, Lucas, warten wir zusammen!",
-                "it": "No, Lucas, aspettiamo insieme!",
-                "es": "No, Lucas, esperemos juntos.",
-                "nl": "Nee, Lucas, laten we samen wachten!",
-                "pt": "Não Lucas, vamos esperar juntos!",
-                "en_pt": "No Lucas, let's wait together!"
-            },
-            "ipa": {
-                "fr": "nˈɔ̃ lykˈa atɑ̃dˈɔ̃z ɑ̃sˈɑ̃bl",
-                "de": "[naɪ̯n, ˈluːkas, ˈvaʁtən viːɐ̯ t͡suˈzamən]",
-                "it": "[nˈɔ\n lˈuːkas\n ˌaspetːjˈaːmo insjˈɛːme]",
-                "es": "[no, ˈlukas, espeˈɾemos ˈxuntos]",
-                "nl": "[nˈeː\n lˈykɑs\n lˈaːtən ʋə sˈaːmən ʋˈɑxtən]",
-                "pt": "[nˌɐ̃ʊ̃ lˈukæs\n vˌɐ̃mʊz ˌespeɾˈar ʒˈũŋtʊs]",
-                "en": "[nˈəʊ lˈuːkəz lˈɛts wˈeɪt təɡˈɛðə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-018",
             "text": {
                 "fr": "Le lendemain matin, Sophie et Lucas commencent leur randonnée.",
                 "en": "The next morning, Sophie and Lucas start their hike.",
@@ -583,7 +60,7 @@
             }
         },
         {
-            "id": "scene-09-019",
+            "id": "scene-09-002",
             "text": {
                 "fr": "Le temps est beau, le ciel est bleu.",
                 "en": "The weather is nice, the sky is blue.",
@@ -613,10 +90,10 @@
             }
         },
         {
-            "id": "scene-09-020",
+            "id": "scene-09-003",
             "text": {
                 "fr": "Ils suivent un sentier qui monte vers un refuge de montagne.",
-                "en": "They follow a trail that goes up to a mountain hut.",
+                "en": "They follow a path that goes up to a mountain refuge.",
                 "de": "Sie folgen einem Weg, der zu einer Berghütte führt.",
                 "it": "Seguono un sentiero che sale verso un rifugio di montagna.",
                 "es": "Siguen un camino que sube hacia un refugio de montaña.",
@@ -631,7 +108,7 @@
                 "es": "[ˈsiɣen un kaˈmino ke ˈsuβe ˈaθja un reˈfuχjo de monˈtaɲa]",
                 "nl": "[zə vˈɔlɣən ən pˈɑd dɑt ɔmhˈoːx lˈoːpt naːr ən bərxhˈɵt]",
                 "pt": "[ˌelys sˈɛɡeɪŋ ˌumæ trˈiljæ ky sˈɔbj ˈeɪŋ dʒˌiɾesˈɐ̃ʊ̃ a ũŋ xˌefˈuʒjʊ na mˌoŋtˈɐ̃ɲæ]",
-                "en": "[ðeɪ fˈɒləʊ ɐ tɹˈeɪl ðat ɡəʊz ˌʌp tʊ ɐ mˈaʊntɪn hˈʌt]"
+                "en": "[ðeɪ fˈɒləʊ ɐ pˈaθ ðat ɡəʊz ˌʌp tʊ ɐ mˈaʊntɪn ɹˈɛfjuːdʒ]"
             },
             "provenance": {
                 "fr": "original",
@@ -644,22 +121,25 @@
             }
         },
         {
-            "id": "scene-09-021",
+            "id": "scene-09-004",
             "text": {
-                "fr": "racontera plus tard Sophie.",
-                "en": "Sophie will tell later.",
-                "de": "erzählt später Sophie.",
-                "it": "racconterà più tardi Sophie.",
-                "es": "lo contará más tarde Sophie.",
-                "nl": "zal Sophie later vertellen."
+                "fr": "Nous marchions depuis trois heures quand les nuages sont arrivés,",
+                "en": "We had been walking for three hours when the clouds arrived,",
+                "de": "Wir waren drei Stunden unterwegs, als die Wolken aufzogen,",
+                "it": "Camminavamo da tre ore quando sono arrivati i nuvoloni,",
+                "es": "Llevábamos tres horas caminando cuando llegaron las nubes,",
+                "nl": "We liepen al drie uur toen de wolken kwamen,",
+                "pt": "Estávamos caminhando há três horas quando as nuvens chegaram, contará Sophie mais tarde.",
+                "en_pt": "We had been walking for three hours when the clouds arrived, Sophie would later recount."
             },
             "ipa": {
-                "fr": "ʁakɔ̃tʁˈa ply tˈaʁ sɔfˈi",
-                "de": "[ɛɐ̯ˈt͡sɛlt ˈʃpɛːtɐ ˈzɔfiː]",
-                "it": "[rˌakːonterˈa pjˌʊ tˈaːrdɪ sˈopje]",
-                "es": "[lo konˈtaɾa mas ˈtaɾðe ˈsofi]",
-                "nl": "[zɑl sɔphˈi lˈaːtər vərtˈɛlən]",
-                "en": "[sˈəʊfi wɪl tˈɛl lˈeɪtə]"
+                "fr": "nu maʁʃjˈɔ̃ dəpyˌi tʁwˈaz ˈœʁ kɑ̃ le- nyˈaʒ sˈɔ̃t aʁivˈe",
+                "de": "[viːɐ̯ vaːʁən dʁaɪ̯ ˈʃtʊndən ˈʊntɐveːks, als diː ˈvɔlkən ˈaʊ̯ftsoːɡən,]",
+                "it": "[kˌamminavˈaːmo dˌa trˈe ˈoːre kwˈando sˌono ˌarɾivˈaːtɪ ˌɪ nˌʊvolˈoːnɪ]",
+                "es": "[ʎeˈβaβamos ˈtɾes ˈoɾas kamˈjando ˈkwando ʎeˈɣaɾon las ˈnubes]",
+                "nl": "[ʋə lˈipən ˈɑl drˈi ˈyr tˈun də ʋˈɔlkən kʋˈaːmən]",
+                "pt": "[estˌavæmʊs kˌæmiɲˈɐ̃ŋdw a trˈes ˈɔɾæs kwˈɐ̃ŋdw az nˈuveɪŋs ʃˌeɡˈaɾɐ̃ʊ̃\n kˌoŋtaɾˈa sˌofˈiy mˈaɪs tˈaɾədʒy]",
+                "en": "[wiː hɐdbɪn wˈɔːkɪŋ fɔː θɹˈiː ˈaʊəz wɛn ðə klˈaʊdz ɐɹˈaɪvd]"
             },
             "provenance": {
                 "fr": "original",
@@ -667,11 +147,12 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-09-022",
+            "id": "scene-09-005",
             "text": {
                 "fr": "Le changement est soudain.",
                 "en": "The change is sudden.",
@@ -701,7 +182,83 @@
             }
         },
         {
-            "id": "scene-09-023",
+            "id": "scene-09-006",
+            "text": {
+                "fr": "Il faisait de plus en plus froid.",
+                "en": "It was getting colder and colder.",
+                "de": "Es wurde immer kälter.",
+                "it": "Stava diventando sempre più freddo.",
+                "es": "Empezaba a hacer cada vez más frío.",
+                "nl": "Het werd steeds kouder.",
+                "pt": "Estava ficando cada vez mais frio."
+            },
+            "ipa": {
+                "fr": "il fəzˈɛ də- plyz ɑ̃ ply fʁwˈa",
+                "de": "[ɛs ˈvʊrdə ˈɪmɐ ˈkɛltɐ]",
+                "it": "[stˈaːva dˌiventˈando sˈɛmpre pjˌʊ frˈedːo]",
+                "es": "[empeˈθaβa a aˈθeɾ ˈkaða βeθ ˈmas ˈfɾio]",
+                "nl": "[hət ʋɛrt stˈeːts kˈʌʊdər]",
+                "pt": "[estˌavæ fˌikˈɐ̃ŋdʊ kˈadæ vˈez mˈaɪs frˈiʊ]",
+                "en": "[ɪt wɒz ɡˌɛtɪŋ kˈəʊldə and kˈəʊldə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-007",
+            "text": {
+                "pt": "Sophie treme.",
+                "en": "Sophie shivers."
+            },
+            "ipa": {
+                "pt": "[sˌofˈiy trˈemy]",
+                "en": "[sˈəʊfi ʃˈɪvəz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-008",
+            "text": {
+                "fr": "Si j'avais su, j'aurais apporté un pull plus chaud.",
+                "en": "If I had known, I would have brought a warmer sweater.",
+                "de": "Hätte ich das gewusst, hätte ich einen wärmeren Pullover mitgebracht.",
+                "it": "Se l'avessi saputo, avrei portato un maglione più caldo.",
+                "es": "Si lo hubiera sabido, habría traído un jersey más abrigado.",
+                "nl": "Als ik het had geweten, had ik een warmere trui meegenomen.",
+                "pt": "Se eu soubesse, teria trazido um casaco mais quente.",
+                "en_pt": "If I had known, I would have brought a warmer jacket."
+            },
+            "ipa": {
+                "fr": "sˈi ʒavˈɛ sˈy ʒoʁˈɛz apɔʁtˈe œ̃pˈul ply ʃˈo",
+                "de": "[ˈhɛtə ɪç das ɡəˈvʊst, ˈhɛtə ɪç ˈaɪ̯nən ˈvɛrməʁən ˈpʊlovɐ ˈmɪtɡəbʁaxt]",
+                "it": "[sˌe lavˌɛssɪ sapˈuːto\n avrˈeːɪ portˈaːto ˌʊn maʎˈoːne pjˌʊ kˈaldo]",
+                "es": "[si lo uˈβjeɾa saˈβiðo, aˈβɾia tɾaˈiðo un ˈxeɾsei mas aβɾiˈɣaðo]",
+                "nl": "[ɑls ɪk hət hˈɑt ɣəʋˈeːtən\n hˈɑt ɪk ən ʋˈɑrmərə trˈœy mˈeːɣənˌoːmən]",
+                "pt": "[sj eʊ sˌowbˈɛsy\n tˌeɾˈiæ trˌazˈidw ũŋ kˌazˈakʊ mˈaɪs kˈeɪŋtʃy]",
+                "en": "[ɪf aɪ hɐd nˈəʊn aɪ wʊdhɐv bɹˈɔːt ɐ wˈɔːmə swˈɛtə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-009",
             "text": {
                 "fr": "Lucas regarde le ciel menaçant.",
                 "en": "Lucas looks at the threatening sky.",
@@ -731,10 +288,118 @@
             }
         },
         {
-            "id": "scene-09-024",
+            "id": "scene-09-010",
+            "text": {
+                "fr": "Nous devrions peut-être faire demi-tour.",
+                "en": "We should maybe turn back.",
+                "de": "Vielleicht sollten wir umkehren.",
+                "it": "Forse dovremmo tornare indietro.",
+                "es": "Quizás deberíamos dar la vuelta.",
+                "nl": "Misschien moeten we terugkeren.",
+                "pt": "Talvez a gente devesse voltar.",
+                "en_pt": "Maybe we should turn back."
+            },
+            "ipa": {
+                "fr": "nu dəvʁiˈɔ̃ pˈøtˈɛtʁ fˈɛʁ dəmˈitˈuʁ",
+                "de": "[fiˈlaɪ̯çt ˈzɔldən viːɐ̯ ˈʊmkɛːʁən]",
+                "it": "[fˈoːrse dovrˈɛmmo tornˈaːre indjˈɛːtro]",
+                "es": "[kiˈθas deβeˈɾiamos ðaɾ la ˈβwelta]",
+                "nl": "[mɪsxˈin mˈutən ʋə tərˈɵxkˌɪːrən]",
+                "pt": "[taʊvˈez a ʒˈeɪŋtʃy dˌevˈesy vowtˈar]",
+                "en": "[wiː ʃˌʊd mˈeɪbiː tˈɜːn bˈak]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-011",
+            "text": {
+                "fr": "Non, le refuge n'est pas loin. Regarde la carte.",
+                "en": "No, the refuge is not far. Look at the map.",
+                "de": "Nein, die Schutzhütte ist nicht weit. Schau auf die Karte.",
+                "it": "No, il rifugio non è lontano. Guarda la mappa.",
+                "es": "No, el refugio no está lejos. Mira el mapa.",
+                "nl": "Nee, de schuilplaats is niet ver. Kijk op de kaart.",
+                "pt": "Não, o refúgio não está longe.",
+                "en_pt": "No, the refuge isn't far."
+            },
+            "ipa": {
+                "fr": "nˈɔ̃ lə- ʁəfˈyʒ nɛ pa lwˈɛ̃ ʁəɡˈaʁd la- kˈaʁt",
+                "de": "[naɪ̯n, diː ˈʃʊtst͡sʏtə ɪst nɪçt vaɪ̯t. ʃaʊ̯ aʊ̯f diː ˈkaʁtə]",
+                "it": "[nˈɔ\n ˌil rifˈuːdʒo nˌon ˌɛ lontˈaːno\n ɡwˈaːrda lˌa mˈapːa]",
+                "es": "[no, el reˈfuχjo no esˈta ˈlexos. ˈmiɾa el ˈmapa]",
+                "nl": "[nˈeː\n də sxœylplˈaːts ɪs nˌit vˈɛr\n kˈɛɪk ɔp də kˈaːrt]",
+                "pt": "[nˈɐ̃ʊ̃\n ʊ xˌefˈuʒjʊ nˌɐ̃ʊ̃ estˌa lˈoŋʒy]",
+                "en": "[nˈəʊ ðə ɹˈɛfjuːdʒ ɪz nˌɒt fˈɑː lˈʊk at ðə mˈap]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-012",
+            "text": {
+                "pt": "Olha o mapa.",
+                "en": "Look at the map."
+            },
+            "ipa": {
+                "pt": "[ˈɔljæ ʊ mˈapæ]",
+                "en": "[lˈʊk at ðə mˈap]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-013",
+            "text": {
+                "fr": "Tu es trop optimiste parfois!",
+                "en": "You are too optimistic sometimes!",
+                "de": "Du bist manchmal zu optimistisch!",
+                "it": "Sei troppo ottimista a volte!",
+                "es": "¡A veces eres demasiado optimista!",
+                "nl": "Je bent soms te optimistisch!",
+                "pt": "Você é otimista demais às vezes!",
+                "en_pt": "You're too optimistic sometimes!"
+            },
+            "ipa": {
+                "fr": "ty ɛ tʁop ɔptimˈist paʁfwˈa",
+                "de": "[duː bɪst ˈmançmaːl t͡suː optimɪsˈtɪʃ]",
+                "it": "[sˌɛj trˈɔpːo ˌotːimˈista ˌa vˈɔlte]",
+                "es": "[a ˈβeθes ˈeɾes ðemaˈsjaðo optiˈmista]",
+                "nl": "[jə bɛnt sˈɔms tə ˈɔptimˌɪstis]",
+                "pt": "[vosˌe ɛ ˌotʃimˈistæ demˈaɪz aːz vˈezys]",
+                "en": "[juː ɑː tˈuː ˌɒptɪmˈɪstɪk sˈʌmtaɪmz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-014",
             "text": {
                 "fr": "dit Sophie, la voix tendue.",
-                "en": "says Sophie, in a tense voice.",
+                "en": "says Sophie, la voix tendue.",
                 "de": "sagt Sophie, ihre Stimme angespannt.",
                 "it": "dice Sophie, con la voce tesa.",
                 "es": "dice Sophie, con la voz tensa.",
@@ -749,7 +414,7 @@
                 "es": "[ˈdiθe ˈsofi, kon la βoθ ˈtensa]",
                 "nl": "[zˈɛxt sɔphˈi\n mɛt ən ɣəspˈɑnən stˈɛm]",
                 "pt": "[dʒˈis sˌofˈiy\n a vˈɔs tˈeɪŋsæ]",
-                "en": "[sˈɛz sˈəʊfi ɪn ɐ tˈɛns vˈɔɪs]"
+                "en": "[sˈɛz sˈəʊfi lˌa vwˈa tˈɛndjuː]"
             },
             "provenance": {
                 "fr": "original",
@@ -762,10 +427,41 @@
             }
         },
         {
-            "id": "scene-09-025",
+            "id": "scene-09-015",
+            "text": {
+                "fr": "Et toi, tu t'inquiètes toujours trop.",
+                "en": "And you, you are always too worried.",
+                "de": "Und du machst dir immer zu viele Sorgen.",
+                "it": "E tu, ti preoccupi sempre troppo.",
+                "es": "Y tú, siempre te preocupas demasiado.",
+                "nl": "En jij maakt je altijd te veel zorgen.",
+                "pt": "E você sempre se preocupa demais.",
+                "en_pt": "And you always worry too much."
+            },
+            "ipa": {
+                "fr": "e twˈa ty tɛ̃kjˈɛt tuʒˌuʁ tʁˈo",
+                "de": "[ʊnt duː maxst diːɐ̯ ˈɪmɐ t͡suː ˈfiːlə ˈzɔʁɡən]",
+                "it": "[ˌe tˈu\n tˌɪ preˈokːʊpɪ sˈɛmpre trˈɔpːo]",
+                "es": "[i ˈtu, ˈsjempɾe te pɾeokuˈpas ðemaˈsjaðo]",
+                "nl": "[ɛn jɛɪ mˈaːkt jə ˈɑltɛɪd tə vˈeːl zˈɔrɣən]",
+                "pt": "[i vosˌe sˌeɪmpry sy prˌeokˈupæ demˈaɪs]",
+                "en": "[and jˈuː juː ɑːɹ ˈɔːlweɪz tˈuː wˈʌɹɪd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-016",
             "text": {
                 "fr": "Sophie s'arrête brusquement.",
-                "en": "Sophie suddenly stops.",
+                "en": "Sophie stops suddenly.",
                 "de": "Sophie bleibt plötzlich stehen.",
                 "it": "Sophie si ferma di colpo.",
                 "es": "Sophie se detiene de repente.",
@@ -780,7 +476,7 @@
                 "es": "[ˈsofi se ðeˈtjene ðe reˈpente]",
                 "nl": "[sɔphˈi stˈɔpt plˈɔtsəlˌɪŋ]",
                 "pt": "[sˌofˈiy pˌaɾæ brˌuskæmˈeɪŋtʃy]",
-                "en": "[sˈəʊfi sˈʌdənli stˈɒps]"
+                "en": "[sˈəʊfi stˈɒps sˈʌdənli]"
             },
             "provenance": {
                 "fr": "original",
@@ -793,7 +489,144 @@
             }
         },
         {
-            "id": "scene-09-026",
+            "id": "scene-09-017",
+            "text": {
+                "fr": "Ce n'est pas le moment de se disputer.",
+                "en": "This is not the time to argue.",
+                "de": "Jetzt ist nicht die Zeit zu streiten.",
+                "it": "Non è il momento di litigare.",
+                "es": "Ahora no es momento de discutir.",
+                "nl": "Dit is niet het moment om te ruziën.",
+                "pt": "Não é hora de brigar.",
+                "en_pt": "This is no time to argue."
+            },
+            "ipa": {
+                "fr": "sə- nɛ pa lə- mɔmˈɑ̃ də- sə- dispytˈe",
+                "de": "[jɛt͡st ɪst nɪçt diː t͡saɪ̯t t͡suː ˈʃtʁaɪ̯tən]",
+                "it": "[nˌon ˌɛ ˌil momˈento dˌɪ lˌitiɡˈaːre]",
+                "es": "[aˈoɾa no es moˈmento ðe ðiskuˈtiɾ]",
+                "nl": "[dɪt ɪs nˌit hət moːmˈɛnt ɔm tə ryzˈiən]",
+                "pt": "[nˌɐ̃ʊ̃ ɛ ˈɔɾæ dʒy briɡˈar]",
+                "en": "[ðɪs ɪz nˌɒt ðə tˈaɪm tʊ ˈɑːɡjuː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-018",
+            "text": {
+                "pt": "Lucas pega a mão dela.",
+                "en": "Lucas takes her hand."
+            },
+            "ipa": {
+                "pt": "[lˈukæs pˈɛɡæ a mˈɐ̃ʊ̃ dˈɛlæ]",
+                "en": "[lˈuːkəz tˈeɪks hɜː hˈand]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-019",
+            "text": {
+                "fr": "Je suis désolé, j'ai juste peur.",
+                "en": "I'm sorry, I'm just scared.",
+                "de": "Es tut mir leid, ich habe nur Angst.",
+                "it": "Mi dispiace, ho solo paura.",
+                "es": "Lo siento, es que tengo miedo.",
+                "nl": "Sorry, ik ben gewoon bang.",
+                "pt": "Desculpa, estou com medo.",
+                "en_pt": "Sorry, I'm scared."
+            },
+            "ipa": {
+                "fr": "ʒə- syˌi dezɔlˈe ʒe ʒˈyst pˈœʁ",
+                "de": "[ɛs tuːt miːɐ̯ laɪ̯t, ɪç haːbə nuːɐ̯ ˈaŋst]",
+                "it": "[mˌɪ dˌispiˈaːtʃe\n ˌo sˈoːlo paˈuːra]",
+                "es": "[lo ˈsjento, es ke ˈteŋɡo ˈmjeðo]",
+                "nl": "[sˈɔɾri\n ɪk bɛn ɣəʋˈoːn bˈɑŋ]",
+                "pt": "[dˌeskˈuwpæ\n estˌow koŋ mˈedʊ]",
+                "en": "[aɪm sˈɒɹi aɪm dʒˈʌst skˈeəd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-020",
+            "text": {
+                "fr": "Moi aussi, mais il faut continuer",
+                "en": "Me too, but we have to keep going.",
+                "de": "Ich auch, aber wir müssen weitermachen",
+                "it": "Anche io, ma dobbiamo andare avanti",
+                "es": "Yo también, pero tenemos que seguir",
+                "nl": "Ik ook, maar we moeten doorgaan",
+                "pt": "Eu também, mas temos que continuar."
+            },
+            "ipa": {
+                "fr": "mwˌa osˈi mɛz il fo kɔ̃tinyˈe",
+                "de": "[ɪç aʊ̯x, ˈabɐ viːɐ̯ ˈmʏsn̩ ˈvaɪ̯tɐmaxən]",
+                "it": "[ˈanke ˈio\n mˌa dobːjˈaːmo andˈaːre avˈantɪ]",
+                "es": "[ʝo tamˈbjen, ˈpeɾo teˈnemos ke seˈɣiɾ]",
+                "nl": "[ɪk ˈoːk\n maːr ʋə mˈutən dɔːrɣˈaːn]",
+                "pt": "[eʊ tɐ̃mbˈeɪŋ\n mas tˌemʊs ky kˌoŋtʃinuˈar]",
+                "en": "[mˌiː tˈuː bˌʌt wiː hav tə kˈiːp ɡˈəʊɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-021",
+            "text": {
+                "fr": "On ne peut pas rester ici.",
+                "en": "We can't stay here.",
+                "de": "Wir können hier nicht bleiben.",
+                "it": "Non possiamo restare qui.",
+                "es": "No podemos quedarnos aquí.",
+                "nl": "We kunnen hier niet blijven.",
+                "pt": "Não podemos ficar aqui."
+            },
+            "ipa": {
+                "fr": "ɔ̃ nə- pˈø pa ʁɛstˈe isˈi",
+                "de": "[viːɐ̯ ˈkœnən hiːɐ̯ nɪçt ˈblaɪ̯bən]",
+                "it": "[nˌon possjˈaːmo restˈaːre kwˈi]",
+                "es": "[no poˈðemos keˈðaɾnos aˈki]",
+                "nl": "[ʋə kˌɵnən hˈir nˌit blˈɛɪvən]",
+                "pt": "[nˌɐ̃ʊ̃ podˌemʊs fikˈaɾ akˈi]",
+                "en": "[wiː kˈɑːnt stˈeɪ hˈiə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-022",
             "text": {
                 "fr": "Le brouillard commence à descendre de la montagne.",
                 "en": "The fog begins to descend from the mountain.",
@@ -823,10 +656,40 @@
             }
         },
         {
-            "id": "scene-09-027",
+            "id": "scene-09-023",
+            "text": {
+                "fr": "Le brouillard devient très épais.",
+                "en": "The fog is getting very thick.",
+                "de": "Der Nebel wird sehr dicht.",
+                "it": "La nebbia si sta addensando molto.",
+                "es": "La niebla se está haciendo muy densa.",
+                "nl": "De mist wordt erg dik.",
+                "pt": "A neblina está ficando muito densa."
+            },
+            "ipa": {
+                "fr": "lə- bʁujˈaʁ dəvjˈɛ̃ tʁɛz epˈɛ",
+                "de": "[deːɐ̯ ˈneːbəl vɪʁt zeːɐ̯ ˈdɪçt]",
+                "it": "[lˌa nˈebːia sˌɪ stˈa ˌadːensˈando mˈolto]",
+                "es": "[la ˈnjeβla se esˈta aˈθjendo ˈmuj ˈðensa]",
+                "nl": "[də mˈɪst ʋɔrt ˈɛrx dˈɪk]",
+                "pt": "[a nˌeblˈinæ estˌa fˌikˈɐ̃ŋdʊ mwˈiŋtʊ dˈeɪŋsæ]",
+                "en": "[ðə fˈɒɡ ɪz ɡˌɛtɪŋ vˈɛɹɪ θˈɪk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-024",
             "text": {
                 "fr": "Lucas avance prudemment.",
-                "en": "Lucas proceeds cautiously.",
+                "en": "Lucas moves forward cautiously.",
                 "de": "Lucas geht vorsichtig voran.",
                 "it": "Lucas avanza con cautela.",
                 "es": "Lucas avanza con cuidado.",
@@ -841,7 +704,7 @@
                 "es": "[ˈlukas aˈβanθa kon kwiˈðaðo]",
                 "nl": "[lˈykɑs ɣˈaːt vˌɔːrzˈɪxtəx vˈɛrdər]",
                 "pt": "[lˈukæz ˌavˈɐ̃ŋsæ koŋ kˌuɪdˈadʊ]",
-                "en": "[lˈuːkəz pɹˈəʊsiːdz kˈɔːʃəsli]"
+                "en": "[lˈuːkəz mˈuːvz fˈɔːwəd kˈɔːʃəsli]"
             },
             "provenance": {
                 "fr": "original",
@@ -854,7 +717,69 @@
             }
         },
         {
-            "id": "scene-09-028",
+            "id": "scene-09-025",
+            "text": {
+                "fr": "Je ne vois presque plus le sentier.",
+                "en": "I can hardly see the path anymore.",
+                "de": "Ich sehe den Weg fast nicht mehr.",
+                "it": "Vedo a malapena il sentiero.",
+                "es": "Casi no veo el camino.",
+                "nl": "Ik zie het pad bijna niet meer.",
+                "pt": "Quase não consigo ver a trilha.",
+                "en_pt": "I can barely see the trail."
+            },
+            "ipa": {
+                "fr": "ʒə- nə- vwˈa pʁˌɛskə ply lə- sɑ̃tjˈe",
+                "de": "[ɪç zeːə deːn veːk fast nɪçt meːɐ̯]",
+                "it": "[vˈeːdo ˌa mˌalapˈeːna ˌil sˌentiˈɛːro]",
+                "es": "[ˈkasi no ˈβeo el kaˈmino]",
+                "nl": "[ɪk zˈi hət pˈɑt bˈɛɪnˌaː nˈit mˌeːr]",
+                "pt": "[kwˈazy nˌɐ̃ʊ̃ kˌoŋsˈiɡʊ vˈeɾ a trˈiljæ]",
+                "en": "[aɪ kan hˈɑːdli sˈiː ðə pˈaθ ˌɛnɪmˈɔː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-026",
+            "text": {
+                "fr": "Restons ensemble, ne nous séparons pas,",
+                "en": "Let's stay together, let's not separate,",
+                "de": "Bleiben wir zusammen, trennen wir uns nicht,",
+                "it": "Restiamo insieme, non separiamoci,",
+                "es": "Quedémonos juntos, no nos separemos,",
+                "nl": "Laten we bij elkaar blijven, laten we niet uit elkaar gaan,",
+                "pt": "Vamos ficar juntos, não nos separemos, insiste Sophie.",
+                "en_pt": "Let's stay together, let's not separate, Sophie insists."
+            },
+            "ipa": {
+                "fr": "ʁɛstˈɔ̃z ɑ̃sˈɑ̃bl nə- nu sepaʁˈɔ̃ pˈa",
+                "de": "[ˈblaɪ̯bən viːɐ̯ t͡suˈzamən, ˈtʁɛnən viːɐ̯ ʊns nɪçt]",
+                "it": "[restjˈaːmo insjˈɛːme\n nˌon sˌepariˈamotʃɪ]",
+                "es": "[keˈðemonos ˈxuntos, no nos sepaˈɾemos]",
+                "nl": "[lˈaːtən ʋə bɛɪ ˈɛlkaːr blˈɛɪvən\n lˈaːtən ʋə nˌit œyt ˈɛlkaːr ɣˈaːn]",
+                "pt": "[vˌɐ̃mʊs fikˈar ʒˈũŋtʊs\n nˌɐ̃ʊ̃ nʊs sˌepaɾˈemʊs\n ˌiŋsˈistʃy sˌofˈiy]",
+                "en": "[lˈɛts stˈeɪ təɡˈɛðə lˈɛts nˌɒt sˈɛpɹət]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-027",
             "text": {
                 "fr": "Soudain, Sophie s'arrête.",
                 "en": "Suddenly, Sophie stops.",
@@ -884,83 +809,7 @@
             }
         },
         {
-            "id": "scene-09-029",
-            "text": {
-                "fr": "Mais Lucas est déjà parti dans le brouillard.",
-                "en": "But Lucas has already gone into the fog.",
-                "de": "Aber Lucas ist schon im Nebel verschwunden.",
-                "it": "Ma Lucas è già partito nella nebbia.",
-                "es": "Pero Lucas ya se ha ido en la niebla.",
-                "nl": "Maar Lucas is al verdwenen in de mist.",
-                "pt": "Mas Lucas já foi embora na neblina.",
-                "en_pt": "But Lucas has already disappeared into the fog."
-            },
-            "ipa": {
-                "fr": "mɛ lykˈaz ɛ deʒˈa paʁtˈi dɑ̃ lə- bʁujˈaʁ",
-                "de": "[ˈabɐ ˈluːkas ɪst ʃoːn ɪm ˈneːbəl fɛɐ̯ˈʃvʊndən]",
-                "it": "[mˌa lˈuːkas ˌɛ dʒˈa partˈiːto nˌɛlla nˈebːia]",
-                "es": "[ˈpeɾo ˈlukas ʝa se a iˈðo en la ˈnjeβla]",
-                "nl": "[maːr lˈykɑs ɪs ˈɑl vərdʋˈeːnən ɪn də mˈɪst]",
-                "pt": "[maz lˈukæz ʒˈa foɪ ˌeɪmbˈɔɾæ na nˌeblˈinæ]",
-                "en": "[bˌʌt lˈuːkəz hɐz ɔːlɹˌɛdi ɡɒn ˌɪntʊ ðə fˈɒɡ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-030",
-            "text": {
-                "pt": "Sophie treme.",
-                "en": "Sophie shivers."
-            },
-            "ipa": {
-                "pt": "[sˌofˈiy trˈemy]",
-                "en": "[sˈəʊfi ʃˈɪvəz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-031",
-            "text": {
-                "pt": "Olha o mapa.",
-                "en": "Look at the map."
-            },
-            "ipa": {
-                "pt": "[ˈɔljæ ʊ mˈapæ]",
-                "en": "[lˈʊk at ðə mˈap]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-032",
-            "text": {
-                "pt": "Lucas pega a mão dela.",
-                "en": "Lucas takes her hand."
-            },
-            "ipa": {
-                "pt": "[lˈukæs pˈɛɡæ a mˈɐ̃ʊ̃ dˈɛlæ]",
-                "en": "[lˈuːkəz tˈeɪks hɜː hˈand]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-09-033",
+            "id": "scene-09-028",
             "text": {
                 "pt": "Espera, perdi minha mochila!",
                 "en": "Wait, I lost my backpack!"
@@ -975,7 +824,69 @@
             }
         },
         {
-            "id": "scene-09-034",
+            "id": "scene-09-029",
+            "text": {
+                "fr": "Attends, j'ai perdu mon sac! Il était juste là!",
+                "en": "Wait, I lost my bag! It was right here!",
+                "de": "Warte, ich habe meinen Rucksack verloren! Er war gerade hier!",
+                "it": "Aspetta, ho perso il mio zaino! Era proprio qui!",
+                "es": "Espera, ¡he perdido mi mochila! Estaba justo aquí.",
+                "nl": "Wacht, ik ben mijn tas kwijt! Hij was net hier!",
+                "pt": "Estava aqui!",
+                "en_pt": "It was right here!"
+            },
+            "ipa": {
+                "fr": "atˈɑ̃ ʒe pɛʁdˈy mɔ̃ sˈak il etˈɛ ʒˈyst lˈa",
+                "de": "[ˈvaʁtə, ɪç haːbə ˈmaɪ̯nən ˈʁʊksak fɛɐ̯ˈloːʁən! ɛɐ̯ vaːɐ̯ ɡəˈʁaːdə hiːɐ̯]",
+                "it": "[aspˈɛtːa\n ˌo pˈɛːrso ˌil mˌio dzˈaɪːno\n ˌɛra prˈɔprio kwˈi]",
+                "es": "[esˈpeɾa, e peɾˈðiðo mi moˈtʃila! esˈtaβa ˈxusto aˈki]",
+                "nl": "[ʋˈɑxt\n ɪk bɛn mɛɪn tˈɑs kʋˈɛɪt\n hɛɪ ʋˈɑs nˈɛt hˈir]",
+                "pt": "[estˌavæ akˈi]",
+                "en": "[wˈeɪt aɪ lˈɒst maɪ bˈaɡ ɪt wɒz ɹˈaɪt hˈiə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-030",
+            "text": {
+                "fr": "Je reviens le chercher, toi, continue! Suis le sentier!",
+                "en": "I'll go back to get it, you keep going! Follow the path!",
+                "de": "Ich gehe ihn holen, du geh weiter! Folge dem Weg!",
+                "it": "Torno indietro a prenderlo, tu continua! Segui il sentiero!",
+                "es": "Voy a buscarla, tú sigue el camino.",
+                "nl": "Ik ga terug om hem te zoeken, jij gaat door! Volg het pad!",
+                "pt": "Vou voltar para procurar, você continua!",
+                "en_pt": "I'll go back to look for it, you keep going!"
+            },
+            "ipa": {
+                "fr": "ʒə- ʁəvjˈɛ̃ lə- ʃɛʁʃˈe twˈa kɔ̃tinˈy syˈi lə- sɑ̃tjˈe",
+                "de": "[ɪç ɡeːə ɪn ˈhoːlən, duː geː ˈvaɪ̯tɐ! ˈfɔlɡə deːm veːk]",
+                "it": "[tˈoːrno indjˈɛːtro ˌa prˈenderlo\n tˌʊ kontˈinʊa\n sˈeɡwɪ ˌil sˌentiˈɛːro]",
+                "es": "[boj a busˈkaɾla, ˈtu ˈsiɣe el kaˈmino]",
+                "nl": "[ɪk ɣˈaː tərˈɵx ɔm hˈɛm tə zˈukən\n jɛɪ ɣˈaː tˈoːr\n vˈɔlx hət pˈɑt]",
+                "pt": "[vow vowtˈar pˌaɾæ prˌokuɾˈar\n vosˌe kˌoŋtʃinˈuæ]",
+                "en": "[aɪl ɡˌəʊ bˈak tə ɡˈɛt ɪt juː kˈiːp ɡˈəʊɪŋ fˈɒləʊ ðə pˈaθ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-031",
             "text": {
                 "pt": "Segue a trilha!",
                 "en": "Follow the trail!"
@@ -986,6 +897,95 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-032",
+            "text": {
+                "fr": "Non, Lucas, attendons ensemble!",
+                "en": "No, Lucas, let's wait together!",
+                "de": "Nein, Lucas, warten wir zusammen!",
+                "it": "No, Lucas, aspettiamo insieme!",
+                "es": "No, Lucas, esperemos juntos.",
+                "nl": "Nee, Lucas, laten we samen wachten!",
+                "pt": "Não Lucas, vamos esperar juntos!",
+                "en_pt": "No Lucas, let's wait together!"
+            },
+            "ipa": {
+                "fr": "nˈɔ̃ lykˈa atɑ̃dˈɔ̃z ɑ̃sˈɑ̃bl",
+                "de": "[naɪ̯n, ˈluːkas, ˈvaʁtən viːɐ̯ t͡suˈzamən]",
+                "it": "[nˈɔ\n lˈuːkas\n ˌaspetːjˈaːmo insjˈɛːme]",
+                "es": "[no, ˈlukas, espeˈɾemos ˈxuntos]",
+                "nl": "[nˈeː\n lˈykɑs\n lˈaːtən ʋə sˈaːmən ʋˈɑxtən]",
+                "pt": "[nˌɐ̃ʊ̃ lˈukæs\n vˌɐ̃mʊz ˌespeɾˈar ʒˈũŋtʊs]",
+                "en": "[nˈəʊ lˈuːkəz lˈɛts wˈeɪt təɡˈɛðə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-033",
+            "text": {
+                "fr": "Mais Lucas est déjà parti dans le brouillard.",
+                "en": "But Lucas has already left into the fog.",
+                "de": "Aber Lucas ist schon im Nebel verschwunden.",
+                "it": "Ma Lucas è già partito nella nebbia.",
+                "es": "Pero Lucas ya se ha ido en la niebla.",
+                "nl": "Maar Lucas is al verdwenen in de mist.",
+                "pt": "Mas Lucas já foi embora na neblina.",
+                "en_pt": "But Lucas has already disappeared into the fog."
+            },
+            "ipa": {
+                "fr": "mɛ lykˈaz ɛ deʒˈa paʁtˈi dɑ̃ lə- bʁujˈaʁ",
+                "de": "[ˈabɐ ˈluːkas ɪst ʃoːn ɪm ˈneːbəl fɛɐ̯ˈʃvʊndən]",
+                "it": "[mˌa lˈuːkas ˌɛ dʒˈa partˈiːto nˌɛlla nˈebːia]",
+                "es": "[ˈpeɾo ˈlukas ʝa se a iˈðo en la ˈnjeβla]",
+                "nl": "[maːr lˈykɑs ɪs ˈɑl vərdʋˈeːnən ɪn də mˈɪst]",
+                "pt": "[maz lˈukæz ʒˈa foɪ ˌeɪmbˈɔɾæ na nˌeblˈinæ]",
+                "en": "[bˌʌt lˈuːkəz hɐz ɔːlɹˌɛdi lˈɛft ˌɪntʊ ðə fˈɒɡ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-09-034",
+            "text": {
+                "fr": "racontera plus tard Sophie.",
+                "en": "Sophie will tell her story later.",
+                "de": "erzählt später Sophie.",
+                "it": "racconterà più tardi Sophie.",
+                "es": "lo contará más tarde Sophie.",
+                "nl": "zal Sophie later vertellen."
+            },
+            "ipa": {
+                "fr": "ʁakɔ̃tʁˈa ply tˈaʁ sɔfˈi",
+                "de": "[ɛɐ̯ˈt͡sɛlt ˈʃpɛːtɐ ˈzɔfiː]",
+                "it": "[rˌakːonterˈa pjˌʊ tˈaːrdɪ sˈopje]",
+                "es": "[lo konˈtaɾa mas ˈtaɾðe ˈsofi]",
+                "nl": "[zɑl sɔphˈi lˈaːtər vərtˈɛlən]",
+                "en": "[sˈəʊfi wɪl tˈɛl hɜː stˈɔːɹɪ lˈeɪtə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-10.json
+++ b/language_materials/unified/stories/scene-10.json
@@ -24,473 +24,12 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-10-001",
-            "text": {
-                "fr": "Lucas? Lucas, où es-tu?",
-                "en": "Lucas? Lucas, where are you?",
-                "de": "Lucas? Lucas, wo bist du?",
-                "it": "Lucas? Lucas, dove sei?",
-                "es": "¿Lucas? ¿Lucas, dónde estás?",
-                "nl": "Lucas? Lucas, waar ben je?",
-                "pt": "Lucas, onde você está?",
-                "en_pt": "Lucas, where are you?"
-            },
-            "ipa": {
-                "fr": "lykˈa lykˈa u ɛtˈy",
-                "de": "[ˈluːkas? ˈluːkas, voː bɪst duː?]",
-                "it": "[lˈuːkas\n lˈuːkas\n dˈoːve sˈɛj]",
-                "es": "[ˈlukas | ˈlukas ˈdonde esˈtas]",
-                "nl": "[lˈykɑs\n lˈykɑs\n ʋˈaːr bɛn jə]",
-                "pt": "[lˈukæs\n ˌoŋdʒy vosˌe estˈa]",
-                "en": "[lˈuːkəz lˈuːkəz wˈeəɹ ɑː juː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-002",
-            "text": {
-                "fr": "Je n'entends plus sa voix.",
-                "en": "I can't hear his voice anymore.",
-                "de": "Ich höre seine Stimme nicht mehr.",
-                "it": "Non sento più la sua voce.",
-                "es": "Ya no oigo su voz.",
-                "nl": "Ik hoor zijn stem niet meer.",
-                "pt": "Não ouço mais a voz dele."
-            },
-            "ipa": {
-                "fr": "ʒə- nɑ̃tˈɑ̃ ply sa- vwˈa",
-                "de": "[ɪç ˈhøːʁə ˈzaɪ̯nə ˈʃtɪmə nɪçt meːɐ̯]",
-                "it": "[nˌon sˈɛnto pjˌʊ lˌa sˌʊa vˈoːtʃe]",
-                "es": "[ʝa no ˈoiɣo su ˈboθ]",
-                "nl": "[ɪk hˈoːr zɛɪn stˈɛm nˈit mˌeːr]",
-                "pt": "[nˌɐ̃ʊ̃ ˈowsʊ mˈaɪz a vˈɔz dˈely]",
-                "en": "[aɪ kˈɑːnt hˈiə hɪz vˈɔɪs ˌɛnɪmˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-003",
-            "text": {
-                "fr": "Si seulement j'avais mon téléphone! Mais il ne sert à rien ici.",
-                "en": "If only I had my phone! But it's useless here anyway.",
-                "de": "Wenn ich nur mein Handy hätte! Aber hier bringt es nichts.",
-                "it": "Se solo avessi il mio telefono! Ma qui non serve a nulla.",
-                "es": "¡Si al menos tuviera mi móvil! Pero aquí no sirve de nada.",
-                "nl": "Had ik maar mijn telefoon! Maar hier heb ik er toch niks aan.",
-                "pt": "Se eu ao menos tivesse meu celular!",
-                "en_pt": "If only I had my phone!"
-            },
-            "ipa": {
-                "fr": "sˈi sølmˈɑ̃ ʒavˈɛ mɔ̃ telefˈɔn mɛz il nə- sˈɛʁ a ʁjˌɛ̃n isˈi",
-                "de": "[vɛn ɪç nuːɐ̯ maɪ̯n ˈhandi ˈhɛtə! ˈaːbɐ hiːɐ̯ ˈbrɪŋt ɛs nɪçts]",
-                "it": "[sˌe sˈoːlo avˌɛssɪ ˌil mˌio telˈɛfono\n mˌa kwˈi nˌon sˈɛːrve ˌa nˈulla]",
-                "es": "[si al ˈmenos tuˈβjeɾa mi ˈmoβil | peɾo aˈki no ˈsiɾβe ðe ˈnaða]",
-                "nl": "[hˈɑt ɪk maːr mɛɪn tˌeːləfˈoːn\n maːr hˈir hɛp ɪk ər tˈɔx nˈɪks ˈaːn]",
-                "pt": "[sj eʊ aʊ mˈenʊs tʃˌivˈɛsy meʊ sˌelulˈar]",
-                "en": "[ɪf ˈəʊnli aɪ hɐd maɪ fˈəʊn bˌʌt ɪts jˈuːsləs hˈiəɹ ˈɛnɪwˌeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-004",
-            "text": {
-                "fr": "Je ne sais plus où je suis.",
-                "en": "I don't know where I am anymore.",
-                "de": "Ich weiß nicht mehr, wo ich bin.",
-                "it": "Non so più dove sono.",
-                "es": "Ya no sé dónde estoy.",
-                "nl": "Ik weet niet meer waar ik ben.",
-                "pt": "Não sei mais onde estou."
-            },
-            "ipa": {
-                "fr": "ʒə- nə- sˈɛ plyz u ʒə- syˈi",
-                "de": "[ɪç vaɪ̯s nɪçt meːɐ̯, voː ɪç bɪn]",
-                "it": "[nˌon sˈo pjˌʊ dˈoːve sˈono]",
-                "es": "[ʝa no se ˈdonde esˈtoj]",
-                "nl": "[ɪk ʋˈeːt nˈit mˌeːr ʋˈaːr ɪk bɛn]",
-                "pt": "[nˌɐ̃ʊ̃ sˈeɪ mˈaɪz ˌoŋdʒj estˌow]",
-                "en": "[aɪ dˈəʊnt nˈəʊ wˌeəɹ aɪɐm ˌɛnɪmˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-005",
-            "text": {
-                "fr": "Il aurait fallu rester ensemble. Nous avons été stupides.",
-                "en": "We should have stayed together. We were foolish.",
-                "de": "Wir hätten zusammenbleiben sollen. Wir waren dumm.",
-                "it": "Avremmo dovuto restare insieme. Siamo stati stupidi.",
-                "es": "Deberíamos haber permanecido juntos. Hemos sido tontos.",
-                "nl": "We hadden bij elkaar moeten blijven. We waren dom.",
-                "pt": "A gente deveria ter ficado junto.",
-                "en_pt": "We should have stayed together."
-            },
-            "ipa": {
-                "fr": "il oʁˈɛ falˈy ʁɛstˈe ɑ̃sˈɑ̃bl nuz avˈɔ̃z etˈe stypˈid",
-                "de": "[viːɐ̯ ˈhɛtən ʦuˈzamənˌblaɪ̯bn̩ ˈzɔlən. viːɐ̯ ˈvaːʁən ˈdʊm]",
-                "it": "[avrˌɛmmo dovˈuːto restˈaːre insjˈɛːme\n sjˌamo stˈaːtɪ stˈupidɪ]",
-                "es": "[deβeˈɾjamos aˈβeɾ peɾmaˈneθiðo ˈxuntos | ˈemos siðo ˈtontos]",
-                "nl": "[ʋə hˌɑdən bɛɪ ˈɛlkaːr mˈutən blˈɛɪvən\n ʋə ʋˌaːrən dˈɔm]",
-                "pt": "[a ʒˈeɪŋtʃy dˌeveɾˈiæ ter fˌikˈadʊ ʒˈũŋtʊ]",
-                "en": "[wiː ʃˌʊdəv stˈeɪd təɡˈɛðə wiː wɜː fˈuːlɪʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-006",
-            "text": {
-                "fr": "Maintenant, je suis complètement seule.",
-                "en": "Now, I'm completely alone.",
-                "de": "Jetzt bin ich völlig allein.",
-                "it": "Ora sono completamente sola.",
-                "es": "Ahora estoy completamente sola.",
-                "nl": "Nu ben ik helemaal alleen.",
-                "pt": "Agora estou completamente sozinha.",
-                "en_pt": "Now I'm completely alone."
-            },
-            "ipa": {
-                "fr": "mɛ̃tnˈɑ̃ ʒə- syˌi kɔ̃plɛtmˈɑ̃ sˈœl",
-                "de": "[jɛt͡st bɪn ɪç ˈfœlɪç aˈlaɪ̯n]",
-                "it": "[ˈɔːra sˌono kˌompletamˈente sˈoːla]",
-                "es": "[aˈoɾa esˈtoj kompletaˈmente ˈsola]",
-                "nl": "[nˈy bɛn ɪk hˌeːləmˈaːl ɑlˈeːn]",
-                "pt": "[ˌaɡˈɔɾæ estˌow kˌompletæmˈeɪŋtʃy sˌozˈiɲæ]",
-                "en": "[nˈaʊ aɪm kəmplˈiːtli ɐlˈəʊn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-007",
-            "text": {
-                "fr": "J'aurais dû l'écouter tout à l'heure",
-                "en": "I should have listened to him earlier.",
-                "de": "Ich hätte auf ihn hören sollen früher.",
-                "it": "Avrei dovuto ascoltarlo prima.",
-                "es": "Debí haberle escuchado antes.",
-                "nl": "Ik had eerder naar hem moeten luisteren.",
-                "pt": "Eu deveria ter escutado ele antes.",
-                "en_pt": "I should have listened to him before."
-            },
-            "ipa": {
-                "fr": "ʒoʁˈɛ dˈyː lekutˈe tut a lˈœʁ",
-                "de": "[ɪç ˈhɛtə aʊ̯f ɪn ˈhøːʁən ˈzɔlən ˈfʁyːɐ̯]",
-                "it": "[avrˈeːɪ dovˈuːto ˌaskoltˈaːrlo prˈiːma]",
-                "es": "[deˈβi aˈβeɾle eskuˈtʃaðo ˈantes]",
-                "nl": "[ɪk hˈɑt ˈɪːrdər naːr hˈɛm mˈutən lˈœystərən]",
-                "pt": "[eʊ dˌeveɾˈiæ teɾ ˌeskutˈadw ˌely ˈɐ̃ŋtʃys]",
-                "en": "[aɪ ʃˌʊdəv lˈɪsənd tə hˌɪm ˈɜːlɪə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-008",
-            "text": {
-                "fr": "Il voulait faire demi-tour.",
-                "en": "He wanted to turn back.",
-                "de": "Er wollte umkehren.",
-                "it": "Voleva tornare indietro.",
-                "es": "Quería dar la vuelta.",
-                "nl": "Hij wilde omdraaien.",
-                "pt": "Ele queria voltar."
-            },
-            "ipa": {
-                "fr": "il vulˈɛ fˈɛʁ dəmˈitˈuʁ",
-                "de": "[ʔeːɐ̯ ˈvɔltə ˈʊmkeːʁən]",
-                "it": "[volˈeːva tornˈaːre indjˈɛːtro]",
-                "es": "[keˈɾia ðaɾ la ˈβwelta]",
-                "nl": "[hɛɪ ʋˌɪldə ˈɔmdraːjən]",
-                "pt": "[ˌely kˌeɾˈiæ vowtˈar]",
-                "en": "[hiː wˈɒntɪd tə tˈɜːn bˈak]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-009",
-            "text": {
-                "fr": "Mais il est trop tard pour les regrets.",
-                "en": "But it's too late for regrets.",
-                "de": "Aber es ist zu spät für Reue.",
-                "it": "Ma ora è troppo tardi per rimpianti.",
-                "es": "Pero ya es demasiado tarde para arrepentirnos.",
-                "nl": "Maar het is te laat voor spijt.",
-                "pt": "Mas é tarde demais para arrependimentos."
-            },
-            "ipa": {
-                "fr": "mɛz il ɛ tʁo tˈaʁ puʁ le- ʁəɡʁˈɛ",
-                "de": "[ˈaːbɐ ʔɛs ɪst t͡su ˈʃpɛːt fyːɐ̯ ˈʁɔʏ̯ə]",
-                "it": "[mˌa ˈɔːra ˌɛ trˈɔpːo tˈaːrdɪ pˌɛr rimpjˈantɪ]",
-                "es": "[ˈpeɾo ʝa es ðemaˈsjaðo ˈtaɾðe paɾa arepenˈtiɾnos]",
-                "nl": "[maːr hət ɪs tə lˈaːt vɔːr spˈɛɪt]",
-                "pt": "[maz ɛ tˈaɾədʒy demˈaɪs pˌaɾæ ˌaxepˌeɪŋdʒimˈeɪŋtʊs]",
-                "en": "[bˌʌt ɪts tˈuː lˈeɪt fɔː ɹɪɡɹˈɛts]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-010",
-            "text": {
-                "fr": "Je dois trouver un abri",
-                "en": "I need to find a shelter.",
-                "de": "Ich muss einen Unterschlupf finden.",
-                "it": "Devo trovare un rifugio",
-                "es": "Tengo que encontrar un refugio.",
-                "nl": "Ik moet een schuilplaats vinden.",
-                "pt": "Preciso encontrar um abrigo.",
-                "en_pt": "I need to find shelter."
-            },
-            "ipa": {
-                "fr": "ʒə- dwˈa tʁuvˈe œ̃n abʁˈi",
-                "de": "[ɪç mʊs ˈaɪ̯nən ˈʊntɐʃlʊpf ˈfɪndən]",
-                "it": "[dˈɛːvo trovˈaːre ˌʊn rifˈuːdʒo]",
-                "es": "[ˈteŋɡo ke enkonˈtɾaɾ un reˈfuχjo]",
-                "nl": "[ɪk mˈut ən sxœylplˈaːts vˈɪndən]",
-                "pt": "[prˌesˈizw ˌeɪŋkoŋtrˈaɾ ũŋ ˌabrˈiɡʊ]",
-                "en": "[aɪ nˈiːd tə fˈaɪnd ɐ ʃˈɛltə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-011",
-            "text": {
-                "fr": "Je ne peux pas rester dehors cette nuit.",
-                "en": "I can't stay outside tonight.",
-                "de": "Ich kann nicht die ganze Nacht draußen bleiben.",
-                "it": "Non posso restare fuori questa notte.",
-                "es": "No puedo quedarme afuera esta noche.",
-                "nl": "Ik kan hier niet buiten blijven vannacht.",
-                "pt": "Não posso ficar aqui fora esta noite.",
-                "en_pt": "I can't stay out here tonight."
-            },
-            "ipa": {
-                "fr": "ʒə- nə- pˈø pa ʁɛstˈe dəˈɔʁ sɛt nyˈi",
-                "de": "[ɪç kan nɪçt diː ˈgantsə naxt ˈdʁaʊ̯sn̩ ˈblaɪ̯bn̩]",
-                "it": "[nˌon pˈɔsso restˈaːre fʊˈoːrɪ kwˌɛsta nˈɔtːe]",
-                "es": "[no ˈpweðo keˈðaɾme aˈfweɾa ˈesta ˈnotʃe]",
-                "nl": "[ɪk kɑn hˈir nˌit bˈœytən blˈɛɪvən vɑnnˈɑxt]",
-                "pt": "[nˌɐ̃ʊ̃ pˌɔsʊ fikˈaɾ akˈi fˈɔɾæ ˌɛstæ nˈoɪtʃy]",
-                "en": "[aɪ kˈɑːnt stˈeɪ aʊtsˈaɪd tənˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-012",
-            "text": {
-                "fr": "Dans le doute, descends. L'eau coule vers le bas.",
-                "en": "When in doubt, go downhill. Water always flows downward.",
-                "de": "Wenn du zweifelst, geh runter. Das Wasser fließt nach unten.",
-                "it": "In caso di dubbio, scendi. L'acqua scorre verso il basso.",
-                "es": "Si tienes dudas, baja. El agua fluye hacia abajo.",
-                "nl": "Als je twijfelt, ga naar beneden. Water stroomt altijd omlaag.",
-                "pt": "A água corre para baixo.",
-                "en_pt": "Water flows downward."
-            },
-            "ipa": {
-                "fr": "dɑ̃ lə- dˈut dɛsˈɑ̃ lˈo kˈul vɛʁ lə- bˈa",
-                "de": "[vɛn du ˈt͡svaɪ̯fl̩st, geː ˈʁʊntɐ. das ˈvasɐ ˈfliːst nax ˈʊntn̩]",
-                "it": "[ˌin kˈaːzo dˌɪ dˈubːio\n ʃˈɛndɪ\n lˈakːwa skˈɔrɾe vˌɛrso ˌil bˈasso]",
-                "es": "[si ˈtjenes ˈðuðas | ˈbaxa | el ˈaɣwa ˈflwe iˈθja aˈβaxo]",
-                "nl": "[ɑls jə tʋˈɛɪfəlt\n ɣˈaː naːr bənˈeːdən\n ʋˈaːtər strˈoːmt ˈɑltɛɪt ɔmlˈaːx]",
-                "pt": "[a ˈaɡwæ kˈɔxy pˌaɾæ bˈaɪʃʊ]",
-                "en": "[wˌɛn ɪn dˈaʊt ɡˌəʊ dˈaʊnhɪl wˈɔːtəɹ ˈɔːlweɪz flˈəʊz dˈaʊnwəd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-013",
-            "text": {
-                "fr": "Où suis-je vraiment? Qui suis-je sans Lucas à mes côtés?",
-                "en": "Where am I really? Who am I without Lucas by my side?",
-                "de": "Wo bin ich wirklich? Wer bin ich ohne Lucas an meiner Seite?",
-                "it": "Dove sono veramente? Chi sono senza Lucas al mio fianco?",
-                "es": "¿Dónde estoy realmente? ¿Quién soy sin Lucas a mi lado?",
-                "nl": "Waar ben ik echt? Wie ben ik zonder Lucas aan mijn zijde?",
-                "pt": "Quem sou eu sem Lucas ao meu lado?",
-                "en_pt": "Who am I without Lucas by my side?"
-            },
-            "ipa": {
-                "fr": "u syˈiʒ vʁɛmˈɑ̃ ki syˌiʒ sɑ̃ lykˈaz a me- kotˈe",
-                "de": "[voː bɪn ɪç ˈvɪʁklɪç? veːɐ̯ bɪn ɪç ˈoːnə ˈluːkas an ˈmaɪ̯nɐ ˈzaɪ̯tə?]",
-                "it": "[dˈoːve sˌono vˌɛramˈente\n kˈi sˌono sˌɛntsa lˈuːkas ˌal mˌio fjˈanko]",
-                "es": "[ˈdonde esˈtoj reˈalmente | ˈkjen soj sin ˈlukas a mi ˈlaðo]",
-                "nl": "[ʋˈaːr bɛn ɪk ˈɛxt\n ʋˈi bɛn ɪk zˈɔndər lˈykɑs aːn mɛɪn zˈɛɪdə]",
-                "pt": "[kˈeɪŋ sow eʊ sˈeɪŋ lˈukæz aʊ meʊ lˈadʊ]",
-                "en": "[wˌeəɹ am aɪ ɹˈiəlɪ hˌuː am aɪ wɪðˌaʊt lˈuːkəz baɪ maɪ sˈaɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-014",
-            "text": {
-                "fr": "Là-bas, il y a quelque chose!",
-                "en": "There's something over there!",
-                "de": "Da vorne, da ist etwas!",
-                "it": "Là, c'è qualcosa!",
-                "es": "¡Allá hay algo!",
-                "nl": "Daar is iets!",
-                "pt": "Ali tem alguma coisa!",
-                "en_pt": "There's something there!"
-            },
-            "ipa": {
-                "fr": "lˈabˈa il i a kˌɛlkə ʃˈoz",
-                "de": "[daː ˈfɔʁnə, daː ɪst ˈʔɛtvas]",
-                "it": "[lˈa\n tʃˌɛ kwalkˈɔːza]",
-                "es": "[ˈaʝa ˈai ˈalɣo]",
-                "nl": "[dˈaːr ɪs ˈits]",
-                "pt": "[alˈi teɪŋ ˌaʊɡˈumæ kˈoɪzæ]",
-                "en": "[ðeəz sˈʌmθɪŋ ˌəʊvə ðˈeə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-015",
-            "text": {
-                "fr": "Une petite cabane abandonnée. Dieu merci!",
-                "en": "A small abandoned cabin. Thank God!",
-                "de": "Eine kleine verlassene Hütte. Gott sei Dank!",
-                "it": "Una piccola capanna abbandonata. Grazie a Dio!",
-                "es": "Una pequeña cabaña abandonada. ¡Gracias a Dios!",
-                "nl": "Een klein verlaten hutje. Godzijdank!",
-                "pt": "Uma pequena cabana abandonada.",
-                "en_pt": "A small abandoned cabin."
-            },
-            "ipa": {
-                "fr": "yn pətˈit kabˈan abɑ̃dɔnˈe djˈø mɛʁsˈi",
-                "de": "[ˈaɪ̯nə ˈklaɪ̯nə fɛɐ̯ˈlasənə ˈhʏtə. ɡɔt zaɪ̯ ˈdaŋk]",
-                "it": "[ˌʊna pˈikːola kapˈanna ˌabːandonˈaːta\n ɡrˈatsje ˌa dˈiːo]",
-                "es": "[ˈuna peˈkeɲa kaˈβaɲa aβanðoˈnaða | ˈɣraθjas a ðjos]",
-                "nl": "[ən klˈɛɪn vərlˈaːtən hˈɵtʲə\n ɣˈɔdzɛɪdˌɑŋk]",
-                "pt": "[ˌumæ pˌekˈenæ kˌabˈɐ̃næ ˌabɐ̃ŋdonˈadæ]",
-                "en": "[ɐ smˈɔːl ɐbˈandənd kˈabɪn θˈaŋk ɡˈɒd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-016",
             "text": {
                 "fr": "Sophie attend quelques minutes, puis commence à paniquer.",
                 "en": "Sophie waits a few minutes, then starts to panic.",
@@ -521,7 +60,53 @@
             }
         },
         {
-            "id": "scene-10-017",
+            "id": "scene-10-002",
+            "text": {
+                "pt": "Lucas?",
+                "en": "Lucas?"
+            },
+            "ipa": {
+                "pt": "[lˈukæs]",
+                "en": "[lˈuːkəz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-003",
+            "text": {
+                "fr": "Lucas? Lucas, où es-tu?",
+                "en": "Lucas? Lucas, where are you?",
+                "de": "Lucas? Lucas, wo bist du?",
+                "it": "Lucas? Lucas, dove sei?",
+                "es": "¿Lucas? ¿Lucas, dónde estás?",
+                "nl": "Lucas? Lucas, waar ben je?",
+                "pt": "Lucas, onde você está?",
+                "en_pt": "Lucas, where are you?"
+            },
+            "ipa": {
+                "fr": "lykˈa lykˈa u ɛtˈy",
+                "de": "[ˈluːkas? ˈluːkas, voː bɪst duː?]",
+                "it": "[lˈuːkas\n lˈuːkas\n dˈoːve sˈɛj]",
+                "es": "[ˈlukas | ˈlukas ˈdonde esˈtas]",
+                "nl": "[lˈykɑs\n lˈykɑs\n ʋˈaːr bɛn jə]",
+                "pt": "[lˈukæs\n ˌoŋdʒy vosˌe estˈa]",
+                "en": "[lˈuːkəz lˈuːkəz wˈeəɹ ɑː juː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-004",
             "text": {
                 "fr": "Le vent emporte sa voix.",
                 "en": "The wind carries away her voice.",
@@ -551,15 +136,16 @@
             }
         },
         {
-            "id": "scene-10-018",
+            "id": "scene-10-005",
             "text": {
                 "fr": "Elle crie plus fort, mais rien.",
-                "en": "She shouts louder, but nothing.",
+                "en": "She screams louder, but nothing.",
                 "de": "Sie schreit lauter, aber nichts.",
                 "it": "Lei grida più forte, ma niente.",
                 "es": "Ella grita más fuerte, pero nada.",
                 "nl": "Ze roept harder, maar niets.",
-                "pt": "Ela grita mais alto, mas nada."
+                "pt": "Ela grita mais alto, mas nada.",
+                "en_pt": "She shouts louder, but nothing."
             },
             "ipa": {
                 "fr": "ɛl kʁˈi ply fˈɔʁ mɛ ʁjˈɛ̃",
@@ -568,7 +154,7 @@
                 "es": "[ˈeʝa ˈɡɾita ˈmas ˈfweɾte | ˈpeɾo ˈnaða]",
                 "nl": "[zə rˈupt hˈɑrdər\n maːr nˈits]",
                 "pt": "[ˌɛlæ ɡrˈitæ mˈaɪz ˈaʊtʊ\n maz nˈadæ]",
-                "en": "[ʃiː ʃˈaʊts lˈaʊdə bˌʌt nˈʌθɪŋ]"
+                "en": "[ʃiː skɹˈiːmz lˈaʊdə bˌʌt nˈʌθɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -581,15 +167,46 @@
             }
         },
         {
-            "id": "scene-10-019",
+            "id": "scene-10-006",
+            "text": {
+                "fr": "Je n'entends plus sa voix.",
+                "en": "I can't hear his voice anymore.",
+                "de": "Ich höre seine Stimme nicht mehr.",
+                "it": "Non sento più la sua voce.",
+                "es": "Ya no oigo su voz.",
+                "nl": "Ik hoor zijn stem niet meer.",
+                "pt": "Não ouço mais a voz dele."
+            },
+            "ipa": {
+                "fr": "ʒə- nɑ̃tˈɑ̃ ply sa- vwˈa",
+                "de": "[ɪç ˈhøːʁə ˈzaɪ̯nə ˈʃtɪmə nɪçt meːɐ̯]",
+                "it": "[nˌon sˈɛnto pjˌʊ lˌa sˌʊa vˈoːtʃe]",
+                "es": "[ʝa no ˈoiɣo su ˈboθ]",
+                "nl": "[ɪk hˈoːr zɛɪn stˈɛm nˈit mˌeːr]",
+                "pt": "[nˌɐ̃ʊ̃ ˈowsʊ mˈaɪz a vˈɔz dˈely]",
+                "en": "[aɪ kˈɑːnt hˈiə hɪz vˈɔɪs ˌɛnɪmˈɔː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-007",
             "text": {
                 "fr": "Elle cherche son téléphone dans sa poche.",
-                "en": "She searches for her phone in her pocket.",
+                "en": "She looks for her phone in her pocket.",
                 "de": "Sie sucht ihr Handy in ihrer Tasche.",
                 "it": "Cerca il suo telefono in tasca.",
                 "es": "Ella busca su móvil en el bolsillo.",
                 "nl": "Ze zoekt haar telefoon in haar zak.",
-                "pt": "Ela procura o celular no bolso."
+                "pt": "Ela procura o celular no bolso.",
+                "en_pt": "She searches for her phone in her pocket."
             },
             "ipa": {
                 "fr": "ɛl ʃˈɛʁʃ sɔ̃ telefˈɔn dɑ̃ sa- pˈɔʃ",
@@ -598,7 +215,7 @@
                 "es": "[ˈeʝa ˈbuska su ˈmoβil en el bolˈsiʝo]",
                 "nl": "[zə zˈukt haːr tˌeːləfˈoːn ɪn haːr zˈɑk]",
                 "pt": "[ˌɛlæ prˌokˈuɾæ ʊ sˌelulˈar nʊ bˈowsʊ]",
-                "en": "[ʃiː sˈɜːtʃɪz fɔː hɜː fˈəʊn ɪn hɜː pˈɒkɪt]"
+                "en": "[ʃiː lˈʊks fɔː hɜː fˈəʊn ɪn hɜː pˈɒkɪt]"
             },
             "provenance": {
                 "fr": "original",
@@ -611,10 +228,71 @@
             }
         },
         {
-            "id": "scene-10-020",
+            "id": "scene-10-008",
+            "text": {
+                "pt": "Sem sinal.",
+                "en": "No signal."
+            },
+            "ipa": {
+                "pt": "[sˈeɪŋ sinˈaʊ]",
+                "en": "[nˈəʊ sˈɪɡnəl]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-009",
+            "text": {
+                "fr": "Si seulement j'avais mon téléphone! Mais il ne sert à rien ici.",
+                "en": "If only I had my phone! But it doesn't work here.",
+                "de": "Wenn ich nur mein Handy hätte! Aber hier bringt es nichts.",
+                "it": "Se solo avessi il mio telefono! Ma qui non serve a nulla.",
+                "es": "¡Si al menos tuviera mi móvil! Pero aquí no sirve de nada.",
+                "nl": "Had ik maar mijn telefoon! Maar hier heb ik er toch niks aan.",
+                "pt": "Se eu ao menos tivesse meu celular!",
+                "en_pt": "If only I had my phone!"
+            },
+            "ipa": {
+                "fr": "sˈi sølmˈɑ̃ ʒavˈɛ mɔ̃ telefˈɔn mɛz il nə- sˈɛʁ a ʁjˌɛ̃n isˈi",
+                "de": "[vɛn ɪç nuːɐ̯ maɪ̯n ˈhandi ˈhɛtə! ˈaːbɐ hiːɐ̯ ˈbrɪŋt ɛs nɪçts]",
+                "it": "[sˌe sˈoːlo avˌɛssɪ ˌil mˌio telˈɛfono\n mˌa kwˈi nˌon sˈɛːrve ˌa nˈulla]",
+                "es": "[si al ˈmenos tuˈβjeɾa mi ˈmoβil | peɾo aˈki no ˈsiɾβe ðe ˈnaða]",
+                "nl": "[hˈɑt ɪk maːr mɛɪn tˌeːləfˈoːn\n maːr hˈir hɛp ɪk ər tˈɔx nˈɪks ˈaːn]",
+                "pt": "[sj eʊ aʊ mˈenʊs tʃˌivˈɛsy meʊ sˌelulˈar]",
+                "en": "[ɪf ˈəʊnli aɪ hɐd maɪ fˈəʊn bˌʌt ɪt dˈʌzənt wˈɜːk hˈiə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-010",
+            "text": {
+                "pt": "Mas não serve para nada aqui.",
+                "en": "But it's useless here."
+            },
+            "ipa": {
+                "pt": "[maz nˌɐ̃ʊ̃ sˈɛɾəvy pˌaɾæ nˈadæ akˈi]",
+                "en": "[bˌʌt ɪts jˈuːsləs hˈiə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-011",
             "text": {
                 "fr": "Le brouillard est si dense qu'elle ne voit pas à trois mètres devant elle.",
-                "en": "The fog is so thick that she can't see three meters in front of her.",
+                "en": "The fog is so dense that she can't see three meters in front of her.",
                 "de": "Der Nebel ist so dicht, dass sie nicht drei Meter vor sich sieht.",
                 "it": "La nebbia è così densa che non vede a tre metri davanti a sé.",
                 "es": "La niebla es tan densa que no ve a tres metros delante de ella.",
@@ -629,7 +307,7 @@
                 "es": "[la ˈnjeβla es tan ˈðensa ke no βe a ˈtɾes ˈmetɾos ðeˈlante ðe ˈeʝa]",
                 "nl": "[də mˈɪst ɪ soː dˈɪxt dɑt zə ɣˈeːn drˈi mˈeːtər vɔːr zɪx œyt kɑn zˈin]",
                 "pt": "[a nˌeblˈinæ estˌa tˈɐ̃ʊ̃ dˈeɪŋsæ ky ˌɛlæ nˌɐ̃ʊ̃ kˌoŋsˈɛɡy vˈeɾ a trˈez mˈɛtrʊz ˌaː frˈeɪŋtʃy]",
-                "en": "[ðə fˈɒɡ ɪz sˌəʊ θˈɪk ðat ʃiː kˈɑːnt sˈiː θɹˈiː mˈiːtəz ɪn fɹˈʌnt ɒv hɜː]"
+                "en": "[ðə fˈɒɡ ɪz sˌəʊ dˈɛns ðat ʃiː kˈɑːnt sˈiː θɹˈiː mˈiːtəz ɪn fɹˈʌnt ɒv hɜː]"
             },
             "provenance": {
                 "fr": "original",
@@ -642,7 +320,37 @@
             }
         },
         {
-            "id": "scene-10-021",
+            "id": "scene-10-012",
+            "text": {
+                "fr": "Je ne sais plus où je suis.",
+                "en": "I don't know where I am anymore.",
+                "de": "Ich weiß nicht mehr, wo ich bin.",
+                "it": "Non so più dove sono.",
+                "es": "Ya no sé dónde estoy.",
+                "nl": "Ik weet niet meer waar ik ben.",
+                "pt": "Não sei mais onde estou."
+            },
+            "ipa": {
+                "fr": "ʒə- nə- sˈɛ plyz u ʒə- syˈi",
+                "de": "[ɪç vaɪ̯s nɪçt meːɐ̯, voː ɪç bɪn]",
+                "it": "[nˌon sˈo pjˌʊ dˈoːve sˈono]",
+                "es": "[ʝa no se ˈdonde esˈtoj]",
+                "nl": "[ɪk ʋˈeːt nˈit mˌeːr ʋˈaːr ɪk bɛn]",
+                "pt": "[nˌɐ̃ʊ̃ sˈeɪ mˈaɪz ˌoŋdʒj estˌow]",
+                "en": "[aɪ dˈəʊnt nˈəʊ wˌeəɹ aɪɐm ˌɛnɪmˈɔː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-013",
             "text": {
                 "fr": "Elle se reproche leur dispute.",
                 "en": "She blames herself for their argument.",
@@ -673,25 +381,25 @@
             }
         },
         {
-            "id": "scene-10-022",
+            "id": "scene-10-014",
             "text": {
-                "fr": "Le vent souffle de plus en plus fort.",
-                "en": "The wind blows harder and harder.",
-                "de": "Der Wind wird immer stärker.",
-                "it": "Il vento soffia sempre più forte.",
-                "es": "El viento sopla cada vez más fuerte.",
-                "nl": "De wind waait steeds harder.",
-                "pt": "O vento sopra cada vez mais forte.",
-                "en_pt": "The wind blows stronger and stronger."
+                "fr": "Il aurait fallu rester ensemble. Nous avons été stupides.",
+                "en": "We should have stayed together. We were stupid.",
+                "de": "Wir hätten zusammenbleiben sollen. Wir waren dumm.",
+                "it": "Avremmo dovuto restare insieme. Siamo stati stupidi.",
+                "es": "Deberíamos haber permanecido juntos. Hemos sido tontos.",
+                "nl": "We hadden bij elkaar moeten blijven. We waren dom.",
+                "pt": "A gente deveria ter ficado junto.",
+                "en_pt": "We should have stayed together."
             },
             "ipa": {
-                "fr": "lə- vˈɑ̃ sˈufl də- plyz ɑ̃ ply fˈɔʁ",
-                "de": "[deːɐ̯ ˈvɪnt vɪʁt ˈɪmɐ ˈʃtɛʁkɐ]",
-                "it": "[ˌil vˈɛnto sˈoffia sˈɛmpre pjˌʊ fˈɔːrte]",
-                "es": "[el ˈβjento ˈsopla ˈkaða βeθ ˈmas ˈfweɾte]",
-                "nl": "[də ʋˈɪnt ʋˈaːjt stˈeːts hˈɑrdər]",
-                "pt": "[ʊ vˈeɪŋtʊ sˈɔpræ kˈadæ vˈez mˈaɪs fˈɔɾətʃy]",
-                "en": "[ðə wˈɪnd blˈəʊz hˈɑːdə and hˈɑːdə]"
+                "fr": "il oʁˈɛ falˈy ʁɛstˈe ɑ̃sˈɑ̃bl nuz avˈɔ̃z etˈe stypˈid",
+                "de": "[viːɐ̯ ˈhɛtən ʦuˈzamənˌblaɪ̯bn̩ ˈzɔlən. viːɐ̯ ˈvaːʁən ˈdʊm]",
+                "it": "[avrˌɛmmo dovˈuːto restˈaːre insjˈɛːme\n sjˌamo stˈaːtɪ stˈupidɪ]",
+                "es": "[deβeˈɾjamos aˈβeɾ peɾmaˈneθiðo ˈxuntos | ˈemos siðo ˈtontos]",
+                "nl": "[ʋə hˌɑdən bɛɪ ˈɛlkaːr mˈutən blˈɛɪvən\n ʋə ʋˌaːrən dˈɔm]",
+                "pt": "[a ʒˈeɪŋtʃy dˌeveɾˈiæ ter fˌikˈadʊ ʒˈũŋtʊ]",
+                "en": "[wiː ʃˌʊdəv stˈeɪd təɡˈɛðə wiː wɜː stjˈuːpɪd]"
             },
             "provenance": {
                 "fr": "original",
@@ -704,7 +412,190 @@
             }
         },
         {
-            "id": "scene-10-023",
+            "id": "scene-10-015",
+            "text": {
+                "pt": "Fomos estúpidos.",
+                "en": "We were stupid."
+            },
+            "ipa": {
+                "pt": "[fˌomʊz ˌestˈupidʊs]",
+                "en": "[wiː wɜː stjˈuːpɪd]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-016",
+            "text": {
+                "fr": "Maintenant, je suis complètement seule.",
+                "en": "Now, I am completely alone.",
+                "de": "Jetzt bin ich völlig allein.",
+                "it": "Ora sono completamente sola.",
+                "es": "Ahora estoy completamente sola.",
+                "nl": "Nu ben ik helemaal alleen.",
+                "pt": "Agora estou completamente sozinha.",
+                "en_pt": "Now I'm completely alone."
+            },
+            "ipa": {
+                "fr": "mɛ̃tnˈɑ̃ ʒə- syˌi kɔ̃plɛtmˈɑ̃ sˈœl",
+                "de": "[jɛt͡st bɪn ɪç ˈfœlɪç aˈlaɪ̯n]",
+                "it": "[ˈɔːra sˌono kˌompletamˈente sˈoːla]",
+                "es": "[aˈoɾa esˈtoj kompletaˈmente ˈsola]",
+                "nl": "[nˈy bɛn ɪk hˌeːləmˈaːl ɑlˈeːn]",
+                "pt": "[ˌaɡˈɔɾæ estˌow kˌompletæmˈeɪŋtʃy sˌozˈiɲæ]",
+                "en": "[nˈaʊ aɪɐm kəmplˈiːtli ɐlˈəʊn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-017",
+            "text": {
+                "fr": "Le vent souffle de plus en plus fort.",
+                "en": "The wind blows stronger and stronger.",
+                "de": "Der Wind wird immer stärker.",
+                "it": "Il vento soffia sempre più forte.",
+                "es": "El viento sopla cada vez más fuerte.",
+                "nl": "De wind waait steeds harder.",
+                "pt": "O vento sopra cada vez mais forte."
+            },
+            "ipa": {
+                "fr": "lə- vˈɑ̃ sˈufl də- plyz ɑ̃ ply fˈɔʁ",
+                "de": "[deːɐ̯ ˈvɪnt vɪʁt ˈɪmɐ ˈʃtɛʁkɐ]",
+                "it": "[ˌil vˈɛnto sˈoffia sˈɛmpre pjˌʊ fˈɔːrte]",
+                "es": "[el ˈβjento ˈsopla ˈkaða βeθ ˈmas ˈfweɾte]",
+                "nl": "[də ʋˈɪnt ʋˈaːjt stˈeːts hˈɑrdər]",
+                "pt": "[ʊ vˈeɪŋtʊ sˈɔpræ kˈadæ vˈez mˈaɪs fˈɔɾətʃy]",
+                "en": "[ðə wˈɪnd blˈəʊz stɹˈɒŋɡə and stɹˈɒŋɡə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-018",
+            "text": {
+                "pt": "A temperatura cai.",
+                "en": "The temperature drops."
+            },
+            "ipa": {
+                "pt": "[a tˌeɪmpeɾatˈuɾæ kˈaɪ]",
+                "en": "[ðə tˈɛmpɹɪtʃə dɹˈɒps]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-019",
+            "text": {
+                "fr": "J'aurais dû l'écouter tout à l'heure",
+                "en": "I should have listened to him earlier.",
+                "de": "Ich hätte auf ihn hören sollen früher.",
+                "it": "Avrei dovuto ascoltarlo prima.",
+                "es": "Debí haberle escuchado antes.",
+                "nl": "Ik had eerder naar hem moeten luisteren.",
+                "pt": "Eu deveria ter escutado ele antes.",
+                "en_pt": "I should have listened to him before."
+            },
+            "ipa": {
+                "fr": "ʒoʁˈɛ dˈyː lekutˈe tut a lˈœʁ",
+                "de": "[ɪç ˈhɛtə aʊ̯f ɪn ˈhøːʁən ˈzɔlən ˈfʁyːɐ̯]",
+                "it": "[avrˈeːɪ dovˈuːto ˌaskoltˈaːrlo prˈiːma]",
+                "es": "[deˈβi aˈβeɾle eskuˈtʃaðo ˈantes]",
+                "nl": "[ɪk hˈɑt ˈɪːrdər naːr hˈɛm mˈutən lˈœystərən]",
+                "pt": "[eʊ dˌeveɾˈiæ teɾ ˌeskutˈadw ˌely ˈɐ̃ŋtʃys]",
+                "en": "[aɪ ʃˌʊdəv lˈɪsənd tə hˌɪm ˈɜːlɪə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-020",
+            "text": {
+                "fr": "Il voulait faire demi-tour.",
+                "en": "He wanted to turn back.",
+                "de": "Er wollte umkehren.",
+                "it": "Voleva tornare indietro.",
+                "es": "Quería dar la vuelta.",
+                "nl": "Hij wilde omdraaien.",
+                "pt": "Ele queria voltar."
+            },
+            "ipa": {
+                "fr": "il vulˈɛ fˈɛʁ dəmˈitˈuʁ",
+                "de": "[ʔeːɐ̯ ˈvɔltə ˈʊmkeːʁən]",
+                "it": "[volˈeːva tornˈaːre indjˈɛːtro]",
+                "es": "[keˈɾia ðaɾ la ˈβwelta]",
+                "nl": "[hɛɪ ʋˌɪldə ˈɔmdraːjən]",
+                "pt": "[ˌely kˌeɾˈiæ vowtˈar]",
+                "en": "[hiː wˈɒntɪd tə tˈɜːn bˈak]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-021",
+            "text": {
+                "fr": "Mais il est trop tard pour les regrets.",
+                "en": "But it is too late for regrets.",
+                "de": "Aber es ist zu spät für Reue.",
+                "it": "Ma ora è troppo tardi per rimpianti.",
+                "es": "Pero ya es demasiado tarde para arrepentirnos.",
+                "nl": "Maar het is te laat voor spijt.",
+                "pt": "Mas é tarde demais para arrependimentos.",
+                "en_pt": "But it's too late for regrets."
+            },
+            "ipa": {
+                "fr": "mɛz il ɛ tʁo tˈaʁ puʁ le- ʁəɡʁˈɛ",
+                "de": "[ˈaːbɐ ʔɛs ɪst t͡su ˈʃpɛːt fyːɐ̯ ˈʁɔʏ̯ə]",
+                "it": "[mˌa ˈɔːra ˌɛ trˈɔpːo tˈaːrdɪ pˌɛr rimpjˈantɪ]",
+                "es": "[ˈpeɾo ʝa es ðemaˈsjaðo ˈtaɾðe paɾa arepenˈtiɾnos]",
+                "nl": "[maːr hət ɪs tə lˈaːt vɔːr spˈɛɪt]",
+                "pt": "[maz ɛ tˈaɾədʒy demˈaɪs pˌaɾæ ˌaxepˌeɪŋdʒimˈeɪŋtʊs]",
+                "en": "[bˌʌt ɪt ɪz tˈuː lˈeɪt fɔː ɹɪɡɹˈɛts]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-022",
             "text": {
                 "fr": "Sophie se force à réfléchir calmement.",
                 "en": "Sophie forces herself to think calmly.",
@@ -734,7 +625,69 @@
             }
         },
         {
+            "id": "scene-10-023",
+            "text": {
+                "fr": "Je dois trouver un abri",
+                "en": "I have to find shelter",
+                "de": "Ich muss einen Unterschlupf finden.",
+                "it": "Devo trovare un rifugio",
+                "es": "Tengo que encontrar un refugio.",
+                "nl": "Ik moet een schuilplaats vinden.",
+                "pt": "Preciso encontrar um abrigo.",
+                "en_pt": "I need to find shelter."
+            },
+            "ipa": {
+                "fr": "ʒə- dwˈa tʁuvˈe œ̃n abʁˈi",
+                "de": "[ɪç mʊs ˈaɪ̯nən ˈʊntɐʃlʊpf ˈfɪndən]",
+                "it": "[dˈɛːvo trovˈaːre ˌʊn rifˈuːdʒo]",
+                "es": "[ˈteŋɡo ke enkonˈtɾaɾ un reˈfuχjo]",
+                "nl": "[ɪk mˈut ən sxœylplˈaːts vˈɪndən]",
+                "pt": "[prˌesˈizw ˌeɪŋkoŋtrˈaɾ ũŋ ˌabrˈiɡʊ]",
+                "en": "[aɪ hav tə fˈaɪnd ʃˈɛltə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
             "id": "scene-10-024",
+            "text": {
+                "fr": "Je ne peux pas rester dehors cette nuit.",
+                "en": "I can't stay outside tonight.",
+                "de": "Ich kann nicht die ganze Nacht draußen bleiben.",
+                "it": "Non posso restare fuori questa notte.",
+                "es": "No puedo quedarme afuera esta noche.",
+                "nl": "Ik kan hier niet buiten blijven vannacht.",
+                "pt": "Não posso ficar aqui fora esta noite.",
+                "en_pt": "I can't stay out here tonight."
+            },
+            "ipa": {
+                "fr": "ʒə- nə- pˈø pa ʁɛstˈe dəˈɔʁ sɛt nyˈi",
+                "de": "[ɪç kan nɪçt diː ˈgantsə naxt ˈdʁaʊ̯sn̩ ˈblaɪ̯bn̩]",
+                "it": "[nˌon pˈɔsso restˈaːre fʊˈoːrɪ kwˌɛsta nˈɔtːe]",
+                "es": "[no ˈpweðo keˈðaɾme aˈfweɾa ˈesta ˈnotʃe]",
+                "nl": "[ɪk kɑn hˈir nˌit bˈœytən blˈɛɪvən vɑnnˈɑxt]",
+                "pt": "[nˌɐ̃ʊ̃ pˌɔsʊ fikˈaɾ akˈi fˈɔɾæ ˌɛstæ nˈoɪtʃy]",
+                "en": "[aɪ kˈɑːnt stˈeɪ aʊtsˈaɪd tənˈaɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-025",
             "text": {
                 "fr": "Elle avance prudemment, les mains tendues devant elle.",
                 "en": "She moves forward cautiously, her hands stretched out in front of her.",
@@ -765,10 +718,10 @@
             }
         },
         {
-            "id": "scene-10-025",
+            "id": "scene-10-026",
             "text": {
                 "fr": "Dans sa tête, des souvenirs surgissent.",
-                "en": "Memories come flooding back in her head.",
+                "en": "In her head, memories arise.",
                 "de": "In ihrem Kopf tauchen Erinnerungen auf.",
                 "it": "Nella sua testa, affiorano ricordi.",
                 "es": "En su cabeza, surgen recuerdos.",
@@ -783,7 +736,7 @@
                 "es": "[en su kaˈβeθa | ˈsuɾxen reˈkwɛrðos]",
                 "nl": "[ɪn haːr hˈoːft kˈoːmən hɛrˈɪnərˌɪŋən naːr bˈoːvən]",
                 "pt": "[ˈeɪŋ sˌuæ kˌabˈesæ\n lˌeɪmbrˈɐ̃ŋsæs sˈuɾəʒeɪŋ]",
-                "en": "[mˈɛməɹˌiz kˈʌm flˈʌdɪŋ bˈak ɪn hɜː hˈɛd]"
+                "en": "[ɪn hɜː hˈɛd mˈɛməɹˌiz ɐɹˈaɪz]"
             },
             "provenance": {
                 "fr": "original",
@@ -796,7 +749,114 @@
             }
         },
         {
-            "id": "scene-10-026",
+            "id": "scene-10-027",
+            "text": {
+                "pt": "Seu pai sempre dizia: Na dúvida, desce.",
+                "en": "Her father always said: When in doubt, go down."
+            },
+            "ipa": {
+                "pt": "[seʊ pˈaɪ sˌeɪmpry dʒˌizˈiæ\n na dˈuvidæ\n dˈɛsy]",
+                "en": "[hɜː fˈɑːðəɹ ˈɔːlweɪz sˈɛd wˌɛn ɪn dˈaʊt ɡˌəʊ dˈaʊn]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-028",
+            "text": {
+                "fr": "Dans le doute, descends. L'eau coule vers le bas.",
+                "en": "When in doubt, go down. The water flows downward.",
+                "de": "Wenn du zweifelst, geh runter. Das Wasser fließt nach unten.",
+                "it": "In caso di dubbio, scendi. L'acqua scorre verso il basso.",
+                "es": "Si tienes dudas, baja. El agua fluye hacia abajo.",
+                "nl": "Als je twijfelt, ga naar beneden. Water stroomt altijd omlaag.",
+                "pt": "A água corre para baixo.",
+                "en_pt": "Water flows downward."
+            },
+            "ipa": {
+                "fr": "dɑ̃ lə- dˈut dɛsˈɑ̃ lˈo kˈul vɛʁ lə- bˈa",
+                "de": "[vɛn du ˈt͡svaɪ̯fl̩st, geː ˈʁʊntɐ. das ˈvasɐ ˈfliːst nax ˈʊntn̩]",
+                "it": "[ˌin kˈaːzo dˌɪ dˈubːio\n ʃˈɛndɪ\n lˈakːwa skˈɔrɾe vˌɛrso ˌil bˈasso]",
+                "es": "[si ˈtjenes ˈðuðas | ˈbaxa | el ˈaɣwa ˈflwe iˈθja aˈβaxo]",
+                "nl": "[ɑls jə tʋˈɛɪfəlt\n ɣˈaː naːr bənˈeːdən\n ʋˈaːtər strˈoːmt ˈɑltɛɪt ɔmlˈaːx]",
+                "pt": "[a ˈaɡwæ kˈɔxy pˌaɾæ bˈaɪʃʊ]",
+                "en": "[wˌɛn ɪn dˈaʊt ɡˌəʊ dˈaʊn ðə wˈɔːtə flˈəʊz dˈaʊnwəd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-029",
+            "text": {
+                "pt": "Mas agora, nesta neblina, o alto e o baixo se confundem.",
+                "en": "But now, in this fog, up and down are confused."
+            },
+            "ipa": {
+                "pt": "[maz ˌaɡˈɔɾæ\n nˌɛstæ nˌeblˈinæ\n u ˈaʊtw i ʊ bˈaɪʃʊ sy kˌoŋfˈũŋdeɪŋ]",
+                "en": "[bˌʌt nˈaʊ ɪn ðɪs fˈɒɡ ˌʌp and dˌaʊn ɑː kənfjˈuːzd]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-030",
+            "text": {
+                "pt": "Onde estou realmente?",
+                "en": "Where am I really?"
+            },
+            "ipa": {
+                "pt": "[ˌoŋdʒj estˌow xˌeaʊmˈeɪŋtʃy]",
+                "en": "[wˌeəɹ am aɪ ɹˈiəlɪ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-031",
+            "text": {
+                "fr": "Où suis-je vraiment? Qui suis-je sans Lucas à mes côtés?",
+                "en": "Where am I really? Who am I without Lucas by my side?",
+                "de": "Wo bin ich wirklich? Wer bin ich ohne Lucas an meiner Seite?",
+                "it": "Dove sono veramente? Chi sono senza Lucas al mio fianco?",
+                "es": "¿Dónde estoy realmente? ¿Quién soy sin Lucas a mi lado?",
+                "nl": "Waar ben ik echt? Wie ben ik zonder Lucas aan mijn zijde?",
+                "pt": "Quem sou eu sem Lucas ao meu lado?",
+                "en_pt": "Who am I without Lucas by my side?"
+            },
+            "ipa": {
+                "fr": "u syˈiʒ vʁɛmˈɑ̃ ki syˌiʒ sɑ̃ lykˈaz a me- kotˈe",
+                "de": "[voː bɪn ɪç ˈvɪʁklɪç? veːɐ̯ bɪn ɪç ˈoːnə ˈluːkas an ˈmaɪ̯nɐ ˈzaɪ̯tə?]",
+                "it": "[dˈoːve sˌono vˌɛramˈente\n kˈi sˌono sˌɛntsa lˈuːkas ˌal mˌio fjˈanko]",
+                "es": "[ˈdonde esˈtoj reˈalmente | ˈkjen soj sin ˈlukas a mi ˈlaðo]",
+                "nl": "[ʋˈaːr bɛn ɪk ˈɛxt\n ʋˈi bɛn ɪk zˈɔndər lˈykɑs aːn mɛɪn zˈɛɪdə]",
+                "pt": "[kˈeɪŋ sow eʊ sˈeɪŋ lˈukæz aʊ meʊ lˈadʊ]",
+                "en": "[wˌeəɹ am aɪ ɹˈiəlɪ hˌuː am aɪ wɪðˌaʊt lˈuːkəz baɪ maɪ sˈaɪd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-10-032",
             "text": {
                 "fr": "Soudain, ses mains touchent quelque chose de solide.",
                 "en": "Suddenly, her hands touch something solid.",
@@ -826,24 +886,25 @@
             }
         },
         {
-            "id": "scene-10-027",
+            "id": "scene-10-033",
             "text": {
-                "fr": "C'est une forme sombre dans le brouillard.",
-                "en": "It's a dark shape in the fog.",
-                "de": "Es ist eine dunkle Gestalt im Nebel.",
-                "it": "È una forma scura nella nebbia.",
-                "es": "Es una forma oscura en la niebla.",
-                "nl": "Het is een donkere vorm in de mist.",
-                "pt": "É uma forma escura na neblina."
+                "fr": "Là-bas, il y a quelque chose!",
+                "en": "Over there, there is something!",
+                "de": "Da vorne, da ist etwas!",
+                "it": "Là, c'è qualcosa!",
+                "es": "¡Allá hay algo!",
+                "nl": "Daar is iets!",
+                "pt": "Ali tem alguma coisa!",
+                "en_pt": "There's something there!"
             },
             "ipa": {
-                "fr": "sɛt yn fˈɔʁm sˈɔ̃bʁ dɑ̃ lə- bʁujˈaʁ",
-                "de": "[ʔɛs ɪst ˈaɪ̯nə ˈdʊŋklə ɡəˈʃtalt ɪm ˈneːbl̩]",
-                "it": "[ˌɛ ˌʊna fˈoːrma skˈuːra nˌɛlla nˈebːia]",
-                "es": "[es ˈuna ˈfoɾma osˈkuɾa en la ˈnjeβla]",
-                "nl": "[hət ɪs ən dˈɔŋkərə vˈɔrm ɪn də mˈɪst]",
-                "pt": "[ɛ ˌumæ fˈɔɾəmæ ˌeskˈuɾæ na nˌeblˈinæ]",
-                "en": "[ɪts ɐ dˈɑːk ʃˈeɪp ɪnðə fˈɒɡ]"
+                "fr": "lˈabˈa il i a kˌɛlkə ʃˈoz",
+                "de": "[daː ˈfɔʁnə, daː ɪst ˈʔɛtvas]",
+                "it": "[lˈa\n tʃˌɛ kwalkˈɔːza]",
+                "es": "[ˈaʝa ˈai ˈalɣo]",
+                "nl": "[dˈaːr ɪs ˈits]",
+                "pt": "[alˈi teɪŋ ˌaʊɡˈumæ kˈoɪzæ]",
+                "en": "[ˌəʊvə ðˈeə ðeəɹ ɪz sˈʌmθɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -856,106 +917,32 @@
             }
         },
         {
-            "id": "scene-10-028",
-            "text": {
-                "pt": "Lucas?",
-                "en": "Lucas?"
-            },
-            "ipa": {
-                "pt": "[lˈukæs]",
-                "en": "[lˈuːkəz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-029",
-            "text": {
-                "pt": "Sem sinal.",
-                "en": "No signal."
-            },
-            "ipa": {
-                "pt": "[sˈeɪŋ sinˈaʊ]",
-                "en": "[nˈəʊ sˈɪɡnəl]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-030",
-            "text": {
-                "pt": "Mas não serve para nada aqui.",
-                "en": "But it's useless here."
-            },
-            "ipa": {
-                "pt": "[maz nˌɐ̃ʊ̃ sˈɛɾəvy pˌaɾæ nˈadæ akˈi]",
-                "en": "[bˌʌt ɪts jˈuːsləs hˈiə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-031",
-            "text": {
-                "pt": "Fomos estúpidos.",
-                "en": "We were stupid."
-            },
-            "ipa": {
-                "pt": "[fˌomʊz ˌestˈupidʊs]",
-                "en": "[wiː wɜː stjˈuːpɪd]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-032",
-            "text": {
-                "pt": "A temperatura cai.",
-                "en": "The temperature drops."
-            },
-            "ipa": {
-                "pt": "[a tˌeɪmpeɾatˈuɾæ kˈaɪ]",
-                "en": "[ðə tˈɛmpɹɪtʃə dɹˈɒps]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-10-033",
-            "text": {
-                "pt": "Seu pai sempre dizia: Na dúvida, desce.",
-                "en": "Her father always said: When in doubt, go down."
-            },
-            "ipa": {
-                "pt": "[seʊ pˈaɪ sˌeɪmpry dʒˌizˈiæ\n na dˈuvidæ\n dˈɛsy]",
-                "en": "[hɜː fˈɑːðəɹ ˈɔːlweɪz sˈɛd wˌɛn ɪn dˈaʊt ɡˌəʊ dˈaʊn]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-10-034",
             "text": {
-                "pt": "Mas agora, nesta neblina, o alto e o baixo se confundem.",
-                "en": "But now, in this fog, up and down are confused."
+                "fr": "C'est une forme sombre dans le brouillard.",
+                "en": "It is a dark shape in the fog.",
+                "de": "Es ist eine dunkle Gestalt im Nebel.",
+                "it": "È una forma scura nella nebbia.",
+                "es": "Es una forma oscura en la niebla.",
+                "nl": "Het is een donkere vorm in de mist.",
+                "pt": "É uma forma escura na neblina.",
+                "en_pt": "It's a dark shape in the fog."
             },
             "ipa": {
-                "pt": "[maz ˌaɡˈɔɾæ\n nˌɛstæ nˌeblˈinæ\n u ˈaʊtw i ʊ bˈaɪʃʊ sy kˌoŋfˈũŋdeɪŋ]",
-                "en": "[bˌʌt nˈaʊ ɪn ðɪs fˈɒɡ ˌʌp and dˌaʊn ɑː kənfjˈuːzd]"
+                "fr": "sɛt yn fˈɔʁm sˈɔ̃bʁ dɑ̃ lə- bʁujˈaʁ",
+                "de": "[ʔɛs ɪst ˈaɪ̯nə ˈdʊŋklə ɡəˈʃtalt ɪm ˈneːbl̩]",
+                "it": "[ˌɛ ˌʊna fˈoːrma skˈuːra nˌɛlla nˈebːia]",
+                "es": "[es ˈuna ˈfoɾma osˈkuɾa en la ˈnjeβla]",
+                "nl": "[hət ɪs ən dˈɔŋkərə vˈɔrm ɪn də mˈɪst]",
+                "pt": "[ɛ ˌumæ fˈɔɾəmæ ˌeskˈuɾæ na nˌeblˈinæ]",
+                "en": "[ɪt ɪz ɐ dˈɑːk ʃˈeɪp ɪnðə fˈɒɡ]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -963,14 +950,30 @@
         {
             "id": "scene-10-035",
             "text": {
-                "pt": "Onde estou realmente?",
-                "en": "Where am I really?"
+                "fr": "Une petite cabane abandonnée. Dieu merci!",
+                "en": "A small abandoned cabin. Thank God!",
+                "de": "Eine kleine verlassene Hütte. Gott sei Dank!",
+                "it": "Una piccola capanna abbandonata. Grazie a Dio!",
+                "es": "Una pequeña cabaña abandonada. ¡Gracias a Dios!",
+                "nl": "Een klein verlaten hutje. Godzijdank!",
+                "pt": "Uma pequena cabana abandonada.",
+                "en_pt": "A small abandoned cabin."
             },
             "ipa": {
-                "pt": "[ˌoŋdʒj estˌow xˌeaʊmˈeɪŋtʃy]",
-                "en": "[wˌeəɹ am aɪ ɹˈiəlɪ]"
+                "fr": "yn pətˈit kabˈan abɑ̃dɔnˈe djˈø mɛʁsˈi",
+                "de": "[ˈaɪ̯nə ˈklaɪ̯nə fɛɐ̯ˈlasənə ˈhʏtə. ɡɔt zaɪ̯ ˈdaŋk]",
+                "it": "[ˌʊna pˈikːola kapˈanna ˌabːandonˈaːta\n ɡrˈatsje ˌa dˈiːo]",
+                "es": "[ˈuna peˈkeɲa kaˈβaɲa aβanðoˈnaða | ˈɣraθjas a ðjos]",
+                "nl": "[ən klˈɛɪn vərlˈaːtən hˈɵtʲə\n ɣˈɔdzɛɪdˌɑŋk]",
+                "pt": "[ˌumæ pˌekˈenæ kˌabˈɐ̃næ ˌabɐ̃ŋdonˈadæ]",
+                "en": "[ɐ smˈɔːl ɐbˈandənd kˈabɪn θˈaŋk ɡˈɒd]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }

--- a/language_materials/unified/stories/scene-11.json
+++ b/language_materials/unified/stories/scene-11.json
@@ -24,27 +24,29 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-11-001",
             "text": {
-                "fr": "...ne pardonne pas...enseigne.",
-                "en": "...does not forgive...teaches.",
-                "de": "...vergibt nicht...lehrt.",
-                "it": "...non perdona...insegna.",
-                "es": "...no perdona...enseña.",
-                "nl": "...vergeeft niet...onderwijst."
+                "fr": "Sophie entre dans la cabane.",
+                "en": "Sophie enters the cabin.",
+                "de": "Sophie betritt die Hütte.",
+                "it": "Sophie entra nella capanna.",
+                "es": "Sophie entra en el piso.",
+                "nl": "Sophie gaat de hut binnen.",
+                "pt": "Sophie entra na cabana."
             },
             "ipa": {
-                "fr": "nə- paʁdˈɔn pˈa ɑ̃sˈɛɲ",
-                "de": "[fɛɾɡˈiːpt nˈɪçt\n lˈeːɾt]",
-                "it": "[nˌon perdˈoːna\n insˈeɲʲa]",
-                "es": "[...no peɾˈðona...enˈseɲa]",
-                "nl": "[vərɣˈeːft nˈit\n ˈɔndərʋˌɛɪst]",
-                "en": "[dʌznˌɒt fəɡˈɪv tˈiːtʃɪz]"
+                "fr": "sɔfˈi ɑ̃tʁ dɑ̃ la- kabˈan",
+                "de": "[zoːfˈiː bətɾˈɪt diː hˈʏtə]",
+                "it": "[sˈopje ˈentra nˌɛlla kapˈanna]",
+                "es": "[ˈsofi ˈentɾa en el ˈpiso]",
+                "nl": "[sɔphˈi ɣˈaː tə hˈɵt bˈɪnən]",
+                "pt": "[sˌofˈij ˈeɪŋtræ na kˌabˈɐ̃næ]",
+                "en": "[sˈəʊfi ˈɛntəz ðə kˈabɪn]"
             },
             "provenance": {
                 "fr": "original",
@@ -52,29 +54,29 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-11-002",
             "text": {
-                "fr": "Qui a vécu ici avant moi? Combien de solitudes cette cabane a-t-elle abritées?",
-                "en": "Who lived here before me? How much loneliness has this cabin sheltered?",
-                "de": "Wer hat hier vor mir gewohnt? Wie viele Einsamkeiten hat diese Hütte beherbergt?",
-                "it": "Chi ha vissuto qui prima di me? Quante solitudini ha ospitato questa casetta?",
-                "es": "¿Quién vivió aquí antes que yo? ¿Cuántas soledades ha albergado este piso?",
-                "nl": "Wie heeft hier voor mij gewoond? Hoeveel eenzaamheid heeft dit huisje herbergt?",
-                "pt": "Quantas solidões esta cabana abrigou?",
-                "en_pt": "How many solitudes has this cabin sheltered?"
+                "fr": "C'est une vieille structure de berger, simple mais solide.",
+                "en": "It's an old shepherd's structure, simple but solid.",
+                "de": "Es ist eine alte Schäferhütte, einfach aber stabil.",
+                "it": "È una vecchia struttura da pastore, semplice ma solida.",
+                "es": "Es una vieja estructura de pastor, simple pero sólida.",
+                "nl": "Het is een oude herdershut, eenvoudig maar stevig.",
+                "pt": "É uma velha estrutura de pastor, simples mas sólida."
             },
             "ipa": {
-                "fr": "ki a vekˈy isˈi avˌɑ̃ mwˈa kɔ̃bjˈɛ̃ də- sɔlitˈyd sɛt kabˈan atɛl abʁitˈe",
-                "de": "[vˈeːɾ hat hˈiːɾ fˌɔɾ miːɾ ɡəvˈoːnt\n viː fˈiːlə ˈaɪnzˌɑːmkaɪtən hat dˌiːzə hˈʏtə bəhˈɛɾbɜkt]",
-                "it": "[kˈi ˌa vissˈuːto kwˈi prˈiːma dˌɪ mˈe\n kwˈante sˌɔlitˈudinɪ ˌa ˌospitˈaːto kwˌɛsta kazˈetːa]",
-                "es": "[ˈkjen biˈbio aˈki ˈantes ke ˈʝo? ˈkwantas soleˈðaðes a alβeɾˈɣaðo ˈeste ˈpiso]",
-                "nl": "[ʋˈi heːft hˈir vɔːr mˈɛɪ ɣəʋˈoːnt\n huvˈeːl ˈeːnzaːmhˌɛɪt heːf tɪt hˈœysjə hɛrbˈɛrxt]",
-                "pt": "[kwˈɐ̃ŋtæs sˌolidˈõjz ˌɛstæ kˌabˈɐ̃næ ˌabriɡˈow]",
-                "en": "[hˌuː lˈɪvd hˈiə bɪfˈɔː mˌiː hˌaʊ mˈʌtʃ lˈəʊnlinəs hɐz ðɪs kˈabɪn ʃˈɛltəd]"
+                "fr": "sɛt yn vjˈɛj stʁyktˈyʁ də- bɛʁʒˈe sˈɛ̃pl mɛ sɔlˈid",
+                "de": "[ɛsɪst ˌaɪnə ˈaltə ʃˈɛːfɜhˌʏtə\n ˈaɪnfˌax ˌɑːbɜ ʃtabˈiːl]",
+                "it": "[ˌɛ ˌʊna vˈɛkːia strʊtːˈuːra dˌa pastˈoːre\n sˈemplitʃe mˌa sˈɔlida]",
+                "es": "[es ˈuna ˈβjexa estɾukˈtuɾa ðe pasˈtoɾ ˈsimple peɾo ˈsolida]",
+                "nl": "[hət ɪs ən ˈʌʊdə hˈɛrdərshˌɵt\n eːnvˈʌʊdəx maːr stˈeːvəx]",
+                "pt": "[ɛ ˌumæ vˈɛljæ ˌestrutˈuɾæ dʒy pastˈor\n sˈimplyz mas sˈɔlidæ]",
+                "en": "[ɪts ɐn ˈəʊld ʃˈɛpədz stɹˈʌktʃə sˈɪmpəl bˌʌt sˈɒlɪd]"
             },
             "provenance": {
                 "fr": "original",
@@ -89,8 +91,99 @@
         {
             "id": "scene-11-003",
             "text": {
+                "pt": "Tem uma lareira.",
+                "en": "There's a fireplace."
+            },
+            "ipa": {
+                "pt": "[teɪŋ ˌumæ lˌaɾˈeɪɾæ]",
+                "en": "[ðeəz ɐ fˈaɪəpleɪs]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-004",
+            "text": {
+                "pt": "Na parede, alguém gravou palavras quase apagadas: ...não perdoa...ensina.",
+                "en": "On the wall, someone carved nearly faded words: ...doesn't forgive...teaches."
+            },
+            "ipa": {
+                "pt": "[na pˌaɾˈedʒy\n aʊɡˈeɪŋ ɡravˈow pˌalˈavræs kwˈazj ˌapaɡˈadæs\n nˌɐ̃ʊ̃ pˌeɾədˈoæ\n ˌeɪŋsˈinæ]",
+                "en": "[ɒnðə wˈɔːl sˈʌmwɒn kˈɑːvd nˌiəli fˈeɪdɪd wˈɜːdz dˈʌzənt fəɡˈɪv tˈiːtʃɪz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-005",
+            "text": {
+                "pt": "Quem morou aqui antes de mim?",
+                "en": "Who lived here before me?"
+            },
+            "ipa": {
+                "pt": "[kˈeɪŋ moɾˈow akˈi ˈɐ̃ŋtʃyz dʒy mˈiŋ]",
+                "en": "[hˌuː lˈɪvd hˈiə bɪfˈɔː mˌiː]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-006",
+            "text": {
+                "fr": "Qui a vécu ici avant moi? Combien de solitudes cette cabane a-t-elle abritées?",
+                "en": "Who lived here before me? How many solitudes has this cabin sheltered?",
+                "de": "Wer hat hier vor mir gewohnt? Wie viele Einsamkeiten hat diese Hütte beherbergt?",
+                "it": "Chi ha vissuto qui prima di me? Quante solitudini ha ospitato questa casetta?",
+                "es": "¿Quién vivió aquí antes que yo? ¿Cuántas soledades ha albergado este piso?",
+                "nl": "Wie heeft hier voor mij gewoond? Hoeveel eenzaamheid heeft dit huisje herbergt?",
+                "pt": "Quantas solidões esta cabana abrigou?",
+                "en_pt": "How many solitudes has this cabin sheltered?"
+            },
+            "ipa": {
+                "fr": "ki a vekˈy isˈi avˌɑ̃ mwˈa kɔ̃bjˈɛ̃ də- sɔlitˈyd sɛt kabˈan atɛl abʁitˈe",
+                "de": "[vˈeːɾ hat hˈiːɾ fˌɔɾ miːɾ ɡəvˈoːnt\n viː fˈiːlə ˈaɪnzˌɑːmkaɪtən hat dˌiːzə hˈʏtə bəhˈɛɾbɜkt]",
+                "it": "[kˈi ˌa vissˈuːto kwˈi prˈiːma dˌɪ mˈe\n kwˈante sˌɔlitˈudinɪ ˌa ˌospitˈaːto kwˌɛsta kazˈetːa]",
+                "es": "[ˈkjen biˈbio aˈki ˈantes ke ˈʝo? ˈkwantas soleˈðaðes a alβeɾˈɣaðo ˈeste ˈpiso]",
+                "nl": "[ʋˈi heːft hˈir vɔːr mˈɛɪ ɣəʋˈoːnt\n huvˈeːl ˈeːnzaːmhˌɛɪt heːf tɪt hˈœysjə hɛrbˈɛrxt]",
+                "pt": "[kwˈɐ̃ŋtæs sˌolidˈõjz ˌɛstæ kˌabˈɐ̃næ ˌabriɡˈow]",
+                "en": "[hˌuː lˈɪvd hˈiə bɪfˈɔː mˌiː hˌaʊ mˈɛni sˈɒlɪtjˌuːdz hɐz ðɪs kˈabɪn ʃˈɛltəd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-007",
+            "text": {
+                "pt": "Ela toca as paredes de pedra.",
+                "en": "She touches the stone walls."
+            },
+            "ipa": {
+                "pt": "[ˌɛlæ tˈɔkæ as pˌaɾˈedʒyz dʒy pˈɛdræ]",
+                "en": "[ʃiː tˈʌtʃɪz ðə stˈəʊn wˈɔːlz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-008",
+            "text": {
                 "fr": "Ces murs ont survécu à combien de tempêtes, à combien d'hivers?",
-                "en": "How many storms and winters have these walls survived?",
+                "en": "How many storms, how many winters have these walls survived?",
                 "de": "Diese Wände haben wie viele Stürme, wie viele Winter überlebt?",
                 "it": "Questi muri hanno resistito a quante tempeste, a quanti inverni?",
                 "es": "¿Estas paredes han sobrevivido a cuántas tormentas, a cuántos inviernos?",
@@ -105,7 +198,7 @@
                 "es": "[ˈestas paˈɾeðes an soβɾebiˈβiðo a ˈkwantas toɾˈmentas a ˈkwantos inˈβjeɾnos]",
                 "nl": "[huvˈeːl stˈɔrmən ɛn ʋˈɪntərs hˌɛbən dˌeːzə mˈyrən dɔːrstˈaːn]",
                 "pt": "[ˌɛstæs pˌaɾˈedʒys sobɾevˌivˈeɾɐ̃ʊ̃ a kwˈɐ̃ŋtæs tˌeɪmpestˈadʒys\n a kwˈɐ̃ŋtʊz ˌiŋvˈɛɾənʊs]",
-                "en": "[hˌaʊ mˈɛni stˈɔːmz and wˈɪntəz hav ðiːz wˈɔːlz səvˈaɪvd]"
+                "en": "[hˌaʊ mˈɛni stˈɔːmz hˌaʊ mˈɛni wˈɪntəz hav ðiːz wˈɔːlz səvˈaɪvd]"
             },
             "provenance": {
                 "fr": "original",
@@ -118,7 +211,7 @@
             }
         },
         {
-            "id": "scene-11-004",
+            "id": "scene-11-009",
             "text": {
                 "fr": "Il faudrait que j'allume un feu.",
                 "en": "I should light a fire.",
@@ -149,10 +242,40 @@
             }
         },
         {
-            "id": "scene-11-005",
+            "id": "scene-11-010",
+            "text": {
+                "fr": "Elle cherche dans ses poches.",
+                "en": "She searches in her pockets.",
+                "de": "Sie sucht in ihren Taschen.",
+                "it": "Cerca nelle sue tasche.",
+                "es": "Busca en sus bolsillos.",
+                "nl": "Ze zoekt in haar zakken.",
+                "pt": "Ela procura nos bolsos."
+            },
+            "ipa": {
+                "fr": "ɛl ʃˈɛʁʃ dɑ̃ se- pˈɔʃ",
+                "de": "[ziː zˈuːxt ɪn ˌiːrən tˈaʃən]",
+                "it": "[tʃˈeːrka nˌɛlle sˌʊe tˈaske]",
+                "es": "[ˈbuska en sus bolˈsiʎos]",
+                "nl": "[zə zˈukt ɪn haːr zˈɑkən]",
+                "pt": "[ˌɛlæ prˌokˈuɾæ nʊz bˈowsʊs]",
+                "en": "[ʃiː sˈɜːtʃɪz ɪn hɜː pˈɒkɪts]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-011",
             "text": {
                 "fr": "Heureusement, j'ai des allumettes dans ma poche.",
-                "en": "Luckily, I have matches in my pocket.",
+                "en": "Fortunately, I have matches in my pocket.",
                 "de": "Zum Glück habe ich Streichhölzer in meiner Tasche.",
                 "it": "Fortunatamente, ho dei fiammiferi in tasca.",
                 "es": "Por suerte, tengo cerillas en el bolsillo.",
@@ -167,7 +290,7 @@
                 "es": "[poɾ ˈswerte ˈteŋɣo θeˈɾiʎas en el bolˈsiʎo]",
                 "nl": "[ɣəlˈɵkəx hɛp ɪk lˈysifərs ɪn mɛɪn zˈɑk]",
                 "pt": "[fˌelizmˈeɪŋtʃy tˌeɲʊ fˈɔsfoɾʊz nʊ bˈowsʊ]",
-                "en": "[lˈʌkilɪ aɪ hav mˈatʃɪz ɪn maɪ pˈɒkɪt]"
+                "en": "[fˈɔːtʃənətli aɪ hav mˈatʃɪz ɪn maɪ pˈɒkɪt]"
             },
             "provenance": {
                 "fr": "original",
@@ -180,15 +303,47 @@
             }
         },
         {
-            "id": "scene-11-006",
+            "id": "scene-11-012",
+            "text": {
+                "fr": "Elle trouve du bois à l'intérieur de la cabane, mais il est humide.",
+                "en": "She finds wood inside the cabin, but it's damp.",
+                "de": "Sie findet Holz in der Hütte, aber es ist feucht.",
+                "it": "Trova della legna all'interno della capanna, ma è umida.",
+                "es": "Encuentra madera dentro del piso, pero está húmeda.",
+                "nl": "Ze vindt hout binnen in de hut, maar het is vochtig.",
+                "pt": "Ela encontra lenha dentro da cabana, mas está úmida.",
+                "en_pt": "She finds firewood inside the cabin, but it's damp."
+            },
+            "ipa": {
+                "fr": "ɛl tʁˈuv dy- bwˈaz a lɛ̃teʁjˈœʁ də- la- kabˈan mɛz il ɛt ymˈid",
+                "de": "[ziː fˈɪndət hˈɔlts ɪn dɛɾ hˈʏtə\n ˌɑːbɜ ɛsɪst fˈɔøçt]",
+                "it": "[trˈɔːva dˌɛlla lˈeɲʲa allintˈɛːrno dˌɛlla kapˈanna\n mˌa ˌɛ ˈumida]",
+                "es": "[enˈkwentɾa maˈðeɾa ˈðentɾo ðel ˈpiso ˈpeɾo ˈesta ˈumeda]",
+                "nl": "[zə vˈɪnt hˈʌʊt bˈɪnən ɪn də hˈɵt\n maːr hət ɪs vˈɔxtəx]",
+                "pt": "[ˌɛlæ ˌeɪŋkˈoŋtræ lˈeɲæ dˈeɪŋtrʊ da kˌabˈɐ̃næ\n maz estˌa ˈũmidæ]",
+                "en": "[ʃiː fˈaɪndz wˈʊd ɪnsˈaɪd ðə kˈabɪn bˌʌt ɪts dˈamp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-013",
             "text": {
                 "fr": "Le bois est humide, ce ne sera pas facile.",
-                "en": "The wood is damp, this won't be easy.",
+                "en": "The wood is damp, it won't be easy.",
                 "de": "Das Holz ist feucht, das wird nicht einfach.",
                 "it": "La legna è umida, non sarà facile.",
                 "es": "La leña está húmeda, no será fácil.",
                 "nl": "Het hout is vochtig, dit wordt niet makkelijk.",
-                "pt": "A lenha está úmida, não vai ser fácil."
+                "pt": "A lenha está úmida, não vai ser fácil.",
+                "en_pt": "The wood is damp, this won't be easy."
             },
             "ipa": {
                 "fr": "lə- bwˈaz ɛt ymˈid sə- nə- səʁˈa pa fasˈil",
@@ -197,7 +352,7 @@
                 "es": "[la ˈleɲa ˈesta ˈumeda no seˈɾa ˈfaθil]",
                 "nl": "[hət hˈʌʊt ɪs vˈɔxtəx\n dɪt ʋɔrt nˌit mˈɑkələk]",
                 "pt": "[a lˈeɲæ estˌa ˈũmidæ\n nˌɐ̃ʊ̃ vaɪ ser fˈasiʊ]",
-                "en": "[ðə wˈʊd ɪz dˈamp ðɪs wəʊnt biː ˈiːzi]"
+                "en": "[ðə wˈʊd ɪz dˈamp ɪt wəʊnt biː ˈiːzi]"
             },
             "provenance": {
                 "fr": "original",
@@ -210,7 +365,68 @@
             }
         },
         {
-            "id": "scene-11-007",
+            "id": "scene-11-014",
+            "text": {
+                "fr": "Elle arrange le bois, met du papier, prend une allumette.",
+                "en": "She arranges the wood, puts paper, takes a match.",
+                "de": "Sie arrangiert das Holz, legt Papier dazu und nimmt ein Streichholz.",
+                "it": "Sistema la legna, mette della carta, prende un fiammifero.",
+                "es": "Arregla la madera, pone papel, saca una cerilla.",
+                "nl": "Ze schikt het hout, legt er papier bij, pakt een lucifer.",
+                "pt": "Ela arruma a lenha, coloca papel, pega um fósforo.",
+                "en_pt": "She arranges the wood, places paper, takes a match."
+            },
+            "ipa": {
+                "fr": "ɛl aʁˈɑ̃ʒ lə- bwˈa mˈɛ dy- papjˈe pʁˈɑ̃t yn alymˈɛt",
+                "de": "[ziː ˌaraŋʒˈiːət das hˈɔlts\n lˈeːkt papˈiːɾ dɑːtsˈuː ʊnt nˈɪmt aɪn ʃtɾˈaɪçhɔlts]",
+                "it": "[sistˈɛːma lˌa lˈeɲʲa\n mˈetːe dˌɛlla kˈaːrta\n prˈɛnde ˌʊn fjammˈifero]",
+                "es": "[aˈrɾeɣla la maˈðeɾa ˈpone paˈpel ˈsaka ˈuna θeˈɾiʎa]",
+                "nl": "[zə sxˈɪkt hət hˈʌʊt\n lˈɛxt ər paːpˈir bˈɛɪ\n pˈɑkt ən lˈysifər]",
+                "pt": "[ˌɛlæ ˌaxˈumæ a lˈeɲæ\n kˌolˈɔkæ papˈɛʊ\n pˈɛɡæ ũŋ fˈɔsfoɾʊ]",
+                "en": "[ʃiː ɐɹˈeɪndʒɪz ðə wˈʊd pˌʊts pˈeɪpə tˈeɪks ɐ mˈatʃ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-015",
+            "text": {
+                "pt": "Ela risca.",
+                "en": "She strikes it."
+            },
+            "ipa": {
+                "pt": "[ˌɛlæ xˈiskæ]",
+                "en": "[ʃiː stɹˈaɪks ɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-016",
+            "text": {
+                "pt": "Nada.",
+                "en": "Nothing."
+            },
+            "ipa": {
+                "pt": "[nˈadæ]",
+                "en": "[nˈʌθɪŋ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-017",
             "text": {
                 "fr": "J'essaie une fois, deux fois, trois fois...",
                 "en": "I try once, twice, three times...",
@@ -240,7 +456,38 @@
             }
         },
         {
-            "id": "scene-11-008",
+            "id": "scene-11-018",
+            "text": {
+                "fr": "Dans son esprit, elle revoit sa grand-mère montrant à la petite Sophie comment allumer un feu dans la cheminée de leur maison de campagne.",
+                "en": "In her mind, she sees her grandmother showing little Sophie how to light a fire in the fireplace of their country house.",
+                "de": "In ihren Gedanken sieht sie ihre Großmutter, die der kleinen Sophie zeigt, wie man im Kamin ihres Landhauses ein Feuer anzündet.",
+                "it": "Nella sua mente, rivede sua nonna insegnare alla piccola Sophie come accendere un fuoco nel camino della loro casa di campagna.",
+                "es": "En su mente, recuerda a su abuela enseñando a la pequeña Sophie cómo encender un fuego en la chimenea de su casa de campo.",
+                "nl": "In haar gedachten ziet ze haar grootmoeder weer voor hoe ze de kleine Sophie leerde een vuur aan te maken in de open haard van hun landhuis.",
+                "pt": "Em sua mente, ela revê sua avó mostrando à pequena Sophie como acender fogo na lareira da casa de campo.",
+                "en_pt": "In her mind, she sees her grandmother showing little Sophie how to light a fire in the country house fireplace."
+            },
+            "ipa": {
+                "fr": "dɑ̃ sɔ̃n ɛspʁˈi ɛl ʁəvwˈa sa- ɡʁˈɑ̃mˈɛʁ mɔ̃tʁˈɑ̃ a la- pətˈit sɔfˈi kɔmˌɑ̃ alymˈe œ̃ fˈø dɑ̃ la- ʃəminˈe də- lœʁ mɛzˈɔ̃ də- kɑ̃pˈaɲ",
+                "de": "[ɪn ˌiːrən ɡədˈaŋkən zˈiːt ziː ˌiːrə ɡrˈɔsmʊtɜ\n diː dɛɾ klˈaɪnən zoːfˈiː tsˈaɪkt\n viː man ɪm kamˈiːn ˌiːrəs lˈanthˌaʊzəs aɪn fˈɔøɜ ˈantsˌʏndət]",
+                "it": "[nˌɛlla sˌʊa mˈente\n rivˈeːde sˌʊa nˈɔnna ˌinseɲˈaːre ˌalla pˈikːola sˈopje kˌome atʃːˈendere ˌʊn fʊˈɔːko nˌɛl kamˈiːno dˌɛlla lˌɔro kˈaːza dˌɪ kampˈaɲɲa]",
+                "es": "[en su ˈmente reˈkwɛɾða a su aˈβwela enseˈɲando a la peˈkeɲa ˈsofi ˈkomo enθenˈdeɾ un ˈfweɣo en la ʧimeˈnea ðe su ˈkasa ðe ˈkampo]",
+                "nl": "[ɪn haːr ɣədˈɑxtən zˈit zə haːr ɣrˈoːtmudər ʋˈɪːr vɔːr hˈu zə də klˈɛɪnə sɔphˈi lˈɪːrdə ən vˈyr aːn tə mˈaːkən ɪn də ˈoːpən hˈaːrt vɑn hɵn lˈɑndhˌœys]",
+                "pt": "[ˈeɪŋ sˌuæ mˈeɪŋtʃy\n ˌɛlæ xevˈe sˌuæ avˈɔ mˌostrˈɐ̃ŋdw ˌaː pˌekˈenæ sˌofˈiy kˌomʊ ˌaseɪŋdˈer fˈoɡʊ na lˌaɾˈeɪɾæ da kˈazæ dʒy kˈɐ̃mpʊ]",
+                "en": "[ɪn hɜː mˈaɪnd ʃiː sˈiːz hɜː ɡɹˈandmʌðə ʃˈəʊɪŋ lˈɪtəl sˈəʊfi hˌaʊ tə lˈaɪt ɐ fˈaɪəɹ ɪnðə fˈaɪəpleɪs ɒv ðeə kˈʌntɹi hˈaʊs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-019",
             "text": {
                 "fr": "Patience, ma chérie",
                 "en": "Patience, my dear",
@@ -271,7 +518,7 @@
             }
         },
         {
-            "id": "scene-11-009",
+            "id": "scene-11-020",
             "text": {
                 "fr": "Le feu vient à ceux qui savent attendre.",
                 "en": "Fire comes to those who know how to wait.",
@@ -301,923 +548,7 @@
             }
         },
         {
-            "id": "scene-11-010",
-            "text": {
-                "fr": "Enfin! Une petite flamme qui grandit!",
-                "en": "Finally! A small flame that grows!",
-                "de": "Endlich! Eine kleine Flamme, die wächst!",
-                "it": "Finalmente! Una piccola fiamma che cresce!",
-                "es": "¡Por fin! Una pequeña llama que crece!",
-                "nl": "Eindelijk! Een klein vlammetje dat groeit!",
-                "pt": "Uma pequena chama que cresce!",
-                "en_pt": "A small flame that's growing!"
-            },
-            "ipa": {
-                "fr": "ɑ̃fˈɛ̃ yn pətˈit flˈam ki ɡʁɑ̃dˈi",
-                "de": "[ˈɛntlɪç\n ˌaɪnə klˈaɪnə flˈamə\n diː vˈɛkst]",
-                "it": "[fˌinalmˈente\n ˌʊna pˈikːola fjˈamma kˌe krˈeːʃe]",
-                "es": "[poɾ ˈfin una peˈkeɲa ˈʎama ke ˈkɾeθe]",
-                "nl": "[ˈɛɪndələk\n ən klˈɛɪn vlˈɑmɛtʲə dɑt ɣrˈujt]",
-                "pt": "[ˌumæ pˌekˈenæ ʃˈɐ̃mæ ky krˈɛsy]",
-                "en": "[fˈaɪnəli ɐ smˈɔːl flˈeɪm ðat ɡɹˈəʊz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-011",
-            "text": {
-                "fr": "Ce feu... c'est moi qui l'ai créé. Moi seule.",
-                "en": "This fire... I created it myself. All alone.",
-                "de": "Dieses Feuer... ich habe es selbst gemacht. Nur ich allein.",
-                "it": "Questo fuoco... l'ho creato io. Solo io.",
-                "es": "Este fuego... lo he creado yo sola.",
-                "nl": "Dit vuur... ik heb het zelf gemaakt. Helemaal alleen."
-            },
-            "ipa": {
-                "fr": "sə- fˈø sɛ mwˌa ki le kʁeˈe mwˌa sˈœl",
-                "de": "[dˌiːzəs fˈɔøɜ\n ɪç hɑːbə ɛs zˈɛlpst ɡəmˈaxt\n nˈuːɾ ɪç alˈaɪn]",
-                "it": "[kwˌɛsto fʊˈɔːko\n lˌo kreˈaːto ˈio\n sˈoːlo ˈio]",
-                "es": "[ˈeste ˈfweɣo lo e kɾeˈaðo ʝo ˈsola]",
-                "nl": "[dɪt vˈyr\n ɪk hɛp hət zˈɛlf ɣəmˈaːkt\n hˌeːləmˈaːl ɑlˈeːn]",
-                "en": "[ðɪs fˈaɪə aɪ kɹiːˈeɪtɪd ɪt maɪsˈɛlf ˈɔːl ɐlˈəʊn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-012",
-            "text": {
-                "fr": "Le feu me donne de la chaleur et du courage.",
-                "en": "The fire gives me warmth and courage.",
-                "de": "Das Feuer gibt mir Wärme und Mut.",
-                "it": "Il fuoco mi dà calore e coraggio.",
-                "es": "El fuego me da calor y valentía.",
-                "nl": "Het vuur geeft me warmte en moed.",
-                "pt": "O fogo me dá calor e coragem."
-            },
-            "ipa": {
-                "fr": "lə- fˈø mə- dˈɔn də- la- ʃalˈœʁ e dy- kuʁˈaʒ",
-                "de": "[das fˈɔøɜ ɡˈiːpt miːɾ vˈɛɾmə ʊnt mˈuːt]",
-                "it": "[ˌil fʊˈɔːko mˌɪ dˈa kalˈoːre ˌe korˈadʒːo]",
-                "es": "[el ˈfweɣo me ða kaˈloɾ i βalenˈti.a]",
-                "nl": "[hət vˈyr ɣˈeːft mə ʋˈɑrmtə ɛn mˈut]",
-                "pt": "[ʊ fˈoɡʊ my dˈa kalˈoɾ i kˌoɾˈaʒeɪŋ]",
-                "en": "[ðə fˈaɪə ɡˈɪvz mˌiː wˈɔːmθ and kˈʌɹɪdʒ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-013",
-            "text": {
-                "fr": "Maintenant, j'ai très faim, mais je n'ai rien à manger.",
-                "en": "Now I'm very hungry, but I have nothing to eat.",
-                "de": "Jetzt habe ich großen Hunger, aber ich habe nichts zu essen.",
-                "it": "Ora ho molto fame, ma non ho nulla da mangiare.",
-                "es": "Ahora tengo mucha hambre, pero no tengo nada que comer.",
-                "nl": "Nu heb ik heel veel honger, maar ik heb niets om te eten.",
-                "pt": "Agora estou com muita fome, mas não tenho nada para comer."
-            },
-            "ipa": {
-                "fr": "mɛ̃tnˈɑ̃ ʒe tʁɛ fˈɛ̃ mɛ ʒə- ne ʁjˌɛ̃n a mɑ̃ʒˈe",
-                "de": "[jˌɛtst hɑːbə ɪç ɡrˈoːsən hˈʊŋɜ\n ˌɑːbɜ ɪç hɑːbə nˈɪçts tsuː ˈɛsən]",
-                "it": "[ˈɔːra ˌo mˈolto fˈaːme\n mˌa nˌon ˌo nˈulla dˌa mandʒˈaːre]",
-                "es": "[aˈoɾa ˈteŋɣo ˈmutʃa ˈamβɾe peɾo no ˈteŋɣo ˈnaða ke koˈmeɾ]",
-                "nl": "[nˈy hɛp ɪk hˈeːl vˈeːl hˈɔŋər\n maːr ɪk hɛp nˌits ɔm tə ˈeːtən]",
-                "pt": "[ˌaɡˈɔɾæ estˌow koŋ mwˈiŋtæ fˈomy\n maz nˌɐ̃ʊ̃ tˌeɲʊ nˈadæ pˌaɾæ komˈer]",
-                "en": "[nˈaʊ aɪm vˈɛɹɪ hˈʌŋɡɹi bˌʌt aɪ hav nˈʌθɪŋ tʊ ˈiːt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-014",
-            "text": {
-                "fr": "Attends... ces plantes près de la cabane, je les reconnais!",
-                "en": "Wait... those plants near the cabin, I recognize them!",
-                "de": "Warte... diese Pflanzen neben der Hütte, ich erkenne sie!",
-                "it": "Aspetta... quelle piante vicino alla capanna, le riconosco!",
-                "es": "Espera... estas plantas cerca del piso, ¡las reconozco!",
-                "nl": "Wacht... die planten bij het huisje, ik herken ze!",
-                "pt": "essas plantas perto da cabana, eu reconheço!",
-                "en_pt": "these plants near the cabin, I recognize them!"
-            },
-            "ipa": {
-                "fr": "atˈɑ̃ se plˈɑ̃t pʁɛ də- la- kabˈan ʒə- le- ʁəkɔnˈɛ",
-                "de": "[vˈaɾtə\n dˌiːzə pflˈantsən nˌeːbən dɛɾ hˈʏtə\n ɪç ɛɾkˈɛnə ziː]",
-                "it": "[aspˈɛtːa\n kwˌɛlle pjˈante vitʃˈiːno ˌalla kapˈanna\n lˌe rˌikonˈosko]",
-                "es": "[esˈpeɾa ˈestas ˈplantas ˈθeɾka ðel ˈpiso las rekoˈnoθko]",
-                "nl": "[ʋˈɑxt\n di plˈɑntən bɛɪ hət hˈœysjə\n ɪk hˈɛrkən zə]",
-                "pt": "[ˈɛsæs plˈɐ̃ŋtæs pˈɛɾətʊ da kˌabˈɐ̃næ\n eʊ xˌekoɲˈesʊ]",
-                "en": "[wˈeɪt ðəʊz plˈants nˌiə ðə kˈabɪn aɪ ɹˈɛkəɡnˌaɪz ðˌɛm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-015",
-            "text": {
-                "fr": "Regarde, Sophie",
-                "en": "Look, Sophie",
-                "de": "Schau, Sophie",
-                "it": "Guarda, Sophie",
-                "es": "Mira, Sophie",
-                "nl": "Kijk, Sophie",
-                "pt": "Olha Sophie.",
-                "en_pt": "Look Sophie."
-            },
-            "ipa": {
-                "fr": "ʁəɡˈaʁd sɔfˈi",
-                "de": "[ʃˈaʊ\n zoːfˈiː]",
-                "it": "[ɡwˈaːrda\n sˈopje]",
-                "es": "[ˈmiɾa ˈsofi]",
-                "nl": "[kˈɛɪk\n sɔphˈi]",
-                "pt": "[ˈɔljæ sˌofˈiy]",
-                "en": "[lˈʊk sˈəʊfi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-016",
-            "text": {
-                "fr": "Les orties te piquent d'abord, mais après, elles te nourrissent",
-                "en": "Nettles sting at first, but then they nourish you",
-                "de": "Die Brennnesseln stechen erst, aber dann nähren sie dich",
-                "it": "Le ortiche prima ti pungono, poi ti nutrono",
-                "es": "Las ortigas te pican primero, pero luego te alimentan",
-                "nl": "Brandnetels prikken eerst, maar daarna voeden ze je",
-                "pt": "As urtigas picam primeiro, mas depois te alimentam.",
-                "en_pt": "Nettles sting first, but then they feed you."
-            },
-            "ipa": {
-                "fr": "le-z ɔʁtˈi tə- pˈik dabˈɔʁ mɛz apʁˈɛ ɛl tə- nuʁˈis",
-                "de": "[diː brˈɛnɛsəln ʃtˈɛçən ˈeːɾst\n ˌɑːbɜ dan nˈɛːrən ziː dˈɪç]",
-                "it": "[lˌe ˈɔrtike prˈiːma tˌɪ pˈuŋɡono\n pˈɔːɪ tˌɪ nˈutrono]",
-                "es": "[las oɾˈtiɣas te ˈpikan pɾiˈmeɾo peɾo ˈlweɣo te aliˈmentan]",
-                "nl": "[brˈɑndnətˌɛls prˈɪkən ˈɪːrst\n maːr dˈaːrnaː vˈudən zə jə]",
-                "pt": "[az ˌuɾətʃˈiɡæs pˈikɐ̃ʊ̃ prˌimˈeɪɾʊ\n maz depˈoɪs tʃj ˌalimˈeɪŋtɐ̃ʊ̃]",
-                "en": "[nˈɛtəlz stˈɪŋ at fˈɜːst bˌʌt ðˈɛn ðeɪ nˈʌɹɪʃ juː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-017",
-            "text": {
-                "fr": "C'est comme la vie, ma petite",
-                "en": "Such is life, my little one",
-                "de": "Das ist wie das Leben, meine Kleine",
-                "it": "È come la vita, piccola mia",
-                "es": "Es como la vida, pequeña",
-                "nl": "Zo is het leven, mijn kleintje",
-                "pt": "É como a vida, minha pequena.",
-                "en_pt": "It's like life, my little one."
-            },
-            "ipa": {
-                "fr": "sɛ kɔm la- vˈi ma- pətˈit",
-                "de": "[das ɪst viː das lˈeːbən\n mˌaɪnə klˈaɪnə]",
-                "it": "[ˌɛ kˌome lˌa vˈiːta\n pˈikːola mˈia]",
-                "es": "[es ˈkomo la ˈβiða peˈkeɲa]",
-                "nl": "[zoː ɪs hət lˈeːvən\n mɛɪn klˈɛɪntʲə]",
-                "pt": "[ɛ kˌomʊ a vˈidæ\n mˌiɲæ pˌekˈenæ]",
-                "en": "[sˈʌtʃ ɪz lˈaɪf maɪ lˈɪtəl wˌɒn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-018",
-            "text": {
-                "fr": "Les choses qui font mal nous rendent plus fortes.",
-                "en": "The things that hurt make us stronger.",
-                "de": "Die Dinge, die wehtun, machen uns stärker.",
-                "it": "Le cose che fanno male ci rendono più forti.",
-                "es": "Las cosas que duelen nos hacen más fuertes.",
-                "nl": "De dingen die pijn doen maken ons sterker.",
-                "pt": "As coisas que machucam nos tornam mais fortes.",
-                "en_pt": "The things that hurt us make us stronger."
-            },
-            "ipa": {
-                "fr": "le- ʃˈoz ki fˈɔ̃ mˈal nu ʁˈɑ̃d ply fˈɔʁt",
-                "de": "[diː dˈɪŋə\n diː vˈeːtuːn\n mˈaxən ʊns ʃtˈɛɾkɜ]",
-                "it": "[lˌe kˈɔːze kˌe fˌanno mˈaːle tʃˌɪ rˈɛndono pjˌʊ fˈɔːrtɪ]",
-                "es": "[las ˈkosas ke ˈdwelen nos ˈaθen ˈmas ˈfwertes]",
-                "nl": "[də dˈɪŋən di pˈɛɪn dˈun mˈaːkən ɔn stˈɛrkər]",
-                "pt": "[as kˈoɪzæs ky mˌaʃˈukɐ̃ʊ̃ nʊs tˈɔɾənɐ̃ʊ̃ mˈaɪs fˈɔɾətʃys]",
-                "en": "[ðə θˈɪŋz ðat hˈɜːt mˌeɪk ˌʌs stɹˈɒŋɡə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-019",
-            "text": {
-                "fr": "Ce sont des orties! Elles sont comestibles si on les fait cuire.",
-                "en": "These are nettles! They are edible if you cook them.",
-                "de": "Das sind Brennnesseln! Sie sind essbar, wenn man sie kocht.",
-                "it": "Sono ortiche! Sono commestibili se cotte.",
-                "es": "¡Son ortigas! Son comestibles si las cocinas.",
-                "nl": "Het zijn brandnetels! Ze zijn eetbaar als je ze kookt.",
-                "pt": "Elas são comestíveis se cozinhar.",
-                "en_pt": "They're edible if you cook them."
-            },
-            "ipa": {
-                "fr": "sə- sˈɔ̃ de-z ɔʁtˈi ɛl sɔ̃ kɔmɛstˈibl sˈi ɔ̃ le- fˈɛ kyˈiʁ",
-                "de": "[das zɪnt brˈɛnɛsəln\n ziː zɪnt ˈɛsbɑːɾ\n vˌɛn man ziː kˈɔxt]",
-                "it": "[sˌono ˈɔrtike\n sˌono kˌommestˈibilɪ sˌe kˈɔtːe]",
-                "es": "[son oɾˈtiɣas son komeˈstiβles si las koˈθinas]",
-                "nl": "[hət zɛɪn brˈɑndnətˌɛls\n zə zɛɪn ˈeːtbaːr ɑls jə zə kˈoːkt]",
-                "pt": "[ˌɛlæs sɐ̃ʊ̃ kˌomestʃˈiveɪs sy kˌoziɲˈar]",
-                "en": "[ðiːz ɑː nˈɛtəlz ðeɪ ɑːɹ ˈɛdəbəl ɪf juː kˈʊk ðˌɛm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-020",
-            "text": {
-                "fr": "J'ose à peine les toucher, elles piquent.",
-                "en": "I hardly dare to touch them, they sting.",
-                "de": "Ich wage es kaum, sie zu berühren, sie stechen.",
-                "it": "Oso a malapena toccarle, pungono.",
-                "es": "Apenas me atrevo a tocarlas, pican.",
-                "nl": "Ik durf ze nauwelijks aan te raken, ze prikken.",
-                "pt": "Mal ouso tocá-las, elas picam.",
-                "en_pt": "I barely dare touch them, they sting."
-            },
-            "ipa": {
-                "fr": "ʒˈoz a pˈɛn le- tuʃˈe ɛl pˈik",
-                "de": "[ɪç vˈɑːɡə ɛs kˈaʊm\n ziː tsuː bərˈyːrən\n ziː ʃtˈɛçən]",
-                "it": "[ˈoːzo ˌa mˌalapˈeːna tokːˈaːrle\n pˈuŋɡono]",
-                "es": "[aˈpenas me aˈtɾeβo a toˈkaɾlas ˈpikan]",
-                "nl": "[ɪk dˈɵrf zə nˈʌʊələks aːn tə rˈaːkən\n zə prˈɪkən]",
-                "pt": "[mˈaʊ ˈowzʊ tokˈalæs\n ˌɛlæs pˈikɐ̃ʊ̃]",
-                "en": "[aɪ hˈɑːdli dˈeə tə tˈʌtʃ ðˌɛm ðeɪ stˈɪŋ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-11-021",
-            "text": {
-                "fr": "Mais il le faut si je veux survivre",
-                "en": "But it's necessary if I want to survive",
-                "de": "Aber ich muss es tun, wenn ich überleben will",
-                "it": "Ma devo farlo se voglio sopravvivere",
-                "es": "Pero tengo que hacerlo si quiero sobrevivir",
-                "nl": "Maar het moet, als ik wil overleven",
-                "pt": "Mas preciso se quero sobreviver.",
-                "en_pt": "But I must if I want to survive."
-            },
-            "ipa": {
-                "fr": "mɛz il lə- fo sˈi ʒə- vˈø syʁvˈivʁ",
-                "de": "[ˌɑːbɜ ɪç mˈʊs ɛs tˈuːn\n vˌɛn ɪç ˌyːbɜlˈeːbən vɪl]",
-                "it": "[mˌa dˈɛːvo fˈaːrlo sˌe vˈoːʎo sˌɔpravvˈivere]",
-                "es": "[ˈpeɾo ˈteŋɣo ke aˈθeɾlo si ˈkjeɾo soβɾeβiˈβiɾ]",
-                "nl": "[maːr hət mˈut\n ɑls ɪk ʋɪl ˌoːvərlˈeːvən]",
-                "pt": "[mas prˌesˈizʊ sy kˈɛɾʊ sobɾevivˈer]",
-                "en": "[bˌʌt ɪts nˈɛsəsəɹi ɪf aɪ wˈɒnt tə səvˈaɪv]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-022",
-            "text": {
-                "fr": "Toute vérité exige qu'on accepte d'abord sa capacité à blesser.",
-                "en": "Every truth requires that you first accept its capacity to hurt.",
-                "de": "Jede Wahrheit erfordert, dass man zuerst ihre Fähigkeit zu verletzen akzeptiert.",
-                "it": "Ogni verità richiede che si accetti prima la sua capacità di ferire.",
-                "es": "Toda verdad requiere que primero aceptemos su capacidad de hacer daño.",
-                "nl": "Elke waarheid vereist dat je eerst haar vermogen om te kwetsen accepteert.",
-                "pt": "Toda verdade exige que aceitemos primeiro sua capacidade de ferir.",
-                "en_pt": "Every truth demands that we first accept its capacity to wound."
-            },
-            "ipa": {
-                "fr": "tut veʁitˈe ɛɡzˈiʒ kɔ̃n aksˈɛpt dabˈɔʁ sa- kapasitˈe a blɛsˈe",
-                "de": "[jˈeːdə vˈɑːɾhaɪt ɛɾfˈɔɾdɜt\n das man tsuːˈeːɾst ˌiːrə fˈɛːɪçkˌaɪt tsuː fɛɾlˈɛtsən ˌaktsɛptˈiːɾt]",
-                "it": "[ˈoɲʲɪ vˌɛritˈa rikjˈeːde kˌe sˌɪ atʃːˈetːɪ prˈiːma lˌa sˌʊa kˌapatʃitˈa dˌɪ ferˈiːre]",
-                "es": "[ˈtoða βeɾˈðað reˈkjeɾe ke pɾiˈmeɾo aθepˈtemos su kapaθiˈðað de aˈθeɾ ˈdaɲo]",
-                "nl": "[ˈɛlkə ʋˈaːrhɛɪt vərˈɛɪst dɑt jə ˈɪːrst haːr vərmˌoːɣən ɔm tə kʋˈɛtsən ˌɑksɛptˈɪrt]",
-                "pt": "[tˈodæ vˌeɾədˈadʒj ˌezˈiʒy ky ˌaseɪtˈemʊs prˌimˈeɪɾʊ sˌuæ kˌapasidˈadʒy dʒy feɾˈir]",
-                "en": "[ˈɛvɹɪ tɹˈuːθ ɹɪkwˈaɪəz ðat juː fˈɜːst ɐksˈɛpt ɪts kəpˈasɪti tə hˈɜːt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-023",
-            "text": {
-                "fr": "Où puis-je trouver de l'eau potable?",
-                "en": "Where can I find drinking water?",
-                "de": "Wo kann ich Trinkwasser finden?",
-                "it": "Dove posso trovare dell'acqua potabile?",
-                "es": "¿Dónde puedo encontrar agua potable?",
-                "nl": "Waar kan ik drinkwater vinden?",
-                "pt": "Onde posso encontrar água potável?"
-            },
-            "ipa": {
-                "fr": "u pyˈiʒ tʁuvˈe də- lˈo pɔtˈabl",
-                "de": "[vˌoː kˌan ɪç tɾˈɪŋkvasɜ fˈɪndən]",
-                "it": "[dˈoːve pˈɔsso trovˈaːre dellˈakːwa potˈabile]",
-                "es": "[ˈðonde ˈpwedo enkonˈtɾaɾ ˈaɣwa poˈtaβle]",
-                "nl": "[ʋˈaːr kɑn ɪk drˈɪŋkʋaːtər vˈɪndən]",
-                "pt": "[ˌoŋdʒy pˌɔsʊ ˌeɪŋkoŋtrˈaɾ ˈaɡwæ pˌotˈaveʊ]",
-                "en": "[wˌeə kan aɪ fˈaɪnd dɹˈɪŋkɪŋ wˈɔːtə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-024",
-            "text": {
-                "fr": "J'entends un bruit... comme de l'eau qui coule!",
-                "en": "I hear a sound... like flowing water!",
-                "de": "Ich höre ein Geräusch... wie Wasser, das fließt!",
-                "it": "Sento un rumore... come di acqua che scorre!",
-                "es": "¡Escucho un ruido... como de agua que fluye!",
-                "nl": "Ik hoor een geluid... als van stromend water!",
-                "pt": "Ouço um barulho...",
-                "en_pt": "I hear a sound..."
-            },
-            "ipa": {
-                "fr": "ʒɑ̃tˈɑ̃z œ̃ bʁyˈi kɔm də- lˈo ki kˈul",
-                "de": "[ɪç hˈøːrə aɪn ɡərˈɔøʃ\n viː vˈasɜ\n das flˈiːst]",
-                "it": "[sˈɛnto ˌʊn rʊmˈoːre\n kˌome dˌɪ ˈakːwa kˌe skˈɔrɾe]",
-                "es": "[esˈkuʧo un ˈrwiðo ˈkomo de ˈaɣwa ke ˈflwe]",
-                "nl": "[ɪk hˈoːr ən ɣəlˈœyt\n ɑls vɑn strˈoːmənt ʋˈaːtər]",
-                "pt": "[ˈowsw ũŋ bˌaɾˈuljʊ]",
-                "en": "[aɪ hˈiəɹ ɐ sˈaʊnd lˈaɪk flˈəʊɪŋ wˈɔːtə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-025",
-            "text": {
-                "fr": "Une source! Une eau claire, douce, qui jaillit des rochers!",
-                "en": "A spring! Clear, soft water that springs from the rocks!",
-                "de": "Eine Quelle! Klares, süßes Wasser, das aus den Felsen sprudelt!",
-                "it": "Una sorgente! Un'acqua chiara, dolce, che sgorga dalle rocce!",
-                "es": "¡Un manantial! Agua clara, dulce, que brota de las rocas!",
-                "nl": "Een bron! Helder, zacht water dat uit de rotsen springt!",
-                "pt": "Água clara, doce, que brota das pedras!",
-                "en_pt": "Clear, fresh water, gushing from the rocks!"
-            },
-            "ipa": {
-                "fr": "yn sˈuʁs yn ˈo klˈɛʁ dˈus ki ʒajˈi de- ʁɔʃˈe",
-                "de": "[ˌaɪnə kvˈɛlə\n klˈɑːrəs\n zˈyːsəs vˈasɜ\n das ˌaʊs deːn fˈɛlzən ʃprˈuːdəlt]",
-                "it": "[ˌʊna sordʒˈɛnte\n ʊnˈakːwa kjˈaːra\n dˈoltʃe\n kˌe zɡˈɔːrɡa dˌalle rˈɔtʃːe]",
-                "es": "[un manaŋˈtʝal ˈaɣwa ˈklaɾa ˈdulθe ke ˈbɾota ðe las ˈrokas]",
-                "nl": "[ən brˈɔn\n hˈɛldər\n zˈɑxt ʋˈaːtər dɑt œy tə rˈɔtsən sprˈɪŋt]",
-                "pt": "[ˈaɡwæ klˈaɾæ\n dˈosy\n ky brˈɔtæ das pˈɛdræs]",
-                "en": "[ɐ spɹˈɪŋ klˈiə sˈɒft wˈɔːtə ðat spɹˈɪŋz fɹʌmðə ɹˈɒks]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-026",
-            "text": {
-                "fr": "Avec le feu, l'eau de la source, et les orties, je fais une soupe.",
-                "en": "With the fire, the spring water, and the nettles, I make a soup.",
-                "de": "Mit dem Feuer, dem Wasser aus der Quelle und den Brennnesseln mache ich eine Suppe.",
-                "it": "Con il fuoco, l'acqua della sorgente e le ortiche, faccio una zuppa.",
-                "es": "Con el fuego, el agua del manantial y las ortigas, hago una sopa.",
-                "nl": "Met het vuur, het water van de bron, en de brandnetels, maak ik een soep.",
-                "pt": "Com o fogo, a água da nascente e as urtigas, faço uma sopa.",
-                "en_pt": "With the fire, the spring water and the nettles, I make a soup."
-            },
-            "ipa": {
-                "fr": "avˌɛk lə- fˈø lˈo də- la- sˈuʁs e le-z ɔʁtˈi ʒə- fˈɛz yn sˈup",
-                "de": "[mɪt deːm fˈɔøɜ\n deːm vˈasɜ ˌaʊs dɛɾ kvˈɛlə ʊnt deːn brˈɛnɛsəln mˈaxə ɪç ˌaɪnə zˈʊpə]",
-                "it": "[kˌon ˌil fʊˈɔːko\n lˈakːwa dˌɛlla sordʒˈɛnte ˌe lˌe ˈɔrtike\n fˌatʃːo ˌʊna dzˈupːa]",
-                "es": "[kon el ˈfweɣo el ˈaɣwa ðel manaŋˈtʝal i las oɾˈtiɣas ˈaɣo ˈuna ˈsopa]",
-                "nl": "[mɛt hət vˈyr\n hət ʋˈaːtər vɑn də brˈɔn\n ɛn də brˈɑndnətˌɛls\n mˈaːk ɪk ən sˈup]",
-                "pt": "[koŋ ʊ fˈoɡʊ\n a ˈaɡwæ da nˌasˈeɪŋtʃj i az ˌuɾətʃˈiɡæs\n fˌasʊ ˌumæ sˈopæ]",
-                "en": "[wɪððə fˈaɪə ðə spɹˈɪŋ wˈɔːtə and ðə nˈɛtəlz aɪ mˌeɪk ɐ sˈuːp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-027",
-            "text": {
-                "fr": "La nature me donne exactement ce dont j'ai besoin",
-                "en": "Nature gives me exactly what I need",
-                "de": "Die Natur gibt mir genau das, was ich brauche",
-                "it": "La natura mi dà esattamente quello di cui ho bisogno",
-                "es": "La naturaleza me ofrece exactamente lo que necesito",
-                "nl": "De natuur geeft me precies wat ik nodig heb",
-                "pt": "A natureza me dá exatamente o que preciso.",
-                "en_pt": "Nature gives me exactly what I need."
-            },
-            "ipa": {
-                "fr": "la- natˈyʁ mə- dˈɔn ɛɡzaktəmˈɑ̃ sə- dɔ̃ ʒe bəzwˈɛ̃",
-                "de": "[diː nˈɑtuːɾ ɡˈiːpt miːɾ ɡənˈaʊ das\n vˈas ɪç brˈaʊxə]",
-                "it": "[lˌa natˈuːra mˌɪ dˈa ˌezatːamˈente kwˈɛllo dˌɪ kˈuj ˌo bizˈoɲʲo]",
-                "es": "[la natuˈɾaleθa me oˈfɾeθe eksakˈtamente lo ke neseˈsito]",
-                "nl": "[də naːtˈyr ɣˈeːft mə preːsˈis ʋɑt ɪk nˈoːdəx hɛp]",
-                "pt": "[a nˌatuɾˈezæ my dˈa ˌezatæmˈeɪŋtʃj ʊ ky prˌesˈizʊ]",
-                "en": "[nˈeɪtʃə ɡˈɪvz mˌiː ɛɡzˈaktli wɒt aɪ nˈiːd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-028",
-            "text": {
-                "fr": "Ou bien..",
-                "en": "Or...",
-                "de": "Oder...",
-                "it": "O forse...",
-                "es": "O quizás...",
-                "nl": "Of..."
-            },
-            "ipa": {
-                "fr": "u bjˈɛ̃",
-                "de": "[ˈoːdɜ]",
-                "it": "[ˌo fˈoːrse]",
-                "es": "[o kiˈθas]",
-                "nl": "[ˈɔf]",
-                "en": "[ˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-029",
-            "text": {
-                "fr": "est-ce moi qui interprète ses dons?",
-                "en": "is it me who interprets her gifts?",
-                "de": "bin ich es, die ihre Gaben interpretiert?",
-                "it": "sono io che interpreto i suoi doni?",
-                "es": "¿será que yo interpreto sus regalos?",
-                "nl": "is het dat ik haar geschenken interpreteer?",
-                "pt": "sou eu quem interpreta seus dons?",
-                "en_pt": "am I the one interpreting its gifts?"
-            },
-            "ipa": {
-                "fr": "ɛs mwˌa ki ɛ̃tɛʁpʁˈɛt se- dˈɔ̃",
-                "de": "[bɪn ɪç ˈɛs\n diː ˌiːrə ɡˈɑːbən ˌɪntɜpreːtˈiːɾt]",
-                "it": "[sˌono ˌio kˌe intˈɛrpreto ˌɪ sʊˌɔɪ dˈoːnɪ]",
-                "es": "[ˈseɾa ke ʝo inteɾˈpɾeto sus reˈɣalos]",
-                "nl": "[ɪs hət dɑt ɪk haːr ɣəsxˈɛŋkən ˌɪntərprətˈɪr]",
-                "pt": "[sow eʊ kˈeɪŋ ˌiŋteɾəprˈɛtæ seʊz dˈoŋs]",
-                "en": "[ɪz ɪt mˌiː hˌuː ɪntˈɜːpɹɪts hɜː ɡˈɪfts]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-030",
-            "text": {
-                "fr": "La montagne m'offre ces éléments, mais c'est moi qui les transforme en survie.",
-                "en": "Nature offers these elements, but it's me who transforms them into survival.",
-                "de": "Die Berge bieten mir diese Elemente, aber ich bin es, die sie in Überleben verwandelt.",
-                "it": "La montagna mi offre questi elementi, ma sono io che li trasformo in sopravvivenza.",
-                "es": "La montaña me ofrece estos elementos, pero soy yo quien los transforma en supervivencia.",
-                "nl": "De natuur biedt deze elementen, maar ik transformeer ze tot overleving.",
-                "pt": "A montanha me oferece esses elementos, mas sou eu quem os transforma em sobrevivência.",
-                "en_pt": "The mountain offers me these elements, but I'm the one who transforms them into survival."
-            },
-            "ipa": {
-                "fr": "la- mɔ̃tˈaɲ mˈɔfʁ sez elemˈɑ̃ mɛ sɛ mwˌa ki le- tʁɑ̃sfˈɔʁm ɑ̃ syʁvˈi",
-                "de": "[diː bˈɛɾɡə bˈiːtən miːɾ dˌiːzə ˌeːleːmˈɛntə\n ˈɑːbɜ ɪç bɪn ɛs\n diː ziː ɪn ˌyːbɜlˈeːbən fɛɾvˈandəlt]",
-                "it": "[lˌa montˈaɲɲa mˌɪ ˈoffre kwˌɛstɪ ˌɛlemˈentɪ\n mˌa sˌono ˌio kˌe lˌɪ trasfˈoːrmo ˌin sˌɔpravvivˈɛntsa]",
-                "es": "[la monˈtaɲa me oˈfɾeθe ˈestos eleˈmentos ˈpeɾo ˈsoʝ ʝo kjen los tɾansˈfoɾma en supeɾbiˈβenθja]",
-                "nl": "[də naːtˈyr bˈi tˌeːzə ˌeːləmˈɛntən\n maːr ɪk trˌɑnsfɔrmˈɪr zə tɔt ˌoːvərlˈeːvɪŋ]",
-                "pt": "[a mˌoŋtˈɐ̃ɲæ mj ˌofeɾˈɛsj ˌesiz ˌelemˈeɪŋtʊs\n mas sow eʊ kˈeɪŋ ʊs trˌɐ̃ŋsfˈɔɾəmæ ˈeɪŋ sobɾevˌivˈeɪŋsjæ]",
-                "en": "[nˈeɪtʃəɹ ˈɒfəz ðiːz ˈɛlɪmənts bˌʌt ɪts mˌiː hˌuː tɹansfˈɔːmz ðˌɛm ˌɪntʊ səvˈaɪvəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-031",
-            "text": {
-                "fr": "Cette épreuve m'apprend que je suis plus forte que je ne pensais.",
-                "en": "This challenge teaches me that I am stronger than I thought.",
-                "de": "Diese Prüfung lehrt mich, dass ich stärker bin, als ich dachte.",
-                "it": "Questa prova mi insegna che sono più forte di quanto pensassi.",
-                "es": "Esta prueba me enseña que soy más fuerte de lo que pensaba.",
-                "nl": "Deze uitdaging leert me dat ik sterker ben dan ik dacht.",
-                "pt": "Esta prova me ensina que sou mais forte do que pensava.",
-                "en_pt": "This trial teaches me that I'm stronger than I thought."
-            },
-            "ipa": {
-                "fr": "sɛt epʁˈøv mapʁˈɑ̃ kə ʒə- syˌi ply fˈɔʁt kə ʒə- nə- pɑ̃sˈɛ",
-                "de": "[dˌiːzə prˈyːfʊŋ lˈeːɾt mɪç\n das ɪç ʃtˈɛɾkɜ bɪn\n als ɪç dˈaxtə]",
-                "it": "[kwˌɛsta prˈɔːva mˌɪ insˈeɲʲa kˌe sˌono pjˌʊ fˈɔːrte dˌɪ kwˈanto pensˈassɪ]",
-                "es": "[ˈesta ˈpɾweβa me enˈseɲa ke ˈsoʝ ˈmas ˈfweɾte ðe lo ke penˈsaβa]",
-                "nl": "[dˌeːzə ˈœytdˌaːɣɪŋ lˈɪːrt mə dɑt ɪk stˈɛrkər bɛn dˈɑn ɪk dˈɑxt]",
-                "pt": "[ˌɛstæ prˈɔvæ mj ˌeɪŋsˈinæ ky sow mˈaɪs fˈɔɾətʃy dʊ ky pˌeɪŋsˈavæ]",
-                "en": "[ðɪs tʃˈalɪndʒ tˈiːtʃɪz mˌiː ðat aɪɐm stɹˈɒŋɡə ðɐn aɪ θˈɔːt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-032",
-            "text": {
-                "fr": "Qui suis-je vraiment? Peut-être que je ne le saurai jamais complètement",
-                "en": "Who am I really? Maybe I'll never fully know.",
-                "de": "Wer bin ich wirklich? Vielleicht werde ich es nie ganz wissen.",
-                "it": "Chi sono veramente? Forse non lo saprò mai completamente.",
-                "es": "¿Quién soy realmente? Quizás nunca lo sepa completamente",
-                "nl": "Wie ben ik echt? Misschien zal ik het nooit helemaal weten.",
-                "pt": "Talvez eu nunca saiba completamente.",
-                "en_pt": "Maybe I'll never know completely."
-            },
-            "ipa": {
-                "fr": "ki syˌiʒ vʁɛmˈɑ̃ pˈøtˈɛtʁ kə ʒə- nə- lə- soʁˈe ʒamˌɛ kɔ̃plɛtmˈɑ̃",
-                "de": "[vˈeːɾ bɪn ɪç vˈɪɾklɪç\n fiːllˈaɪçt vˌɛɾdə ɪç ɛs nˈiː ɡˌants vˈɪsən]",
-                "it": "[kˈi sˌono vˌɛramˈente\n fˈoːrse nˌon lˌo saprˈɔ mˌaɪ kˌompletamˈente]",
-                "es": "[ˈkjen ˈsoʝ reˈalmente kiˈθas ˈnunka lo ˈsepa kompleˈtamente]",
-                "nl": "[ʋˈi bɛn ɪk ˈɛxt\n mɪsxˈin zɑl ɪk hət nˈoːjt hˌeːləmˈaːl ʋˈeːtən]",
-                "pt": "[taʊvˈez eʊ nˌũŋkæ sˈaɪbæ kˌompletæmˈeɪŋtʃy]",
-                "en": "[hˌuː am aɪ ɹˈiəlɪ mˈeɪbiː aɪl nˈɛvə fˈʊli nˈəʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-033",
-            "text": {
-                "fr": "Peut-être que c'est normal.",
-                "en": "Maybe that's normal.",
-                "de": "Vielleicht ist das normal.",
-                "it": "Forse è normale.",
-                "es": "Quizás eso es normal.",
-                "nl": "Misschien is dat normaal.",
-                "pt": "Talvez seja normal."
-            },
-            "ipa": {
-                "fr": "pˈøtˈɛtʁ kə sɛ nɔʁmˈal",
-                "de": "[fiːllˈaɪçt ɪst das nˈɔɾmɑːl]",
-                "it": "[fˈoːrse ˌɛ normˈaːle]",
-                "es": "[kiˈθas ˈeso es noɾˈmal]",
-                "nl": "[mɪsxˈin ɪs dɑt nɔrmˈaːl]",
-                "pt": "[taʊvˈes sˈeʒæ noɾəmˈaʊ]",
-                "en": "[mˈeɪbiː ðats nˈɔːməl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-034",
-            "text": {
-                "fr": "Sophie entre dans la cabane.",
-                "en": "Sophie enters the cabin.",
-                "de": "Sophie betritt die Hütte.",
-                "it": "Sophie entra nella capanna.",
-                "es": "Sophie entra en el piso.",
-                "nl": "Sophie gaat de hut binnen.",
-                "pt": "Sophie entra na cabana."
-            },
-            "ipa": {
-                "fr": "sɔfˈi ɑ̃tʁ dɑ̃ la- kabˈan",
-                "de": "[zoːfˈiː bətɾˈɪt diː hˈʏtə]",
-                "it": "[sˈopje ˈentra nˌɛlla kapˈanna]",
-                "es": "[ˈsofi ˈentɾa en el ˈpiso]",
-                "nl": "[sɔphˈi ɣˈaː tə hˈɵt bˈɪnən]",
-                "pt": "[sˌofˈij ˈeɪŋtræ na kˌabˈɐ̃næ]",
-                "en": "[sˈəʊfi ˈɛntəz ðə kˈabɪn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-035",
-            "text": {
-                "fr": "C'est une vieille structure de berger, simple mais solide.",
-                "en": "It's an old shepherd's hut, simple but sturdy.",
-                "de": "Es ist eine alte Schäferhütte, einfach aber stabil.",
-                "it": "È una vecchia struttura da pastore, semplice ma solida.",
-                "es": "Es una vieja estructura de pastor, simple pero sólida.",
-                "nl": "Het is een oude herdershut, eenvoudig maar stevig.",
-                "pt": "É uma velha estrutura de pastor, simples mas sólida.",
-                "en_pt": "It's an old shepherd's structure, simple but solid."
-            },
-            "ipa": {
-                "fr": "sɛt yn vjˈɛj stʁyktˈyʁ də- bɛʁʒˈe sˈɛ̃pl mɛ sɔlˈid",
-                "de": "[ɛsɪst ˌaɪnə ˈaltə ʃˈɛːfɜhˌʏtə\n ˈaɪnfˌax ˌɑːbɜ ʃtabˈiːl]",
-                "it": "[ˌɛ ˌʊna vˈɛkːia strʊtːˈuːra dˌa pastˈoːre\n sˈemplitʃe mˌa sˈɔlida]",
-                "es": "[es ˈuna ˈβjexa estɾukˈtuɾa ðe pasˈtoɾ ˈsimple peɾo ˈsolida]",
-                "nl": "[hət ɪs ən ˈʌʊdə hˈɛrdərshˌɵt\n eːnvˈʌʊdəx maːr stˈeːvəx]",
-                "pt": "[ɛ ˌumæ vˈɛljæ ˌestrutˈuɾæ dʒy pastˈor\n sˈimplyz mas sˈɔlidæ]",
-                "en": "[ɪts ɐn ˈəʊld ʃˈɛpədz hˈʌt sˈɪmpəl bˌʌt stˈɜːdi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-036",
-            "text": {
-                "fr": "Elle cherche dans ses poches.",
-                "en": "She searches in her pockets.",
-                "de": "Sie sucht in ihren Taschen.",
-                "it": "Cerca nelle sue tasche.",
-                "es": "Busca en sus bolsillos.",
-                "nl": "Ze zoekt in haar zakken.",
-                "pt": "Ela procura nos bolsos."
-            },
-            "ipa": {
-                "fr": "ɛl ʃˈɛʁʃ dɑ̃ se- pˈɔʃ",
-                "de": "[ziː zˈuːxt ɪn ˌiːrən tˈaʃən]",
-                "it": "[tʃˈeːrka nˌɛlle sˌʊe tˈaske]",
-                "es": "[ˈbuska en sus bolˈsiʎos]",
-                "nl": "[zə zˈukt ɪn haːr zˈɑkən]",
-                "pt": "[ˌɛlæ prˌokˈuɾæ nʊz bˈowsʊs]",
-                "en": "[ʃiː sˈɜːtʃɪz ɪn hɜː pˈɒkɪts]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-037",
-            "text": {
-                "fr": "Elle trouve du bois à l'intérieur de la cabane, mais il est humide.",
-                "en": "She finds wood inside the cabin, but it is damp.",
-                "de": "Sie findet Holz in der Hütte, aber es ist feucht.",
-                "it": "Trova della legna all'interno della capanna, ma è umida.",
-                "es": "Encuentra madera dentro del piso, pero está húmeda.",
-                "nl": "Ze vindt hout binnen in de hut, maar het is vochtig.",
-                "pt": "Ela encontra lenha dentro da cabana, mas está úmida.",
-                "en_pt": "She finds firewood inside the cabin, but it's damp."
-            },
-            "ipa": {
-                "fr": "ɛl tʁˈuv dy- bwˈaz a lɛ̃teʁjˈœʁ də- la- kabˈan mɛz il ɛt ymˈid",
-                "de": "[ziː fˈɪndət hˈɔlts ɪn dɛɾ hˈʏtə\n ˌɑːbɜ ɛsɪst fˈɔøçt]",
-                "it": "[trˈɔːva dˌɛlla lˈeɲʲa allintˈɛːrno dˌɛlla kapˈanna\n mˌa ˌɛ ˈumida]",
-                "es": "[enˈkwentɾa maˈðeɾa ˈðentɾo ðel ˈpiso ˈpeɾo ˈesta ˈumeda]",
-                "nl": "[zə vˈɪnt hˈʌʊt bˈɪnən ɪn də hˈɵt\n maːr hət ɪs vˈɔxtəx]",
-                "pt": "[ˌɛlæ ˌeɪŋkˈoŋtræ lˈeɲæ dˈeɪŋtrʊ da kˌabˈɐ̃næ\n maz estˌa ˈũmidæ]",
-                "en": "[ʃiː fˈaɪndz wˈʊd ɪnsˈaɪd ðə kˈabɪn bˌʌt ɪt ɪz dˈamp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-038",
-            "text": {
-                "fr": "Elle arrange le bois, met du papier, prend une allumette.",
-                "en": "She arranges the wood, adds some paper, takes a match.",
-                "de": "Sie arrangiert das Holz, legt Papier dazu und nimmt ein Streichholz.",
-                "it": "Sistema la legna, mette della carta, prende un fiammifero.",
-                "es": "Arregla la madera, pone papel, saca una cerilla.",
-                "nl": "Ze schikt het hout, legt er papier bij, pakt een lucifer.",
-                "pt": "Ela arruma a lenha, coloca papel, pega um fósforo.",
-                "en_pt": "She arranges the wood, places paper, takes a match."
-            },
-            "ipa": {
-                "fr": "ɛl aʁˈɑ̃ʒ lə- bwˈa mˈɛ dy- papjˈe pʁˈɑ̃t yn alymˈɛt",
-                "de": "[ziː ˌaraŋʒˈiːət das hˈɔlts\n lˈeːkt papˈiːɾ dɑːtsˈuː ʊnt nˈɪmt aɪn ʃtɾˈaɪçhɔlts]",
-                "it": "[sistˈɛːma lˌa lˈeɲʲa\n mˈetːe dˌɛlla kˈaːrta\n prˈɛnde ˌʊn fjammˈifero]",
-                "es": "[aˈrɾeɣla la maˈðeɾa ˈpone paˈpel ˈsaka ˈuna θeˈɾiʎa]",
-                "nl": "[zə sxˈɪkt hət hˈʌʊt\n lˈɛxt ər paːpˈir bˈɛɪ\n pˈɑkt ən lˈysifər]",
-                "pt": "[ˌɛlæ ˌaxˈumæ a lˈeɲæ\n kˌolˈɔkæ papˈɛʊ\n pˈɛɡæ ũŋ fˈɔsfoɾʊ]",
-                "en": "[ʃiː ɐɹˈeɪndʒɪz ðə wˈʊd ˈadz sˌʌm pˈeɪpə tˈeɪks ɐ mˈatʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-039",
-            "text": {
-                "fr": "Dans son esprit, elle revoit sa grand-mère montrant à la petite Sophie comment allumer un feu dans la cheminée de leur maison de campagne.",
-                "en": "In her mind, she revisits her grandmother showing young Sophie how to light a fire in the fireplace of their country house.",
-                "de": "In ihren Gedanken sieht sie ihre Großmutter, die der kleinen Sophie zeigt, wie man im Kamin ihres Landhauses ein Feuer anzündet.",
-                "it": "Nella sua mente, rivede sua nonna insegnare alla piccola Sophie come accendere un fuoco nel camino della loro casa di campagna.",
-                "es": "En su mente, recuerda a su abuela enseñando a la pequeña Sophie cómo encender un fuego en la chimenea de su casa de campo.",
-                "nl": "In haar gedachten ziet ze haar grootmoeder weer voor hoe ze de kleine Sophie leerde een vuur aan te maken in de open haard van hun landhuis.",
-                "pt": "Em sua mente, ela revê sua avó mostrando à pequena Sophie como acender fogo na lareira da casa de campo.",
-                "en_pt": "In her mind, she sees her grandmother showing little Sophie how to light a fire in the country house fireplace."
-            },
-            "ipa": {
-                "fr": "dɑ̃ sɔ̃n ɛspʁˈi ɛl ʁəvwˈa sa- ɡʁˈɑ̃mˈɛʁ mɔ̃tʁˈɑ̃ a la- pətˈit sɔfˈi kɔmˌɑ̃ alymˈe œ̃ fˈø dɑ̃ la- ʃəminˈe də- lœʁ mɛzˈɔ̃ də- kɑ̃pˈaɲ",
-                "de": "[ɪn ˌiːrən ɡədˈaŋkən zˈiːt ziː ˌiːrə ɡrˈɔsmʊtɜ\n diː dɛɾ klˈaɪnən zoːfˈiː tsˈaɪkt\n viː man ɪm kamˈiːn ˌiːrəs lˈanthˌaʊzəs aɪn fˈɔøɜ ˈantsˌʏndət]",
-                "it": "[nˌɛlla sˌʊa mˈente\n rivˈeːde sˌʊa nˈɔnna ˌinseɲˈaːre ˌalla pˈikːola sˈopje kˌome atʃːˈendere ˌʊn fʊˈɔːko nˌɛl kamˈiːno dˌɛlla lˌɔro kˈaːza dˌɪ kampˈaɲɲa]",
-                "es": "[en su ˈmente reˈkwɛɾða a su aˈβwela enseˈɲando a la peˈkeɲa ˈsofi ˈkomo enθenˈdeɾ un ˈfweɣo en la ʧimeˈnea ðe su ˈkasa ðe ˈkampo]",
-                "nl": "[ɪn haːr ɣədˈɑxtən zˈit zə haːr ɣrˈoːtmudər ʋˈɪːr vɔːr hˈu zə də klˈɛɪnə sɔphˈi lˈɪːrdə ən vˈyr aːn tə mˈaːkən ɪn də ˈoːpən hˈaːrt vɑn hɵn lˈɑndhˌœys]",
-                "pt": "[ˈeɪŋ sˌuæ mˈeɪŋtʃy\n ˌɛlæ xevˈe sˌuæ avˈɔ mˌostrˈɐ̃ŋdw ˌaː pˌekˈenæ sˌofˈiy kˌomʊ ˌaseɪŋdˈer fˈoɡʊ na lˌaɾˈeɪɾæ da kˈazæ dʒy kˈɐ̃mpʊ]",
-                "en": "[ɪn hɜː mˈaɪnd ʃiː ɹɪvˈɪzɪts hɜː ɡɹˈandmʌðə ʃˈəʊɪŋ jˈʌŋ sˈəʊfi hˌaʊ tə lˈaɪt ɐ fˈaɪəɹ ɪnðə fˈaɪəpleɪs ɒv ðeə kˈʌntɹi hˈaʊs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-040",
             "text": {
                 "fr": "À la quatrième tentative, une petite flamme apparaît.",
                 "en": "On the fourth attempt, a small flame appears.",
@@ -1248,7 +579,53 @@
             }
         },
         {
-            "id": "scene-11-041",
+            "id": "scene-11-022",
+            "text": {
+                "pt": "Finalmente!",
+                "en": "Finally!"
+            },
+            "ipa": {
+                "pt": "[fˌinaʊmˈeɪŋtʃy]",
+                "en": "[fˈaɪnəli]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-023",
+            "text": {
+                "fr": "Enfin! Une petite flamme qui grandit!",
+                "en": "Finally! A small flame growing!",
+                "de": "Endlich! Eine kleine Flamme, die wächst!",
+                "it": "Finalmente! Una piccola fiamma che cresce!",
+                "es": "¡Por fin! Una pequeña llama que crece!",
+                "nl": "Eindelijk! Een klein vlammetje dat groeit!",
+                "pt": "Uma pequena chama que cresce!",
+                "en_pt": "A small flame that's growing!"
+            },
+            "ipa": {
+                "fr": "ɑ̃fˈɛ̃ yn pətˈit flˈam ki ɡʁɑ̃dˈi",
+                "de": "[ˈɛntlɪç\n ˌaɪnə klˈaɪnə flˈamə\n diː vˈɛkst]",
+                "it": "[fˌinalmˈente\n ˌʊna pˈikːola fjˈamma kˌe krˈeːʃe]",
+                "es": "[poɾ ˈfin una peˈkeɲa ˈʎama ke ˈkɾeθe]",
+                "nl": "[ˈɛɪndələk\n ən klˈɛɪn vlˈɑmɛtʲə dɑt ɣrˈujt]",
+                "pt": "[ˌumæ pˌekˈenæ ʃˈɐ̃mæ ky krˈɛsy]",
+                "en": "[fˈaɪnəli ɐ smˈɔːl flˈeɪm ɡɹˈəʊɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-024",
             "text": {
                 "fr": "Elle souffle doucement et la flamme grandit.",
                 "en": "She blows gently and the flame grows.",
@@ -1278,7 +655,7 @@
             }
         },
         {
-            "id": "scene-11-042",
+            "id": "scene-11-025",
             "text": {
                 "fr": "Bientôt, un vrai feu brûle dans la cheminée.",
                 "en": "Soon, a real fire burns in the fireplace.",
@@ -1308,15 +685,61 @@
             }
         },
         {
-            "id": "scene-11-043",
+            "id": "scene-11-026",
+            "text": {
+                "pt": "Este fogo...",
+                "en": "This fire..."
+            },
+            "ipa": {
+                "pt": "[ˌestʃy fˈoɡʊ]",
+                "en": "[ðɪs fˈaɪə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-027",
+            "text": {
+                "pt": "fui eu quem criei.",
+                "en": "I created it."
+            },
+            "ipa": {
+                "pt": "[fuɪ eʊ kˈeɪŋ kriˈeɪ]",
+                "en": "[aɪ kɹiːˈeɪtɪd ɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-028",
+            "text": {
+                "pt": "Só eu.",
+                "en": "Just me."
+            },
+            "ipa": {
+                "pt": "[sˈɔ ˈeʊ]",
+                "en": "[dʒˈʌst mˌiː]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-029",
             "text": {
                 "fr": "La chaleur se répand dans la petite cabane.",
-                "en": "The warmth spreads through the small cabin.",
+                "en": "Warmth spreads through the little cabin.",
                 "de": "Die Wärme breitet sich in der kleinen Hütte aus.",
                 "it": "Il calore si diffonde nella piccola capanna.",
                 "es": "El calor se extiende por la pequeña cabaña.",
                 "nl": "De warmte verspreidt zich door de kleine hut.",
-                "pt": "O calor se espalha pela pequena cabana."
+                "pt": "O calor se espalha pela pequena cabana.",
+                "en_pt": "The warmth spreads through the small cabin."
             },
             "ipa": {
                 "fr": "la- ʃalˈœʁ sə- ʁepˈɑ̃ dɑ̃ la- pətˈit kabˈan",
@@ -1325,7 +748,7 @@
                 "es": "[el kaˈloɾ se eksˈtjen.de poɾ la peˈkeɲa kaˈβa.ɲa]",
                 "nl": "[də ʋˈɑrmtə vərsprˈɛɪt zɪx doːr də klˈɛɪnə hˈɵt]",
                 "pt": "[ʊ kalˈor sj ˌespˈaljæ pˈelæ pˌekˈenæ kˌabˈɐ̃næ]",
-                "en": "[ðə wˈɔːmθ spɹˈɛdz θɹuː ðə smˈɔːl kˈabɪn]"
+                "en": "[wˈɔːmθ spɹˈɛdz θɹuː ðə lˈɪtəl kˈabɪn]"
             },
             "provenance": {
                 "fr": "original",
@@ -1338,16 +761,45 @@
             }
         },
         {
-            "id": "scene-11-044",
+            "id": "scene-11-030",
+            "text": {
+                "fr": "Le feu me donne de la chaleur et du courage.",
+                "en": "The fire gives me warmth and courage.",
+                "de": "Das Feuer gibt mir Wärme und Mut.",
+                "it": "Il fuoco mi dà calore e coraggio.",
+                "es": "El fuego me da calor y valentía.",
+                "nl": "Het vuur geeft me warmte en moed.",
+                "pt": "O fogo me dá calor e coragem."
+            },
+            "ipa": {
+                "fr": "lə- fˈø mə- dˈɔn də- la- ʃalˈœʁ e dy- kuʁˈaʒ",
+                "de": "[das fˈɔøɜ ɡˈiːpt miːɾ vˈɛɾmə ʊnt mˈuːt]",
+                "it": "[ˌil fʊˈɔːko mˌɪ dˈa kalˈoːre ˌe korˈadʒːo]",
+                "es": "[el ˈfweɣo me ða kaˈloɾ i βalenˈti.a]",
+                "nl": "[hət vˈyr ɣˈeːft mə ʋˈɑrmtə ɛn mˈut]",
+                "pt": "[ʊ fˈoɡʊ my dˈa kalˈoɾ i kˌoɾˈaʒeɪŋ]",
+                "en": "[ðə fˈaɪə ɡˈɪvz mˌiː wˈɔːmθ and kˈʌɹɪdʒ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-031",
             "text": {
                 "fr": "Mais après quelques heures, la faim se fait sentir.",
-                "en": "But after a few hours, she starts to feel hungry.",
+                "en": "But after a few hours, hunger makes itself felt.",
                 "de": "Aber nach einigen Stunden stellt sich der Hunger ein.",
                 "it": "Ma dopo qualche ora, inizia a sentire la fame.",
                 "es": "Pero después de unas horas, el hambre empieza a notarse.",
                 "nl": "Maar na een paar uur begint ze honger te krijgen.",
-                "pt": "Mas depois de algumas horas, a fome se faz sentir.",
-                "en_pt": "But after a few hours, hunger makes itself felt."
+                "pt": "Mas depois de algumas horas, a fome se faz sentir."
             },
             "ipa": {
                 "fr": "mɛz apʁˌɛ kˌɛlkəz ˈœʁ la- fˈɛ̃ sə- fˈɛ sɑ̃tˈiʁ",
@@ -1356,7 +808,7 @@
                 "es": "[ˈpe.ɾo desˈpwes ðe ˈu.nas ˈo.ɾas el ˈam.bɾe emˈpje.θa a noˈtar.se]",
                 "nl": "[maːr naː ən pˈaːr ˈyr bəɣˈɪnt zə hˈɔŋər tə krˈɛɪɣən]",
                 "pt": "[maz depˈoɪz dʒj aʊɡˌumæs ˈɔɾæs\n a fˈomy sy fas seɪŋtʃˈir]",
-                "en": "[bˌʌt ˈaftəɹ ɐ fjˈuː ˈaʊəz ʃiː stˈɑːts tə fˈiːl hˈʌŋɡɹi]"
+                "en": "[bˌʌt ˈaftəɹ ɐ fjˈuː ˈaʊəz hˈʌŋɡə mˌeɪks ɪtsˈɛlf fˈɛlt]"
             },
             "provenance": {
                 "fr": "original",
@@ -1369,16 +821,46 @@
             }
         },
         {
-            "id": "scene-11-045",
+            "id": "scene-11-032",
+            "text": {
+                "fr": "Maintenant, j'ai très faim, mais je n'ai rien à manger.",
+                "en": "Now, I'm very hungry, but I have nothing to eat.",
+                "de": "Jetzt habe ich großen Hunger, aber ich habe nichts zu essen.",
+                "it": "Ora ho molto fame, ma non ho nulla da mangiare.",
+                "es": "Ahora tengo mucha hambre, pero no tengo nada que comer.",
+                "nl": "Nu heb ik heel veel honger, maar ik heb niets om te eten.",
+                "pt": "Agora estou com muita fome, mas não tenho nada para comer.",
+                "en_pt": "Now I'm very hungry, but I have nothing to eat."
+            },
+            "ipa": {
+                "fr": "mɛ̃tnˈɑ̃ ʒe tʁɛ fˈɛ̃ mɛ ʒə- ne ʁjˌɛ̃n a mɑ̃ʒˈe",
+                "de": "[jˌɛtst hɑːbə ɪç ɡrˈoːsən hˈʊŋɜ\n ˌɑːbɜ ɪç hɑːbə nˈɪçts tsuː ˈɛsən]",
+                "it": "[ˈɔːra ˌo mˈolto fˈaːme\n mˌa nˌon ˌo nˈulla dˌa mandʒˈaːre]",
+                "es": "[aˈoɾa ˈteŋɣo ˈmutʃa ˈamβɾe peɾo no ˈteŋɣo ˈnaða ke koˈmeɾ]",
+                "nl": "[nˈy hɛp ɪk hˈeːl vˈeːl hˈɔŋər\n maːr ɪk hɛp nˌits ɔm tə ˈeːtən]",
+                "pt": "[ˌaɡˈɔɾæ estˌow koŋ mwˈiŋtæ fˈomy\n maz nˌɐ̃ʊ̃ tˌeɲʊ nˈadæ pˌaɾæ komˈer]",
+                "en": "[nˈaʊ aɪm vˈɛɹɪ hˈʌŋɡɹi bˌʌt aɪ hav nˈʌθɪŋ tʊ ˈiːt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-033",
             "text": {
                 "fr": "Elle sort de la cabane pour explorer les environs.",
-                "en": "She goes out of the cabin to explore the surroundings.",
+                "en": "She leaves the cabin to explore the surroundings.",
                 "de": "Sie verlässt die Hütte, um die Umgebung zu erkunden.",
                 "it": "Esce dalla capanna per esplorare i dintorni.",
                 "es": "Sale de la cabaña para explorar los alrededores.",
                 "nl": "Ze gaat de hut uit om de omgeving te verkennen.",
-                "pt": "Ela sai da cabana para explorar os arredores.",
-                "en_pt": "She leaves the cabin to explore the surroundings."
+                "pt": "Ela sai da cabana para explorar os arredores."
             },
             "ipa": {
                 "fr": "ɛl sˈɔʁ də- la- kabˈan puʁ ɛksplɔʁˈe le-z ɑ̃viʁˈɔ̃",
@@ -1387,7 +869,7 @@
                 "es": "[ˈsa.le ðe la kaˈβa.ɲa ˈpa.ɾa eks.ploˈɾaɾ los al.ɾeˈðo.ɾes]",
                 "nl": "[zə ɣˈaː tə hˈɵt œyt ɔm də ɔmɣˈeːvɪŋ tə vərkˈɛnən]",
                 "pt": "[ˌɛlæ sˈaɪ da kˌabˈɐ̃næ pˌaɾæ ˌesploɾˈaɾ ʊz ˌaxedˈɔɾys]",
-                "en": "[ʃiː ɡəʊz ˌaʊtəv ðə kˈabɪn tʊ ɛksplˈɔː ðə səɹˈaʊndɪŋz]"
+                "en": "[ʃiː lˈiːvz ðə kˈabɪn tʊ ɛksplˈɔː ðə səɹˈaʊndɪŋz]"
             },
             "provenance": {
                 "fr": "original",
@@ -1400,15 +882,16 @@
             }
         },
         {
-            "id": "scene-11-046",
+            "id": "scene-11-034",
             "text": {
                 "fr": "Près de la porte, elle remarque des plantes.",
-                "en": "Near the door, she notices some plants.",
+                "en": "Near the door, she notices plants.",
                 "de": "Nahe der Tür bemerkt sie Pflanzen.",
                 "it": "Vicino alla porta, nota delle piante.",
                 "es": "Cerca de la puerta, observa algunas plantas.",
                 "nl": "Bij de deur merkt ze wat planten op.",
-                "pt": "Perto da porta, ela nota algumas plantas."
+                "pt": "Perto da porta, ela nota algumas plantas.",
+                "en_pt": "Near the door, she notices some plants."
             },
             "ipa": {
                 "fr": "pʁɛ də- la- pˈɔʁt ɛl ʁəmˈaʁk de- plˈɑ̃t",
@@ -1417,7 +900,7 @@
                 "es": "[ˈθeɾ.ka ðe la ˈpwer.ta obˈser.βa alˈɣu.nas ˈplan.tas]",
                 "nl": "[bɛɪ də dˈøːr mˈɛrkt zə ʋɑt plˈɑntən ˈɔp]",
                 "pt": "[pˈɛɾətʊ da pˈɔɾətæ\n ˌɛlæ nˈɔtæ ˌaʊɡˈumæs plˈɐ̃ŋtæs]",
-                "en": "[nˌiə ðə dˈɔː ʃiː nˈəʊtɪsɪz sˌʌm plˈants]"
+                "en": "[nˌiə ðə dˈɔː ʃiː nˈəʊtɪsɪz plˈants]"
             },
             "provenance": {
                 "fr": "original",
@@ -1430,10 +913,56 @@
             }
         },
         {
-            "id": "scene-11-047",
+            "id": "scene-11-035",
+            "text": {
+                "pt": "Espera...",
+                "en": "Wait..."
+            },
+            "ipa": {
+                "pt": "[ˌespˈɛɾæ]",
+                "en": "[wˈeɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-036",
+            "text": {
+                "fr": "Attends... ces plantes près de la cabane, je les reconnais!",
+                "en": "Wait... those plants near the cabin, I recognize them!",
+                "de": "Warte... diese Pflanzen neben der Hütte, ich erkenne sie!",
+                "it": "Aspetta... quelle piante vicino alla capanna, le riconosco!",
+                "es": "Espera... estas plantas cerca del piso, ¡las reconozco!",
+                "nl": "Wacht... die planten bij het huisje, ik herken ze!",
+                "pt": "essas plantas perto da cabana, eu reconheço!",
+                "en_pt": "these plants near the cabin, I recognize them!"
+            },
+            "ipa": {
+                "fr": "atˈɑ̃ se plˈɑ̃t pʁɛ də- la- kabˈan ʒə- le- ʁəkɔnˈɛ",
+                "de": "[vˈaɾtə\n dˌiːzə pflˈantsən nˌeːbən dɛɾ hˈʏtə\n ɪç ɛɾkˈɛnə ziː]",
+                "it": "[aspˈɛtːa\n kwˌɛlle pjˈante vitʃˈiːno ˌalla kapˈanna\n lˌe rˌikonˈosko]",
+                "es": "[esˈpeɾa ˈestas ˈplantas ˈθeɾka ðel ˈpiso las rekoˈnoθko]",
+                "nl": "[ʋˈɑxt\n di plˈɑntən bɛɪ hət hˈœysjə\n ɪk hˈɛrkən zə]",
+                "pt": "[ˈɛsæs plˈɐ̃ŋtæs pˈɛɾətʊ da kˌabˈɐ̃næ\n eʊ xˌekoɲˈesʊ]",
+                "en": "[wˈeɪt ðəʊz plˈants nˌiə ðə kˈabɪn aɪ ɹˈɛkəɡnˌaɪz ðˌɛm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-037",
             "text": {
                 "fr": "Des souvenirs de son enfance reviennent.",
-                "en": "Memories of her childhood come back.",
+                "en": "Memories of her childhood return.",
                 "de": "Erinnerungen an ihre Kindheit kommen zurück.",
                 "it": "I ricordi dell'infanzia tornano.",
                 "es": "Recuerdos de su infancia regresan.",
@@ -1448,7 +977,7 @@
                 "es": "[reˈkwer.ðos ðe su inˈfan.θja reˈɣɾe.san]",
                 "nl": "[hɛrˈɪnərˌɪŋən aːn haːr jˈøːxt kˈoːmən tərˈɵx]",
                 "pt": "[lˌeɪmbrˈɐ̃ŋsæz da ˌiŋfˈɐ̃ŋsjæ vˈɔltɐ̃ʊ̃]",
-                "en": "[mˈɛməɹˌiz ɒv hɜː tʃˈaɪldhʊd kˈʌm bˈak]"
+                "en": "[mˈɛməɹˌiz ɒv hɜː tʃˈaɪldhʊd ɹɪtˈɜːn]"
             },
             "provenance": {
                 "fr": "original",
@@ -1461,10 +990,10 @@
             }
         },
         {
-            "id": "scene-11-048",
+            "id": "scene-11-038",
             "text": {
                 "fr": "Elle revoit sa grand-mère dans le jardin de Normandie, ses mains ridées tenant délicatement les tiges vertes.",
-                "en": "She sees her grandmother again in the garden of Normandy, her wrinkled hands delicately holding the green stems.",
+                "en": "She sees her grandmother in the Normandy garden, her wrinkled hands delicately holding the green stems.",
                 "de": "Sie sieht ihre Großmutter im Garten in der Normandie, wie ihre runzligen Hände vorsichtig die grünen Stängel halten.",
                 "it": "Rivede sua nonna nel giardino in Normandia, le sue mani rugose che tengono delicatamente i gambi verdi.",
                 "es": "Ve a su abuela en el jardín de Normandía, sus manos arrugadas sosteniendo delicadamente los tallos verdes.",
@@ -1479,7 +1008,299 @@
                 "es": "[be a su aˈβwe.la en el xarˈðin de noɾ.manˈdi.a sus ˈma.nos aˈru.ɣa.ðas sos.teˈnjen.do ðe.li.kaˈða.men.te los ˈta.ʎos ˈβeɾ.ðes]",
                 "nl": "[zə zˈit haːr ɣrˈoːtmudər ʋˈɪːr ɪn də tˈœyn vɑn nˈɔrmɑndˌiə\n haːr ɣərˈɪmpəldə hˈɑndən hˈʌʊdən vˌɔːrzˈɪxtəx də ɣrˈunə stˈɛŋəls vˈɑst]",
                 "pt": "[ˌɛlæ xevˈe sˌuæ avˈɔ nʊ ʒaɾədʒˈiŋ dʊ ˌiŋteɾiˈor\n sˌuæz mˈɐ̃ʊ̃z ˌeɪŋxuɡˈadæs sˌeɡuɾˈɐ̃ŋdʊ dˌelikˌadæmˈeɪŋtʃj ʊs tˈalʊz vˈeɾədʒys]",
-                "en": "[ʃiː sˈiːz hɜː ɡɹˈandmʌðəɹ ɐɡˈɛn ɪnðə ɡˈɑːdən ɒv nˈɔːmandi hɜː ɹˈɪŋkəld hˈandz dˈɛlɪkətli hˈəʊldɪŋ ðə ɡɹˈiːn stˈɛmz]"
+                "en": "[ʃiː sˈiːz hɜː ɡɹˈandmʌðəɹ ɪnðə nˈɔːmandi ɡˈɑːdən hɜː ɹˈɪŋkəld hˈandz dˈɛlɪkətli hˈəʊldɪŋ ðə ɡɹˈiːn stˈɛmz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-039",
+            "text": {
+                "fr": "Regarde, Sophie",
+                "en": "Look, Sophie",
+                "de": "Schau, Sophie",
+                "it": "Guarda, Sophie",
+                "es": "Mira, Sophie",
+                "nl": "Kijk, Sophie",
+                "pt": "Olha Sophie.",
+                "en_pt": "Look Sophie."
+            },
+            "ipa": {
+                "fr": "ʁəɡˈaʁd sɔfˈi",
+                "de": "[ʃˈaʊ\n zoːfˈiː]",
+                "it": "[ɡwˈaːrda\n sˈopje]",
+                "es": "[ˈmiɾa ˈsofi]",
+                "nl": "[kˈɛɪk\n sɔphˈi]",
+                "pt": "[ˈɔljæ sˌofˈiy]",
+                "en": "[lˈʊk sˈəʊfi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-040",
+            "text": {
+                "fr": "Les orties te piquent d'abord, mais après, elles te nourrissent",
+                "en": "Nettles sting you at first, but afterwards, they nourish you",
+                "de": "Die Brennnesseln stechen erst, aber dann nähren sie dich",
+                "it": "Le ortiche prima ti pungono, poi ti nutrono",
+                "es": "Las ortigas te pican primero, pero luego te alimentan",
+                "nl": "Brandnetels prikken eerst, maar daarna voeden ze je",
+                "pt": "As urtigas picam primeiro, mas depois te alimentam.",
+                "en_pt": "Nettles sting first, but then they feed you."
+            },
+            "ipa": {
+                "fr": "le-z ɔʁtˈi tə- pˈik dabˈɔʁ mɛz apʁˈɛ ɛl tə- nuʁˈis",
+                "de": "[diː brˈɛnɛsəln ʃtˈɛçən ˈeːɾst\n ˌɑːbɜ dan nˈɛːrən ziː dˈɪç]",
+                "it": "[lˌe ˈɔrtike prˈiːma tˌɪ pˈuŋɡono\n pˈɔːɪ tˌɪ nˈutrono]",
+                "es": "[las oɾˈtiɣas te ˈpikan pɾiˈmeɾo peɾo ˈlweɣo te aliˈmentan]",
+                "nl": "[brˈɑndnətˌɛls prˈɪkən ˈɪːrst\n maːr dˈaːrnaː vˈudən zə jə]",
+                "pt": "[az ˌuɾətʃˈiɡæs pˈikɐ̃ʊ̃ prˌimˈeɪɾʊ\n maz depˈoɪs tʃj ˌalimˈeɪŋtɐ̃ʊ̃]",
+                "en": "[nˈɛtəlz stˈɪŋ juː at fˈɜːst bˌʌt ˈaftəwədz ðeɪ nˈʌɹɪʃ juː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-041",
+            "text": {
+                "fr": "C'est comme la vie, ma petite",
+                "en": "It's like life, my little one",
+                "de": "Das ist wie das Leben, meine Kleine",
+                "it": "È come la vita, piccola mia",
+                "es": "Es como la vida, pequeña",
+                "nl": "Zo is het leven, mijn kleintje",
+                "pt": "É como a vida, minha pequena.",
+                "en_pt": "It's like life, my little one."
+            },
+            "ipa": {
+                "fr": "sɛ kɔm la- vˈi ma- pətˈit",
+                "de": "[das ɪst viː das lˈeːbən\n mˌaɪnə klˈaɪnə]",
+                "it": "[ˌɛ kˌome lˌa vˈiːta\n pˈikːola mˈia]",
+                "es": "[es ˈkomo la ˈβiða peˈkeɲa]",
+                "nl": "[zoː ɪs hət lˈeːvən\n mɛɪn klˈɛɪntʲə]",
+                "pt": "[ɛ kˌomʊ a vˈidæ\n mˌiɲæ pˌekˈenæ]",
+                "en": "[ɪts lˈaɪk lˈaɪf maɪ lˈɪtəl wˌɒn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-042",
+            "text": {
+                "fr": "Les choses qui font mal nous rendent plus fortes.",
+                "en": "The things that hurt us make us stronger.",
+                "de": "Die Dinge, die wehtun, machen uns stärker.",
+                "it": "Le cose che fanno male ci rendono più forti.",
+                "es": "Las cosas que duelen nos hacen más fuertes.",
+                "nl": "De dingen die pijn doen maken ons sterker.",
+                "pt": "As coisas que machucam nos tornam mais fortes."
+            },
+            "ipa": {
+                "fr": "le- ʃˈoz ki fˈɔ̃ mˈal nu ʁˈɑ̃d ply fˈɔʁt",
+                "de": "[diː dˈɪŋə\n diː vˈeːtuːn\n mˈaxən ʊns ʃtˈɛɾkɜ]",
+                "it": "[lˌe kˈɔːze kˌe fˌanno mˈaːle tʃˌɪ rˈɛndono pjˌʊ fˈɔːrtɪ]",
+                "es": "[las ˈkosas ke ˈdwelen nos ˈaθen ˈmas ˈfwertes]",
+                "nl": "[də dˈɪŋən di pˈɛɪn dˈun mˈaːkən ɔn stˈɛrkər]",
+                "pt": "[as kˈoɪzæs ky mˌaʃˈukɐ̃ʊ̃ nʊs tˈɔɾənɐ̃ʊ̃ mˈaɪs fˈɔɾətʃys]",
+                "en": "[ðə θˈɪŋz ðat hˈɜːt ˌʌs mˌeɪk ˌʌs stɹˈɒŋɡə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-043",
+            "text": {
+                "pt": "São urtigas!",
+                "en": "They're nettles!"
+            },
+            "ipa": {
+                "pt": "[sɐ̃ʊ̃ ˌuɾətʃˈiɡæs]",
+                "en": "[ðeɪə nˈɛtəlz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-044",
+            "text": {
+                "fr": "Ce sont des orties! Elles sont comestibles si on les fait cuire.",
+                "en": "They're nettles! They're edible if you cook them.",
+                "de": "Das sind Brennnesseln! Sie sind essbar, wenn man sie kocht.",
+                "it": "Sono ortiche! Sono commestibili se cotte.",
+                "es": "¡Son ortigas! Son comestibles si las cocinas.",
+                "nl": "Het zijn brandnetels! Ze zijn eetbaar als je ze kookt.",
+                "pt": "Elas são comestíveis se cozinhar.",
+                "en_pt": "They're edible if you cook them."
+            },
+            "ipa": {
+                "fr": "sə- sˈɔ̃ de-z ɔʁtˈi ɛl sɔ̃ kɔmɛstˈibl sˈi ɔ̃ le- fˈɛ kyˈiʁ",
+                "de": "[das zɪnt brˈɛnɛsəln\n ziː zɪnt ˈɛsbɑːɾ\n vˌɛn man ziː kˈɔxt]",
+                "it": "[sˌono ˈɔrtike\n sˌono kˌommestˈibilɪ sˌe kˈɔtːe]",
+                "es": "[son oɾˈtiɣas son komeˈstiβles si las koˈθinas]",
+                "nl": "[hət zɛɪn brˈɑndnətˌɛls\n zə zɛɪn ˈeːtbaːr ɑls jə zə kˈoːkt]",
+                "pt": "[ˌɛlæs sɐ̃ʊ̃ kˌomestʃˈiveɪs sy kˌoziɲˈar]",
+                "en": "[ðeɪə nˈɛtəlz ðeɪəɹ ˈɛdəbəl ɪf juː kˈʊk ðˌɛm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-045",
+            "text": {
+                "fr": "Elle les regarde avec hésitation.",
+                "en": "She looks at them with hesitation.",
+                "de": "Sie betrachtet sie zögernd.",
+                "it": "Le osserva con esitazione.",
+                "es": "Las mira con duda.",
+                "nl": "Ze kijkt er met aarzeling naar.",
+                "pt": "Ela as olha com hesitação."
+            },
+            "ipa": {
+                "fr": "ɛl le- ʁəɡˈaʁd avˌɛk ezitasjˈɔ̃",
+                "de": "[ziː bətɾˈaxtət ziː tsˈøːɡɛɾnt]",
+                "it": "[lˌe ossˈɛːrva kˌon ˌezitˌatsiˈɔːne]",
+                "es": "[las ˈmi.ɾa kon ˈðu.ða]",
+                "nl": "[zə kˈɛɪkt ər mɛt ˈaːrzəlˌɪŋ nˈaːr]",
+                "pt": "[ˌɛlæ az ˈɔljæ koŋ ˌezitasˈɐ̃ʊ̃]",
+                "en": "[ʃiː lˈʊks at ðˌɛm wɪð hˌɛsɪtˈeɪʃən]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-046",
+            "text": {
+                "fr": "J'ose à peine les toucher, elles piquent.",
+                "en": "I dare barely touch them, they sting.",
+                "de": "Ich wage es kaum, sie zu berühren, sie stechen.",
+                "it": "Oso a malapena toccarle, pungono.",
+                "es": "Apenas me atrevo a tocarlas, pican.",
+                "nl": "Ik durf ze nauwelijks aan te raken, ze prikken.",
+                "pt": "Mal ouso tocá-las, elas picam.",
+                "en_pt": "I barely dare touch them, they sting."
+            },
+            "ipa": {
+                "fr": "ʒˈoz a pˈɛn le- tuʃˈe ɛl pˈik",
+                "de": "[ɪç vˈɑːɡə ɛs kˈaʊm\n ziː tsuː bərˈyːrən\n ziː ʃtˈɛçən]",
+                "it": "[ˈoːzo ˌa mˌalapˈeːna tokːˈaːrle\n pˈuŋɡono]",
+                "es": "[aˈpenas me aˈtɾeβo a toˈkaɾlas ˈpikan]",
+                "nl": "[ɪk dˈɵrf zə nˈʌʊələks aːn tə rˈaːkən\n zə prˈɪkən]",
+                "pt": "[mˈaʊ ˈowzʊ tokˈalæs\n ˌɛlæs pˈikɐ̃ʊ̃]",
+                "en": "[aɪ dˈeə bˈeəli tˈʌtʃ ðˌɛm ðeɪ stˈɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-047",
+            "text": {
+                "fr": "Mais il le faut si je veux survivre",
+                "en": "But it is necessary if I want to survive",
+                "de": "Aber ich muss es tun, wenn ich überleben will",
+                "it": "Ma devo farlo se voglio sopravvivere",
+                "es": "Pero tengo que hacerlo si quiero sobrevivir",
+                "nl": "Maar het moet, als ik wil overleven",
+                "pt": "Mas preciso se quero sobreviver.",
+                "en_pt": "But I must if I want to survive."
+            },
+            "ipa": {
+                "fr": "mɛz il lə- fo sˈi ʒə- vˈø syʁvˈivʁ",
+                "de": "[ˌɑːbɜ ɪç mˈʊs ɛs tˈuːn\n vˌɛn ɪç ˌyːbɜlˈeːbən vɪl]",
+                "it": "[mˌa dˈɛːvo fˈaːrlo sˌe vˈoːʎo sˌɔpravvˈivere]",
+                "es": "[ˈpeɾo ˈteŋɣo ke aˈθeɾlo si ˈkjeɾo soβɾeβiˈβiɾ]",
+                "nl": "[maːr hət mˈut\n ɑls ɪk ʋɪl ˌoːvərlˈeːvən]",
+                "pt": "[mas prˌesˈizʊ sy kˈɛɾʊ sobɾevivˈer]",
+                "en": "[bˌʌt ɪt ɪz nˈɛsəsəɹi ɪf aɪ wˈɒnt tə səvˈaɪv]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-048",
+            "text": {
+                "fr": "Toute vérité exige qu'on accepte d'abord sa capacité à blesser.",
+                "en": "Every truth requires that we first accept its capacity to hurt.",
+                "de": "Jede Wahrheit erfordert, dass man zuerst ihre Fähigkeit zu verletzen akzeptiert.",
+                "it": "Ogni verità richiede che si accetti prima la sua capacità di ferire.",
+                "es": "Toda verdad requiere que primero aceptemos su capacidad de hacer daño.",
+                "nl": "Elke waarheid vereist dat je eerst haar vermogen om te kwetsen accepteert.",
+                "pt": "Toda verdade exige que aceitemos primeiro sua capacidade de ferir.",
+                "en_pt": "Every truth demands that we first accept its capacity to wound."
+            },
+            "ipa": {
+                "fr": "tut veʁitˈe ɛɡzˈiʒ kɔ̃n aksˈɛpt dabˈɔʁ sa- kapasitˈe a blɛsˈe",
+                "de": "[jˈeːdə vˈɑːɾhaɪt ɛɾfˈɔɾdɜt\n das man tsuːˈeːɾst ˌiːrə fˈɛːɪçkˌaɪt tsuː fɛɾlˈɛtsən ˌaktsɛptˈiːɾt]",
+                "it": "[ˈoɲʲɪ vˌɛritˈa rikjˈeːde kˌe sˌɪ atʃːˈetːɪ prˈiːma lˌa sˌʊa kˌapatʃitˈa dˌɪ ferˈiːre]",
+                "es": "[ˈtoða βeɾˈðað reˈkjeɾe ke pɾiˈmeɾo aθepˈtemos su kapaθiˈðað de aˈθeɾ ˈdaɲo]",
+                "nl": "[ˈɛlkə ʋˈaːrhɛɪt vərˈɛɪst dɑt jə ˈɪːrst haːr vərmˌoːɣən ɔm tə kʋˈɛtsən ˌɑksɛptˈɪrt]",
+                "pt": "[tˈodæ vˌeɾədˈadʒj ˌezˈiʒy ky ˌaseɪtˈemʊs prˌimˈeɪɾʊ sˌuæ kˌapasidˈadʒy dʒy feɾˈir]",
+                "en": "[ˈɛvɹɪ tɹˈuːθ ɹɪkwˈaɪəz ðat wiː fˈɜːst ɐksˈɛpt ɪts kəpˈasɪti tə hˈɜːt]"
             },
             "provenance": {
                 "fr": "original",
@@ -1494,23 +1315,22 @@
         {
             "id": "scene-11-049",
             "text": {
-                "fr": "Elle les regarde avec hésitation.",
-                "en": "She looks at them hesitantly.",
-                "de": "Sie betrachtet sie zögernd.",
-                "it": "Le osserva con esitazione.",
-                "es": "Las mira con duda.",
-                "nl": "Ze kijkt er met aarzeling naar.",
-                "pt": "Ela as olha com hesitação.",
-                "en_pt": "She looks at them with hesitation."
+                "fr": "Elle cueille les orties avec précaution, en utilisant un bout de tissu pour protéger ses mains.",
+                "en": "She picks the nettles carefully, using a piece of cloth to protect her hands.",
+                "de": "Sie pflückt die Brennnesseln vorsichtig, indem sie ein Stück Stoff verwendet, um ihre Hände zu schützen.",
+                "it": "Raccoglie le ortiche con attenzione, usando un pezzo di stoffa per proteggere le mani.",
+                "es": "Recoge las ortigas con cuidado, usando un trozo de tela para proteger sus manos.",
+                "nl": "Ze plukt de brandnetels voorzichtig, waarbij ze een stuk stof gebruikt om haar handen te beschermen.",
+                "pt": "Ela colhe as urtigas com cuidado, usando um pedaço de pano para proteger as mãos."
             },
             "ipa": {
-                "fr": "ɛl le- ʁəɡˈaʁd avˌɛk ezitasjˈɔ̃",
-                "de": "[ziː bətɾˈaxtət ziː tsˈøːɡɛɾnt]",
-                "it": "[lˌe ossˈɛːrva kˌon ˌezitˌatsiˈɔːne]",
-                "es": "[las ˈmi.ɾa kon ˈðu.ða]",
-                "nl": "[zə kˈɛɪkt ər mɛt ˈaːrzəlˌɪŋ nˈaːr]",
-                "pt": "[ˌɛlæ az ˈɔljæ koŋ ˌezitasˈɐ̃ʊ̃]",
-                "en": "[ʃiː lˈʊks at ðˌɛm hˈɛsɪtəntli]"
+                "fr": "ɛl kˈœj le-z ɔʁtˈi avˌɛk pʁekosjˈɔ̃ ɑ̃n ytilizˈɑ̃ œ̃ bˈu də- tisˈy puʁ pʁɔteʒˈe se- mˈɛ̃",
+                "de": "[ziː pflˈʏkt diː brˈɛnɛsəln fˈoːɾzˌɪçtɪç\n ɪndˈeːm ziː aɪn ʃtˈʏk ʃtˈɔf fɛɾvˈɛndət\n ʊm ˌiːrə hˈɛndə tsuː ʃˈʏtsən]",
+                "it": "[rakːˈoːʎe lˌe ˈɔrtike kˌon ˌatːentsiˈɔːne\n ʊzˈando ˌʊn pˈɛtsːo dˌɪ stˈɔffa pˌɛr protˈedʒːere lˌe mˈaːnɪ]",
+                "es": "[reˈko.xe las oɾˈti.ɣas kon kwiˈða.ðo uˈsan.do un ˈtɾo.θo ðe ˈte.la paɾa pɾo.teˈxer sus ˈma.nos]",
+                "nl": "[zə plˈɵk tə brˈɑndnətˌɛls vˌɔːrzˈɪxtəx\n ʋaːrbˈɛɪ zə ən stˈɵk stˈɔf ɣəbrˈœykt ɔm haːr hˈɑndən tə bəsxˈɛrmən]",
+                "pt": "[ˌɛlæ kˈɔljj az ˌuɾətʃˈiɡæs koŋ kˌuɪdˈadʊ\n ˌuzˈɐ̃ŋdw ũŋ pˌedˈasʊ dʒy pˈɐ̃nʊ pˌaɾæ prˌoteʒˈeɾ az mˈɐ̃ʊ̃s]",
+                "en": "[ʃiː pˈɪks ðə nˈɛtəlz kˈeəfəlɪ jˈuːzɪŋ ɐ pˈiːs ɒv klˈɒθ tə pɹətˈɛkt hɜː hˈandz]"
             },
             "provenance": {
                 "fr": "original",
@@ -1524,37 +1344,6 @@
         },
         {
             "id": "scene-11-050",
-            "text": {
-                "fr": "Elle cueille les orties avec précaution, en utilisant un bout de tissu pour protéger ses mains.",
-                "en": "She cautiously picks the nettles, using a piece of cloth to protect her hands.",
-                "de": "Sie pflückt die Brennnesseln vorsichtig, indem sie ein Stück Stoff verwendet, um ihre Hände zu schützen.",
-                "it": "Raccoglie le ortiche con attenzione, usando un pezzo di stoffa per proteggere le mani.",
-                "es": "Recoge las ortigas con cuidado, usando un trozo de tela para proteger sus manos.",
-                "nl": "Ze plukt de brandnetels voorzichtig, waarbij ze een stuk stof gebruikt om haar handen te beschermen.",
-                "pt": "Ela colhe as urtigas com cuidado, usando um pedaço de pano para proteger as mãos.",
-                "en_pt": "She picks the nettles carefully, using a piece of cloth to protect her hands."
-            },
-            "ipa": {
-                "fr": "ɛl kˈœj le-z ɔʁtˈi avˌɛk pʁekosjˈɔ̃ ɑ̃n ytilizˈɑ̃ œ̃ bˈu də- tisˈy puʁ pʁɔteʒˈe se- mˈɛ̃",
-                "de": "[ziː pflˈʏkt diː brˈɛnɛsəln fˈoːɾzˌɪçtɪç\n ɪndˈeːm ziː aɪn ʃtˈʏk ʃtˈɔf fɛɾvˈɛndət\n ʊm ˌiːrə hˈɛndə tsuː ʃˈʏtsən]",
-                "it": "[rakːˈoːʎe lˌe ˈɔrtike kˌon ˌatːentsiˈɔːne\n ʊzˈando ˌʊn pˈɛtsːo dˌɪ stˈɔffa pˌɛr protˈedʒːere lˌe mˈaːnɪ]",
-                "es": "[reˈko.xe las oɾˈti.ɣas kon kwiˈða.ðo uˈsan.do un ˈtɾo.θo ðe ˈte.la paɾa pɾo.teˈxer sus ˈma.nos]",
-                "nl": "[zə plˈɵk tə brˈɑndnətˌɛls vˌɔːrzˈɪxtəx\n ʋaːrbˈɛɪ zə ən stˈɵk stˈɔf ɣəbrˈœykt ɔm haːr hˈɑndən tə bəsxˈɛrmən]",
-                "pt": "[ˌɛlæ kˈɔljj az ˌuɾətʃˈiɡæs koŋ kˌuɪdˈadʊ\n ˌuzˈɐ̃ŋdw ũŋ pˌedˈasʊ dʒy pˈɐ̃nʊ pˌaɾæ prˌoteʒˈeɾ az mˈɐ̃ʊ̃s]",
-                "en": "[ʃiː kˈɔːʃəsli pˈɪks ðə nˈɛtəlz jˈuːzɪŋ ɐ pˈiːs ɒv klˈɒθ tə pɹətˈɛkt hɜː hˈandz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-051",
             "text": {
                 "fr": "Les piqûres lui rappellent que la nature n'est ni bonne ni mauvaise.",
                 "en": "The stings remind her that nature is neither good nor bad.",
@@ -1585,42 +1374,16 @@
             }
         },
         {
-            "id": "scene-11-052",
-            "text": {
-                "fr": "elle est simplement authentique.",
-                "en": "It is just authentic.",
-                "de": "sie ist einfach authentisch.",
-                "it": "È semplicemente autentica.",
-                "es": "es simplemente auténtica.",
-                "nl": "Ze is gewoon authentiek."
-            },
-            "ipa": {
-                "fr": "ɛl ɛ sɛ̃pləmˈɑ̃ɔːθɛntˈiːk",
-                "de": "[ziː ɪst ˈaɪnfˌax aʊtˈɛntɪʃ]",
-                "it": "[ˌɛ sˌemplitʃemˈente ˌaʊtˈɛntika]",
-                "es": "[es sim.pleˈmen.te awˈten.ti.ka]",
-                "nl": "[zə ɪs ɣəʋˈoːn ˌʌʊtəntˈik]",
-                "en": "[ɪt ɪz dʒˈʌst ɔːθˈɛntɪk]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-053",
+            "id": "scene-11-051",
             "text": {
                 "fr": "Maintenant, elle a besoin d'eau.",
-                "en": "Now she needs water.",
+                "en": "Now, she needs water.",
                 "de": "Jetzt braucht sie Wasser.",
                 "it": "Ora ha bisogno di acqua.",
                 "es": "Ahora necesita agua.",
                 "nl": "Nu heeft ze water nodig.",
-                "pt": "Agora ela precisa de água."
+                "pt": "Agora ela precisa de água.",
+                "en_pt": "Now she needs water."
             },
             "ipa": {
                 "fr": "mɛ̃tnˈɑ̃ ɛl a bəzwˈɛ̃ dˈo",
@@ -1642,16 +1405,45 @@
             }
         },
         {
-            "id": "scene-11-054",
+            "id": "scene-11-052",
+            "text": {
+                "fr": "Où puis-je trouver de l'eau potable?",
+                "en": "Where can I find drinking water?",
+                "de": "Wo kann ich Trinkwasser finden?",
+                "it": "Dove posso trovare dell'acqua potabile?",
+                "es": "¿Dónde puedo encontrar agua potable?",
+                "nl": "Waar kan ik drinkwater vinden?",
+                "pt": "Onde posso encontrar água potável?"
+            },
+            "ipa": {
+                "fr": "u pyˈiʒ tʁuvˈe də- lˈo pɔtˈabl",
+                "de": "[vˌoː kˌan ɪç tɾˈɪŋkvasɜ fˈɪndən]",
+                "it": "[dˈoːve pˈɔsso trovˈaːre dellˈakːwa potˈabile]",
+                "es": "[ˈðonde ˈpwedo enkonˈtɾaɾ ˈaɣwa poˈtaβle]",
+                "nl": "[ʋˈaːr kɑn ɪk drˈɪŋkʋaːtər vˈɪndən]",
+                "pt": "[ˌoŋdʒy pˌɔsʊ ˌeɪŋkoŋtrˈaɾ ˈaɡwæ pˌotˈaveʊ]",
+                "en": "[wˌeə kan aɪ fˈaɪnd dɹˈɪŋkɪŋ wˈɔːtə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-053",
             "text": {
                 "fr": "Elle écoute attentivement.",
-                "en": "She listens attentively.",
+                "en": "She listens carefully.",
                 "de": "Sie hört aufmerksam hin.",
                 "it": "Ascolta attentamente.",
                 "es": "Escucha atentamente.",
                 "nl": "Ze luistert aandachtig.",
-                "pt": "Ela escuta atentamente.",
-                "en_pt": "She listens carefully."
+                "pt": "Ela escuta atentamente."
             },
             "ipa": {
                 "fr": "ɛl ekˈut atɑ̃tivmˈɑ̃",
@@ -1660,7 +1452,38 @@
                 "es": "[esˈku.tʃa a.tenˈta.men.te]",
                 "nl": "[zə lˈœystərt ˈaːndɑxtəx]",
                 "pt": "[ˌɛlæ ˌeskˈutæ ˌateɪŋtæmˈeɪŋtʃy]",
-                "en": "[ʃiː lˈɪsənz ɐtˈɛntɪvli]"
+                "en": "[ʃiː lˈɪsənz kˈeəfəlɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-054",
+            "text": {
+                "fr": "J'entends un bruit... comme de l'eau qui coule!",
+                "en": "I hear a sound... like flowing water!",
+                "de": "Ich höre ein Geräusch... wie Wasser, das fließt!",
+                "it": "Sento un rumore... come di acqua che scorre!",
+                "es": "¡Escucho un ruido... como de agua que fluye!",
+                "nl": "Ik hoor een geluid... als van stromend water!",
+                "pt": "Ouço um barulho...",
+                "en_pt": "I hear a sound..."
+            },
+            "ipa": {
+                "fr": "ʒɑ̃tˈɑ̃z œ̃ bʁyˈi kɔm də- lˈo ki kˈul",
+                "de": "[ɪç hˈøːrə aɪn ɡərˈɔøʃ\n viː vˈasɜ\n das flˈiːst]",
+                "it": "[sˈɛnto ˌʊn rʊmˈoːre\n kˌome dˌɪ ˈakːwa kˌe skˈɔrɾe]",
+                "es": "[esˈkuʧo un ˈrwiðo ˈkomo de ˈaɣwa ke ˈflwe]",
+                "nl": "[ɪk hˈoːr ən ɣəlˈœyt\n ɑls vɑn strˈoːmənt ʋˈaːtər]",
+                "pt": "[ˈowsw ũŋ bˌaɾˈuljʊ]",
+                "en": "[aɪ hˈiəɹ ɐ sˈaʊnd lˈaɪk flˈəʊɪŋ wˈɔːtə]"
             },
             "provenance": {
                 "fr": "original",
@@ -1674,6 +1497,21 @@
         },
         {
             "id": "scene-11-055",
+            "text": {
+                "pt": "como água correndo!",
+                "en": "like running water!"
+            },
+            "ipa": {
+                "pt": "[kˌomʊ ˈaɡwæ kˌoxˈeɪŋdʊ]",
+                "en": "[lˈaɪk ɹˈʌnɪŋ wˈɔːtə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-056",
             "text": {
                 "fr": "Elle suit le son et découvre une merveille.",
                 "en": "She follows the sound and discovers a wonder.",
@@ -1704,16 +1542,61 @@
             }
         },
         {
-            "id": "scene-11-056",
+            "id": "scene-11-057",
+            "text": {
+                "pt": "Uma nascente!",
+                "en": "A spring!"
+            },
+            "ipa": {
+                "pt": "[ˌumæ nˌasˈeɪŋtʃy]",
+                "en": "[ɐ spɹˈɪŋ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-058",
+            "text": {
+                "fr": "Une source! Une eau claire, douce, qui jaillit des rochers!",
+                "en": "A spring! Clear, fresh water gushing from the rocks!",
+                "de": "Eine Quelle! Klares, süßes Wasser, das aus den Felsen sprudelt!",
+                "it": "Una sorgente! Un'acqua chiara, dolce, che sgorga dalle rocce!",
+                "es": "¡Un manantial! Agua clara, dulce, que brota de las rocas!",
+                "nl": "Een bron! Helder, zacht water dat uit de rotsen springt!",
+                "pt": "Água clara, doce, que brota das pedras!",
+                "en_pt": "Clear, fresh water, gushing from the rocks!"
+            },
+            "ipa": {
+                "fr": "yn sˈuʁs yn ˈo klˈɛʁ dˈus ki ʒajˈi de- ʁɔʃˈe",
+                "de": "[ˌaɪnə kvˈɛlə\n klˈɑːrəs\n zˈyːsəs vˈasɜ\n das ˌaʊs deːn fˈɛlzən ʃprˈuːdəlt]",
+                "it": "[ˌʊna sordʒˈɛnte\n ʊnˈakːwa kjˈaːra\n dˈoltʃe\n kˌe zɡˈɔːrɡa dˌalle rˈɔtʃːe]",
+                "es": "[un manaŋˈtʝal ˈaɣwa ˈklaɾa ˈdulθe ke ˈbɾota ðe las ˈrokas]",
+                "nl": "[ən brˈɔn\n hˈɛldər\n zˈɑxt ʋˈaːtər dɑt œy tə rˈɔtsən sprˈɪŋt]",
+                "pt": "[ˈaɡwæ klˈaɾæ\n dˈosy\n ky brˈɔtæ das pˈɛdræs]",
+                "en": "[ɐ spɹˈɪŋ klˈiə fɹˈɛʃ wˈɔːtə ɡˈʌʃɪŋ fɹʌmðə ɹˈɒks]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-059",
             "text": {
                 "fr": "Elle remplit une petite casserole qu'elle a trouvée dans la cabane.",
-                "en": "She fills a small pan she found in the cabin.",
+                "en": "She fills a small pot she found in the cabin.",
                 "de": "Sie füllt einen kleinen Topf, den sie in der Hütte gefunden hat.",
                 "it": "Riempie una piccola pentola che ha trovato nella capanna.",
                 "es": "Llena una pequeña cazuela que encontró en la cabaña.",
                 "nl": "Ze vult een kleine pan die ze in de hut heeft gevonden.",
-                "pt": "Ela enche uma panelinha que encontrou na cabana.",
-                "en_pt": "She fills a small pot she found in the cabin."
+                "pt": "Ela enche uma panelinha que encontrou na cabana."
             },
             "ipa": {
                 "fr": "ɛl ʁɑ̃plˈit yn pətˈit kasʁˈɔl kɛl a tʁuvˈe dɑ̃ la- kabˈan",
@@ -1722,7 +1605,7 @@
                 "es": "[ˈʎe.na uˈna peˈkeɲa kaˈθwe.la ke en.konˈtɾo en la kaˈβa.ɲa]",
                 "nl": "[zə vˈɵlt ən klˈɛɪnə pˈɑn di zə ɪn də hˈɵt heːft ɣəvˈɔndən]",
                 "pt": "[ˌɛlæ ˈeɪŋʃj ˌumæ pˌænelˈiɲæ ky ˌeɪŋkoŋtrˈow na kˌabˈɐ̃næ]",
-                "en": "[ʃiː fˈɪlz ɐ smˈɔːl pˈan ʃiː fˈaʊnd ɪnðə kˈabɪn]"
+                "en": "[ʃiː fˈɪlz ɐ smˈɔːl pˈɒt ʃiː fˈaʊnd ɪnðə kˈabɪn]"
             },
             "provenance": {
                 "fr": "original",
@@ -1735,15 +1618,16 @@
             }
         },
         {
-            "id": "scene-11-057",
+            "id": "scene-11-060",
             "text": {
                 "fr": "De retour près du feu, elle fait bouillir l'eau et y met les orties.",
-                "en": "Back by the fire, she boils the water and adds the nettles.",
+                "en": "Back near the fire, she boils the water and adds the nettles.",
                 "de": "Zurück beim Feuer bringt sie das Wasser zum Kochen und gibt die Brennnesseln hinein.",
                 "it": "Tornata vicino al fuoco, fa bollire l'acqua e ci mette le ortiche.",
                 "es": "De vuelta cerca del fuego, hierve el agua y añade las ortigas.",
                 "nl": "Terug bij het vuur kookt ze het water en doet de brandnetels erin.",
-                "pt": "De volta perto do fogo, ela ferve a água e coloca as urtigas."
+                "pt": "De volta perto do fogo, ela ferve a água e coloca as urtigas.",
+                "en_pt": "Back by the fire, she boils the water and adds the nettles."
             },
             "ipa": {
                 "fr": "də- ʁətˈuʁ pʁɛ dy- fˈø ɛl fˈɛ bujˈiʁ lˈo e i mˈɛ le-z ɔʁtˈi",
@@ -1752,7 +1636,7 @@
                 "es": "[de ˈβwel.ta ˈθeɾ.ka ðel ˈfwe.ɣo ˈʝeɾ.βe el ˈa.ɣwa i aˈɲa.ðe las oɾˈti.ɣas]",
                 "nl": "[tərˈɵx bɛɪ hət vˈyr kˈoːkt zə hət ʋˈaːtər ɛn dˈu tə brˈɑndnətˌɛls ɛrˈɪn]",
                 "pt": "[dʒy vˈɔltæ pˈɛɾətʊ dʊ fˈoɡʊ\n ˌɛlæ fˈɛɾəvj a ˈaɡwæ i kˌolˈɔkæ az ˌuɾətʃˈiɡæs]",
-                "en": "[bˈak baɪ ðə fˈaɪə ʃiː bˈɔɪlz ðə wˈɔːtə and ˈadz ðə nˈɛtəlz]"
+                "en": "[bˈak nˌiə ðə fˈaɪə ʃiː bˈɔɪlz ðə wˈɔːtə and ˈadz ðə nˈɛtəlz]"
             },
             "provenance": {
                 "fr": "original",
@@ -1765,7 +1649,38 @@
             }
         },
         {
-            "id": "scene-11-058",
+            "id": "scene-11-061",
+            "text": {
+                "fr": "Avec le feu, l'eau de la source, et les orties, je fais une soupe.",
+                "en": "With the fire, spring water, and nettles, I make soup.",
+                "de": "Mit dem Feuer, dem Wasser aus der Quelle und den Brennnesseln mache ich eine Suppe.",
+                "it": "Con il fuoco, l'acqua della sorgente e le ortiche, faccio una zuppa.",
+                "es": "Con el fuego, el agua del manantial y las ortigas, hago una sopa.",
+                "nl": "Met het vuur, het water van de bron, en de brandnetels, maak ik een soep.",
+                "pt": "Com o fogo, a água da nascente e as urtigas, faço uma sopa.",
+                "en_pt": "With the fire, the spring water and the nettles, I make a soup."
+            },
+            "ipa": {
+                "fr": "avˌɛk lə- fˈø lˈo də- la- sˈuʁs e le-z ɔʁtˈi ʒə- fˈɛz yn sˈup",
+                "de": "[mɪt deːm fˈɔøɜ\n deːm vˈasɜ ˌaʊs dɛɾ kvˈɛlə ʊnt deːn brˈɛnɛsəln mˈaxə ɪç ˌaɪnə zˈʊpə]",
+                "it": "[kˌon ˌil fʊˈɔːko\n lˈakːwa dˌɛlla sordʒˈɛnte ˌe lˌe ˈɔrtike\n fˌatʃːo ˌʊna dzˈupːa]",
+                "es": "[kon el ˈfweɣo el ˈaɣwa ðel manaŋˈtʝal i las oɾˈtiɣas ˈaɣo ˈuna ˈsopa]",
+                "nl": "[mɛt hət vˈyr\n hət ʋˈaːtər vɑn də brˈɔn\n ɛn də brˈɑndnətˌɛls\n mˈaːk ɪk ən sˈup]",
+                "pt": "[koŋ ʊ fˈoɡʊ\n a ˈaɡwæ da nˌasˈeɪŋtʃj i az ˌuɾətʃˈiɡæs\n fˌasʊ ˌumæ sˈopæ]",
+                "en": "[wɪððə fˈaɪə spɹˈɪŋ wˈɔːtə and nˈɛtəlz aɪ mˌeɪk sˈuːp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-062",
             "text": {
                 "fr": "La soupe est simple mais délicieuse.",
                 "en": "The soup is simple but delicious.",
@@ -1795,7 +1710,7 @@
             }
         },
         {
-            "id": "scene-11-059",
+            "id": "scene-11-063",
             "text": {
                 "fr": "Elle la boit lentement, sentant la chaleur se répandre dans son corps.",
                 "en": "She drinks it slowly, feeling the warmth spread through her body.",
@@ -1826,7 +1741,84 @@
             }
         },
         {
-            "id": "scene-11-060",
+            "id": "scene-11-064",
+            "text": {
+                "fr": "La nature me donne exactement ce dont j'ai besoin",
+                "en": "Nature gives me exactly what I need",
+                "de": "Die Natur gibt mir genau das, was ich brauche",
+                "it": "La natura mi dà esattamente quello di cui ho bisogno",
+                "es": "La naturaleza me ofrece exactamente lo que necesito",
+                "nl": "De natuur geeft me precies wat ik nodig heb",
+                "pt": "A natureza me dá exatamente o que preciso.",
+                "en_pt": "Nature gives me exactly what I need."
+            },
+            "ipa": {
+                "fr": "la- natˈyʁ mə- dˈɔn ɛɡzaktəmˈɑ̃ sə- dɔ̃ ʒe bəzwˈɛ̃",
+                "de": "[diː nˈɑtuːɾ ɡˈiːpt miːɾ ɡənˈaʊ das\n vˈas ɪç brˈaʊxə]",
+                "it": "[lˌa natˈuːra mˌɪ dˈa ˌezatːamˈente kwˈɛllo dˌɪ kˈuj ˌo bizˈoɲʲo]",
+                "es": "[la natuˈɾaleθa me oˈfɾeθe eksakˈtamente lo ke neseˈsito]",
+                "nl": "[də naːtˈyr ɣˈeːft mə preːsˈis ʋɑt ɪk nˈoːdəx hɛp]",
+                "pt": "[a nˌatuɾˈezæ my dˈa ˌezatæmˈeɪŋtʃj ʊ ky prˌesˈizʊ]",
+                "en": "[nˈeɪtʃə ɡˈɪvz mˌiː ɛɡzˈaktli wɒt aɪ nˈiːd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-065",
+            "text": {
+                "pt": "Ou será...",
+                "en": "Or is it..."
+            },
+            "ipa": {
+                "pt": "[ow seɾˈa]",
+                "en": "[ɔːɹ ɪz ˈɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-066",
+            "text": {
+                "fr": "est-ce moi qui interprète ses dons?",
+                "en": "Is it me who interprets these gifts?",
+                "de": "bin ich es, die ihre Gaben interpretiert?",
+                "it": "sono io che interpreto i suoi doni?",
+                "es": "¿será que yo interpreto sus regalos?",
+                "nl": "is het dat ik haar geschenken interpreteer?",
+                "pt": "sou eu quem interpreta seus dons?",
+                "en_pt": "am I the one interpreting its gifts?"
+            },
+            "ipa": {
+                "fr": "ɛs mwˌa ki ɛ̃tɛʁpʁˈɛt se- dˈɔ̃",
+                "de": "[bɪn ɪç ˈɛs\n diː ˌiːrə ɡˈɑːbən ˌɪntɜpreːtˈiːɾt]",
+                "it": "[sˌono ˌio kˌe intˈɛrpreto ˌɪ sʊˌɔɪ dˈoːnɪ]",
+                "es": "[ˈseɾa ke ʝo inteɾˈpɾeto sus reˈɣalos]",
+                "nl": "[ɪs hət dɑt ɪk haːr ɣəsxˈɛŋkən ˌɪntərprətˈɪr]",
+                "pt": "[sow eʊ kˈeɪŋ ˌiŋteɾəprˈɛtæ seʊz dˈoŋs]",
+                "en": "[ɪz ɪt mˌiː hˌuː ɪntˈɜːpɹɪts ðiːz ɡˈɪfts]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-067",
             "text": {
                 "fr": "Elle regarde le feu danser dans la cheminée.",
                 "en": "She watches the fire dance in the fireplace.",
@@ -1856,7 +1848,7 @@
             }
         },
         {
-            "id": "scene-11-061",
+            "id": "scene-11-068",
             "text": {
                 "fr": "Le feu qu'elle a allumé.",
                 "en": "The fire she lit.",
@@ -1886,7 +1878,7 @@
             }
         },
         {
-            "id": "scene-11-062",
+            "id": "scene-11-069",
             "text": {
                 "fr": "L'eau qu'elle a trouvée.",
                 "en": "The water she found.",
@@ -1916,7 +1908,7 @@
             }
         },
         {
-            "id": "scene-11-063",
+            "id": "scene-11-070",
             "text": {
                 "fr": "Les orties qu'elle a reconnues.",
                 "en": "The nettles she recognized.",
@@ -1946,16 +1938,46 @@
             }
         },
         {
-            "id": "scene-11-064",
+            "id": "scene-11-071",
+            "text": {
+                "fr": "La montagne m'offre ces éléments, mais c'est moi qui les transforme en survie.",
+                "en": "The mountain offers me these elements, but it's I who transform them into survival.",
+                "de": "Die Berge bieten mir diese Elemente, aber ich bin es, die sie in Überleben verwandelt.",
+                "it": "La montagna mi offre questi elementi, ma sono io che li trasformo in sopravvivenza.",
+                "es": "La montaña me ofrece estos elementos, pero soy yo quien los transforma en supervivencia.",
+                "nl": "De natuur biedt deze elementen, maar ik transformeer ze tot overleving.",
+                "pt": "A montanha me oferece esses elementos, mas sou eu quem os transforma em sobrevivência.",
+                "en_pt": "The mountain offers me these elements, but I'm the one who transforms them into survival."
+            },
+            "ipa": {
+                "fr": "la- mɔ̃tˈaɲ mˈɔfʁ sez elemˈɑ̃ mɛ sɛ mwˌa ki le- tʁɑ̃sfˈɔʁm ɑ̃ syʁvˈi",
+                "de": "[diː bˈɛɾɡə bˈiːtən miːɾ dˌiːzə ˌeːleːmˈɛntə\n ˈɑːbɜ ɪç bɪn ɛs\n diː ziː ɪn ˌyːbɜlˈeːbən fɛɾvˈandəlt]",
+                "it": "[lˌa montˈaɲɲa mˌɪ ˈoffre kwˌɛstɪ ˌɛlemˈentɪ\n mˌa sˌono ˌio kˌe lˌɪ trasfˈoːrmo ˌin sˌɔpravvivˈɛntsa]",
+                "es": "[la monˈtaɲa me oˈfɾeθe ˈestos eleˈmentos ˈpeɾo ˈsoʝ ʝo kjen los tɾansˈfoɾma en supeɾbiˈβenθja]",
+                "nl": "[də naːtˈyr bˈi tˌeːzə ˌeːləmˈɛntən\n maːr ɪk trˌɑnsfɔrmˈɪr zə tɔt ˌoːvərlˈeːvɪŋ]",
+                "pt": "[a mˌoŋtˈɐ̃ɲæ mj ˌofeɾˈɛsj ˌesiz ˌelemˈeɪŋtʊs\n mas sow eʊ kˈeɪŋ ʊs trˌɐ̃ŋsfˈɔɾəmæ ˈeɪŋ sobɾevˌivˈeɪŋsjæ]",
+                "en": "[ðə mˈaʊntɪn ˈɒfəz mˌiː ðiːz ˈɛlɪmənts bˌʌt ɪts aɪ hˌuː tɹansfˈɔːm ðˌɛm ˌɪntʊ səvˈaɪvəl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-072",
             "text": {
                 "fr": "Cette nuit-là, assise près du feu, Sophie réfléchit à sa vie.",
-                "en": "That night, sitting by the fire, Sophie reflected on her life.",
+                "en": "That night, sitting by the fire, Sophie reflects on her life.",
                 "de": "In jener Nacht, sitzend neben dem Feuer, reflektierte Sophie über ihr Leben.",
                 "it": "Quella notte, seduta vicino al fuoco, Sophie rifletteva sulla sua vita.",
                 "es": "Esa noche, sentada cerca del fuego, Sophie reflexiona sobre su vida.",
                 "nl": "Die avond, zittend bij het vuur, dacht Sophie na over haar leven.",
-                "pt": "Naquela noite, sentada perto do fogo, Sophie reflete sobre sua vida.",
-                "en_pt": "That night, sitting by the fire, Sophie reflects on her life."
+                "pt": "Naquela noite, sentada perto do fogo, Sophie reflete sobre sua vida."
             },
             "ipa": {
                 "fr": "sɛt nyˈilˈa asˈiz pʁɛ dy- fˈø sɔfˈi ʁefleʃˈi a sa- vˈi",
@@ -1964,7 +1986,7 @@
                 "es": "[ˈe.sa ˈno.tʃe senˈta.ða ˈθeɾ.ka ðel ˈfwe.ɣo ˈso.fi re.fleˈxjo.na ˈso.βɾe su ˈβi.ða]",
                 "nl": "[di ˈaːvɔnt\n zˈɪtənt bɛɪ hət vˈyr\n dˈɑxt sɔphˈi naː ˈoːvər haːr lˈeːvən]",
                 "pt": "[nˌakˈɛlæ nˈoɪtʃy\n sˌeɪŋtˈadæ pˈɛɾətʊ dʊ fˈoɡʊ\n sˌofˈiy xˌeflˈɛtʃy sˈobry sˌuæ vˈidæ]",
-                "en": "[ðat nˈaɪt sˈɪtɪŋ baɪ ðə fˈaɪə sˈəʊfi ɹɪflˈɛktɪd ˌɒn hɜː lˈaɪf]"
+                "en": "[ðat nˈaɪt sˈɪtɪŋ baɪ ðə fˈaɪə sˈəʊfi ɹɪflˈɛkts ˌɒn hɜː lˈaɪf]"
             },
             "provenance": {
                 "fr": "original",
@@ -1977,16 +1999,46 @@
             }
         },
         {
-            "id": "scene-11-065",
+            "id": "scene-11-073",
+            "text": {
+                "fr": "Cette épreuve m'apprend que je suis plus forte que je ne pensais.",
+                "en": "This ordeal teaches me that I'm stronger than I thought.",
+                "de": "Diese Prüfung lehrt mich, dass ich stärker bin, als ich dachte.",
+                "it": "Questa prova mi insegna che sono più forte di quanto pensassi.",
+                "es": "Esta prueba me enseña que soy más fuerte de lo que pensaba.",
+                "nl": "Deze uitdaging leert me dat ik sterker ben dan ik dacht.",
+                "pt": "Esta prova me ensina que sou mais forte do que pensava.",
+                "en_pt": "This trial teaches me that I'm stronger than I thought."
+            },
+            "ipa": {
+                "fr": "sɛt epʁˈøv mapʁˈɑ̃ kə ʒə- syˌi ply fˈɔʁt kə ʒə- nə- pɑ̃sˈɛ",
+                "de": "[dˌiːzə prˈyːfʊŋ lˈeːɾt mɪç\n das ɪç ʃtˈɛɾkɜ bɪn\n als ɪç dˈaxtə]",
+                "it": "[kwˌɛsta prˈɔːva mˌɪ insˈeɲʲa kˌe sˌono pjˌʊ fˈɔːrte dˌɪ kwˈanto pensˈassɪ]",
+                "es": "[ˈesta ˈpɾweβa me enˈseɲa ke ˈsoʝ ˈmas ˈfweɾte ðe lo ke penˈsaβa]",
+                "nl": "[dˌeːzə ˈœytdˌaːɣɪŋ lˈɪːrt mə dɑt ɪk stˈɛrkər bɛn dˈɑn ɪk dˈɑxt]",
+                "pt": "[ˌɛstæ prˈɔvæ mj ˌeɪŋsˈinæ ky sow mˈaɪs fˈɔɾətʃy dʊ ky pˌeɪŋsˈavæ]",
+                "en": "[ðɪs ɔːdˈiəl tˈiːtʃɪz mˌiː ðat aɪm stɹˈɒŋɡə ðɐn aɪ θˈɔːt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-074",
             "text": {
                 "fr": "Elle pense à tous les futurs possibles.",
-                "en": "She thinks about all possible futures.",
+                "en": "She thinks about all the possible futures.",
                 "de": "Sie denkt über alle möglichen Zukünfte nach.",
                 "it": "Pensava a tutti i futuri possibili.",
                 "es": "Piensa en todas las posibilidades futuras.",
                 "nl": "Ze denkt aan alle mogelijke toekomsten.",
-                "pt": "Ela pensa em todos os futuros possíveis.",
-                "en_pt": "She thinks about all the possible futures."
+                "pt": "Ela pensa em todos os futuros possíveis."
             },
             "ipa": {
                 "fr": "ɛl pˈɑ̃s a tu le- fytˈyʁ pɔsˈibl",
@@ -1995,7 +2047,7 @@
                 "es": "[ˈpjen.sa en ˈto.ðas las po.siβiˈli.ða.ðes fuˈtu.ɾas]",
                 "nl": "[zə dˈɛŋkt aːn ˈɑlə mˈoːɣələkə tˈukˌɔmstən]",
                 "pt": "[ˌɛlæ pˈeɪŋsæ ˈeɪŋ tˈodʊz ʊs fˌutˈuɾʊs pˌosˈiveɪs]",
-                "en": "[ʃiː θˈɪŋks ɐbˌaʊt ˈɔːl pˈɒsəbəl fjˈuːtʃəz]"
+                "en": "[ʃiː θˈɪŋks ɐbˌaʊt ˈɔːl ðə pˈɒsəbəl fjˈuːtʃəz]"
             },
             "provenance": {
                 "fr": "original",
@@ -2008,10 +2060,10 @@
             }
         },
         {
-            "id": "scene-11-066",
+            "id": "scene-11-075",
             "text": {
                 "fr": "Un futur où elle retourne à Paris et reprend sa vie d'avant.",
-                "en": "A future where she returns to Amsterdam and resumes her former life.",
+                "en": "A future where she returns to Paris and resumes her previous life.",
                 "de": "Eine Zukunft, in der sie nach Paris zurückkehrt und ihr altes Leben wieder aufnimmt.",
                 "it": "Un futuro dove torna a Roma e riprende la sua vita di prima.",
                 "es": "Un futuro donde regresa a Madrid y retoma su vida anterior.",
@@ -2026,7 +2078,7 @@
                 "es": "[un fuˈtu.ɾo ˈðon.de reˈɣɾe.sa a maˈðɾið i reˈto.ma su ˈβi.ða an.teˈɾjor]",
                 "nl": "[ən tˈukˌɔmst ʋˈaːrɪn zə tərˈɵxkˌɪːrt naːr ˈɑmstərdˌɑm ɛn haːr ˈʌʊdə lˈeːvən ʋˈɪːr ˈɔpɑkt]",
                 "pt": "[ũŋ fˌutˈuɾw ˌoŋdʒy vˈɔltæ pˌaɾæ sɐ̃ʊ̃ pˈaʊlw i xˌetˈomæ sˌuæ vˈidæ dʒj ˈɐ̃ŋtʃys]",
-                "en": "[ɐ fjˈuːtʃə wˌeə ʃiː ɹɪtˈɜːnz tʊ ˈamstədˌam and ɹɪzjˈuːmz hɜː fˈɔːmə lˈaɪf]"
+                "en": "[ɐ fjˈuːtʃə wˌeə ʃiː ɹɪtˈɜːnz tə pˈaɹɪs and ɹɪzjˈuːmz hɜː pɹˈiːvɪəs lˈaɪf]"
             },
             "provenance": {
                 "fr": "original",
@@ -2039,16 +2091,15 @@
             }
         },
         {
-            "id": "scene-11-067",
+            "id": "scene-11-076",
             "text": {
                 "fr": "Un futur où elle reste dans les montagnes.",
-                "en": "A future where she stays in the Ardennes.",
+                "en": "A future where she stays in the mountains.",
                 "de": "Eine Zukunft, in der sie in den Bergen bleibt.",
                 "it": "Un futuro dove rimane sulle montagne.",
                 "es": "Un futuro donde se queda en los Pirineos.",
                 "nl": "Een toekomst waarin ze in de Ardennen blijft.",
-                "pt": "Um futuro onde fica nas montanhas.",
-                "en_pt": "A future where she stays in the mountains."
+                "pt": "Um futuro onde fica nas montanhas."
             },
             "ipa": {
                 "fr": "œ̃ fytˈyʁ u ɛl ʁˈɛst dɑ̃ le- mɔ̃tˈanj",
@@ -2057,7 +2108,7 @@
                 "es": "[un fuˈtu.ɾo ˈðon.de se ˈke.ða en los pi.ɾiˈne.os]",
                 "nl": "[ən tˈukˌɔmst ʋˈaːrɪn zə ɪn də ˈɑrdɛnən blˈɛɪft]",
                 "pt": "[ũŋ fˌutˈuɾw ˌoŋdʒy fˈikæ naz mˌoŋtˈɐ̃ɲæs]",
-                "en": "[ɐ fjˈuːtʃə wˌeə ʃiː stˈeɪz ɪnðɪ ˈɑːdənz]"
+                "en": "[ɐ fjˈuːtʃə wˌeə ʃiː stˈeɪz ɪnðə mˈaʊntɪnz]"
             },
             "provenance": {
                 "fr": "original",
@@ -2070,16 +2121,15 @@
             }
         },
         {
-            "id": "scene-11-068",
+            "id": "scene-11-077",
             "text": {
                 "fr": "Un futur où elle et Lucas se séparent.",
-                "en": "A future where she and Lucas split up.",
+                "en": "A future where she and Lucas separate.",
                 "de": "Eine Zukunft, in der sie und Lucas sich trennen.",
                 "it": "Un futuro dove lei e Lucas si separano.",
                 "es": "Un futuro donde ella y Lucas se separan.",
                 "nl": "Een toekomst waarin zij en Lucas uit elkaar gaan.",
-                "pt": "Um futuro onde ela e Lucas se separam.",
-                "en_pt": "A future where she and Lucas separate."
+                "pt": "Um futuro onde ela e Lucas se separam."
             },
             "ipa": {
                 "fr": "œ̃ fytˈyʁ u ɛl e lykˈa sə- sepˈaʁ",
@@ -2088,7 +2138,7 @@
                 "es": "[un fuˈtu.ɾo ˈðon.de ˈe.ʎa i ˈlu.kas se se.paˈɾan]",
                 "nl": "[ən tˈukˌɔmst ʋˈaːrɪn zɛɪ ɛn lˈykɑs œyt ˈɛlkaːr ɣˈaːn]",
                 "pt": "[ũŋ fˌutˈuɾw ˌoŋdʒj ˌɛlæ i lˈukæs sy sˌepˈaɾɐ̃ʊ̃]",
-                "en": "[ɐ fjˈuːtʃə wˌeə ʃiː and lˈuːkəz splˈɪt ˈʌp]"
+                "en": "[ɐ fjˈuːtʃə wˌeə ʃiː and lˈuːkəz sˈɛpɹət]"
             },
             "provenance": {
                 "fr": "original",
@@ -2101,15 +2151,16 @@
             }
         },
         {
-            "id": "scene-11-069",
+            "id": "scene-11-078",
             "text": {
                 "fr": "Un futur où ils restent ensemble mais différents.",
-                "en": "A future where they stay together but different.",
+                "en": "A future where they stay together but changed.",
                 "de": "Eine Zukunft, in der sie zusammenbleiben, aber sich verändern.",
                 "it": "Un futuro dove restano insieme ma sono cambiati.",
                 "es": "Un futuro donde siguen juntos pero diferentes.",
                 "nl": "Een toekomst waarin ze samen blijven, maar anders.",
-                "pt": "Um futuro onde ficam juntos mas diferentes."
+                "pt": "Um futuro onde ficam juntos mas diferentes.",
+                "en_pt": "A future where they stay together but different."
             },
             "ipa": {
                 "fr": "œ̃ fytˈyʁ u il ʁˈɛstt ɑ̃sˈɑ̃bl mɛ difeʁˈɑ̃",
@@ -2118,7 +2169,7 @@
                 "es": "[un fuˈtu.ɾo ˈðon.de ˈsi.ɣen ˈxun.tos ˈpe.ro di.feˈɾen.tes]",
                 "nl": "[ən tˈukˌɔmst ʋˈaːrɪn zə sˈaːmən blˈɛɪvən\n maːr ˈɑndərs]",
                 "pt": "[ũŋ fˌutˈuɾw ˌoŋdʒy fˈikɐ̃ʊ̃ ʒˈũŋtʊz maz dʒˌifeɾˈeɪŋtʃys]",
-                "en": "[ɐ fjˈuːtʃə wˌeə ðeɪ stˈeɪ təɡˌɛðə bˌʌt dˈɪfɹənt]"
+                "en": "[ɐ fjˈuːtʃə wˌeə ðeɪ stˈeɪ təɡˌɛðə bˌʌt tʃˈeɪndʒd]"
             },
             "provenance": {
                 "fr": "original",
@@ -2131,232 +2182,7 @@
             }
         },
         {
-            "id": "scene-11-070",
-            "text": {
-                "pt": "Tem uma lareira.",
-                "en": "There's a fireplace."
-            },
-            "ipa": {
-                "pt": "[teɪŋ ˌumæ lˌaɾˈeɪɾæ]",
-                "en": "[ðeəz ɐ fˈaɪəpleɪs]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-071",
-            "text": {
-                "pt": "Na parede, alguém gravou palavras quase apagadas: ...não perdoa...ensina.",
-                "en": "On the wall, someone carved nearly faded words: ...doesn't forgive...teaches."
-            },
-            "ipa": {
-                "pt": "[na pˌaɾˈedʒy\n aʊɡˈeɪŋ ɡravˈow pˌalˈavræs kwˈazj ˌapaɡˈadæs\n nˌɐ̃ʊ̃ pˌeɾədˈoæ\n ˌeɪŋsˈinæ]",
-                "en": "[ɒnðə wˈɔːl sˈʌmwɒn kˈɑːvd nˌiəli fˈeɪdɪd wˈɜːdz dˈʌzənt fəɡˈɪv tˈiːtʃɪz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-072",
-            "text": {
-                "pt": "Quem morou aqui antes de mim?",
-                "en": "Who lived here before me?"
-            },
-            "ipa": {
-                "pt": "[kˈeɪŋ moɾˈow akˈi ˈɐ̃ŋtʃyz dʒy mˈiŋ]",
-                "en": "[hˌuː lˈɪvd hˈiə bɪfˈɔː mˌiː]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-073",
-            "text": {
-                "pt": "Ela toca as paredes de pedra.",
-                "en": "She touches the stone walls."
-            },
-            "ipa": {
-                "pt": "[ˌɛlæ tˈɔkæ as pˌaɾˈedʒyz dʒy pˈɛdræ]",
-                "en": "[ʃiː tˈʌtʃɪz ðə stˈəʊn wˈɔːlz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-074",
-            "text": {
-                "pt": "Ela risca.",
-                "en": "She strikes it."
-            },
-            "ipa": {
-                "pt": "[ˌɛlæ xˈiskæ]",
-                "en": "[ʃiː stɹˈaɪks ɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-075",
-            "text": {
-                "pt": "Nada.",
-                "en": "Nothing."
-            },
-            "ipa": {
-                "pt": "[nˈadæ]",
-                "en": "[nˈʌθɪŋ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-076",
-            "text": {
-                "pt": "Finalmente!",
-                "en": "Finally!"
-            },
-            "ipa": {
-                "pt": "[fˌinaʊmˈeɪŋtʃy]",
-                "en": "[fˈaɪnəli]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-077",
-            "text": {
-                "pt": "Este fogo...",
-                "en": "This fire..."
-            },
-            "ipa": {
-                "pt": "[ˌestʃy fˈoɡʊ]",
-                "en": "[ðɪs fˈaɪə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-078",
-            "text": {
-                "pt": "fui eu quem criei.",
-                "en": "I created it."
-            },
-            "ipa": {
-                "pt": "[fuɪ eʊ kˈeɪŋ kriˈeɪ]",
-                "en": "[aɪ kɹiːˈeɪtɪd ɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-11-079",
-            "text": {
-                "pt": "Só eu.",
-                "en": "Just me."
-            },
-            "ipa": {
-                "pt": "[sˈɔ ˈeʊ]",
-                "en": "[dʒˈʌst mˌiː]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-080",
-            "text": {
-                "pt": "Espera...",
-                "en": "Wait..."
-            },
-            "ipa": {
-                "pt": "[ˌespˈɛɾæ]",
-                "en": "[wˈeɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-081",
-            "text": {
-                "pt": "São urtigas!",
-                "en": "They're nettles!"
-            },
-            "ipa": {
-                "pt": "[sɐ̃ʊ̃ ˌuɾətʃˈiɡæs]",
-                "en": "[ðeɪə nˈɛtəlz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-082",
-            "text": {
-                "pt": "como água correndo!",
-                "en": "like running water!"
-            },
-            "ipa": {
-                "pt": "[kˌomʊ ˈaɡwæ kˌoxˈeɪŋdʊ]",
-                "en": "[lˈaɪk ɹˈʌnɪŋ wˈɔːtə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-083",
-            "text": {
-                "pt": "Uma nascente!",
-                "en": "A spring!"
-            },
-            "ipa": {
-                "pt": "[ˌumæ nˌasˈeɪŋtʃy]",
-                "en": "[ɐ spɹˈɪŋ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-084",
-            "text": {
-                "pt": "Ou será...",
-                "en": "Or is it..."
-            },
-            "ipa": {
-                "pt": "[ow seɾˈa]",
-                "en": "[ɔːɹ ɪz ˈɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-11-085",
             "text": {
                 "pt": "Quem sou eu realmente?",
                 "en": "Who am I really?"
@@ -2367,6 +2193,175 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-080",
+            "text": {
+                "fr": "Qui suis-je vraiment? Peut-être que je ne le saurai jamais complètement",
+                "en": "Who am I really? Maybe I'll never fully know",
+                "de": "Wer bin ich wirklich? Vielleicht werde ich es nie ganz wissen.",
+                "it": "Chi sono veramente? Forse non lo saprò mai completamente.",
+                "es": "¿Quién soy realmente? Quizás nunca lo sepa completamente",
+                "nl": "Wie ben ik echt? Misschien zal ik het nooit helemaal weten.",
+                "pt": "Talvez eu nunca saiba completamente.",
+                "en_pt": "Maybe I'll never know completely."
+            },
+            "ipa": {
+                "fr": "ki syˌiʒ vʁɛmˈɑ̃ pˈøtˈɛtʁ kə ʒə- nə- lə- soʁˈe ʒamˌɛ kɔ̃plɛtmˈɑ̃",
+                "de": "[vˈeːɾ bɪn ɪç vˈɪɾklɪç\n fiːllˈaɪçt vˌɛɾdə ɪç ɛs nˈiː ɡˌants vˈɪsən]",
+                "it": "[kˈi sˌono vˌɛramˈente\n fˈoːrse nˌon lˌo saprˈɔ mˌaɪ kˌompletamˈente]",
+                "es": "[ˈkjen ˈsoʝ reˈalmente kiˈθas ˈnunka lo ˈsepa kompleˈtamente]",
+                "nl": "[ʋˈi bɛn ɪk ˈɛxt\n mɪsxˈin zɑl ɪk hət nˈoːjt hˌeːləmˈaːl ʋˈeːtən]",
+                "pt": "[taʊvˈez eʊ nˌũŋkæ sˈaɪbæ kˌompletæmˈeɪŋtʃy]",
+                "en": "[hˌuː am aɪ ɹˈiəlɪ mˈeɪbiː aɪl nˈɛvə fˈʊli nˈəʊ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-081",
+            "text": {
+                "fr": "Peut-être que c'est normal.",
+                "en": "Maybe that's normal.",
+                "de": "Vielleicht ist das normal.",
+                "it": "Forse è normale.",
+                "es": "Quizás eso es normal.",
+                "nl": "Misschien is dat normaal.",
+                "pt": "Talvez seja normal."
+            },
+            "ipa": {
+                "fr": "pˈøtˈɛtʁ kə sɛ nɔʁmˈal",
+                "de": "[fiːllˈaɪçt ɪst das nˈɔɾmɑːl]",
+                "it": "[fˈoːrse ˌɛ normˈaːle]",
+                "es": "[kiˈθas ˈeso es noɾˈmal]",
+                "nl": "[mɪsxˈin ɪs dɑt nɔrmˈaːl]",
+                "pt": "[taʊvˈes sˈeʒæ noɾəmˈaʊ]",
+                "en": "[mˈeɪbiː ðats nˈɔːməl]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-082",
+            "text": {
+                "fr": "...ne pardonne pas...enseigne.",
+                "en": "...does not forgive...teaches.",
+                "de": "...vergibt nicht...lehrt.",
+                "it": "...non perdona...insegna.",
+                "es": "...no perdona...enseña.",
+                "nl": "...vergeeft niet...onderwijst."
+            },
+            "ipa": {
+                "fr": "nə- paʁdˈɔn pˈa ɑ̃sˈɛɲ",
+                "de": "[fɛɾɡˈiːpt nˈɪçt\n lˈeːɾt]",
+                "it": "[nˌon perdˈoːna\n insˈeɲʲa]",
+                "es": "[...no peɾˈðona...enˈseɲa]",
+                "nl": "[vərɣˈeːft nˈit\n ˈɔndərʋˌɛɪst]",
+                "en": "[dʌznˌɒt fəɡˈɪv tˈiːtʃɪz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-083",
+            "text": {
+                "fr": "Ce feu... c'est moi qui l'ai créé. Moi seule.",
+                "en": "This fire... I created it. Me alone.",
+                "de": "Dieses Feuer... ich habe es selbst gemacht. Nur ich allein.",
+                "it": "Questo fuoco... l'ho creato io. Solo io.",
+                "es": "Este fuego... lo he creado yo sola.",
+                "nl": "Dit vuur... ik heb het zelf gemaakt. Helemaal alleen."
+            },
+            "ipa": {
+                "fr": "sə- fˈø sɛ mwˌa ki le kʁeˈe mwˌa sˈœl",
+                "de": "[dˌiːzəs fˈɔøɜ\n ɪç hɑːbə ɛs zˈɛlpst ɡəmˈaxt\n nˈuːɾ ɪç alˈaɪn]",
+                "it": "[kwˌɛsto fʊˈɔːko\n lˌo kreˈaːto ˈio\n sˈoːlo ˈio]",
+                "es": "[ˈeste ˈfweɣo lo e kɾeˈaðo ʝo ˈsola]",
+                "nl": "[dɪt vˈyr\n ɪk hɛp hət zˈɛlf ɣəmˈaːkt\n hˌeːləmˈaːl ɑlˈeːn]",
+                "en": "[ðɪs fˈaɪə aɪ kɹiːˈeɪtɪd ɪt mˌiː ɐlˈəʊn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-084",
+            "text": {
+                "fr": "Ou bien..",
+                "en": "Or else..",
+                "de": "Oder...",
+                "it": "O forse...",
+                "es": "O quizás...",
+                "nl": "Of..."
+            },
+            "ipa": {
+                "fr": "u bjˈɛ̃",
+                "de": "[ˈoːdɜ]",
+                "it": "[ˌo fˈoːrse]",
+                "es": "[o kiˈθas]",
+                "nl": "[ˈɔf]",
+                "en": "[ɔːɹ ˈɛls]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-11-085",
+            "text": {
+                "fr": "elle est simplement authentique.",
+                "en": "She is simply authentic.",
+                "de": "sie ist einfach authentisch.",
+                "it": "È semplicemente autentica.",
+                "es": "es simplemente auténtica.",
+                "nl": "Ze is gewoon authentiek."
+            },
+            "ipa": {
+                "fr": "ɛl ɛ sɛ̃pləmˈɑ̃ɔːθɛntˈiːk",
+                "de": "[ziː ɪst ˈaɪnfˌax aʊtˈɛntɪʃ]",
+                "it": "[ˌɛ sˌemplitʃemˈente ˌaʊtˈɛntika]",
+                "es": "[es sim.pleˈmen.te awˈten.ti.ka]",
+                "nl": "[zə ɪs ɣəʋˈoːn ˌʌʊtəntˈik]",
+                "en": "[ʃiː ɪz sˈɪmpli ɔːθˈɛntɪk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-12.json
+++ b/language_materials/unified/stories/scene-12.json
@@ -24,12 +24,42 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-12-001",
+            "text": {
+                "fr": "Pendant ce temps, Lucas cherche désespérément Sophie dans le brouillard.",
+                "en": "Meanwhile, Lucas desperately searches for Sophie in the fog.",
+                "de": "Unterdessen sucht Lucas verzweifelt im Nebel nach Sophie.",
+                "it": "Intanto, Lucas cerca disperatamente Sophie nella nebbia.",
+                "es": "Mientras tanto, Lucas busca desesperadamente a Sophie en la niebla.",
+                "nl": "Ondertussen zoekt Lucas wanhopig naar Sophie in de mist.",
+                "pt": "Enquanto isso, Lucas procura desesperadamente Sophie na neblina."
+            },
+            "ipa": {
+                "fr": "pɑ̃dˈɑ̃ sə- tˈɑ̃ lykˈa ʃˈɛʁʃ dezɛspeʁemˈɑ̃ sɔfˈi dɑ̃ lə- bʁujˈaʁ",
+                "de": "[ˌʊntɜdˈɛsən zˈuːxt lˈuːkɑːs fɛɾtsvˈaɪfəlt ɪm nˈeːbəl nɑːx zoːfˈiː]",
+                "it": "[intˈanto\n lˈuːkas tʃˈeːrka dˌisperˌatamˈente sˈopje nˌɛlla nˈebːia]",
+                "es": "[mjenˈtɾas ˈtanto | ˈlukas ˈbuska ðesezpeɾaˈðamente a ˈsofi en la ˈnjεβla]",
+                "nl": "[ˈɔndərtˌɵsən zˈukt lˈykɑs ʋɑnhˈoːpəx naːr sɔphˈi ɪn də mˈɪst]",
+                "pt": "[ˌeɪŋkwˈɐ̃ŋtw ˈisʊ\n lˈukæs prˌokˈuɾæ dˌezespˌeɾadæmˈeɪŋtʃy sˌofˈiy na nˌeblˈinæ]",
+                "en": "[mˈiːnwaɪl lˈuːkəz dˈɛspəɹətli sˈɜːtʃɪz fɔː sˈəʊfi ɪnðə fˈɒɡ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-002",
             "text": {
                 "fr": "Comment ai-je pu la perdre? Comment?",
                 "en": "How could I have lost her? How?",
@@ -60,10 +90,55 @@
             }
         },
         {
-            "id": "scene-12-002",
+            "id": "scene-12-003",
+            "text": {
+                "pt": "Como?",
+                "en": "How?"
+            },
+            "ipa": {
+                "pt": "[kˈomʊ]",
+                "en": "[hˈaʊ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-004",
+            "text": {
+                "fr": "Il se sent terriblement coupable.",
+                "en": "He feels terribly guilty.",
+                "de": "Er fühlt sich furchtbar schuldig.",
+                "it": "Si sente terribilmente in colpa.",
+                "es": "Se siente terriblemente culpable.",
+                "nl": "Hij voelt zich vreselijk schuldig.",
+                "pt": "Ele se sente terrivelmente culpado."
+            },
+            "ipa": {
+                "fr": "il sə- sˈɑ̃ tɛʁibləmˈɑ̃ kupˈabl",
+                "de": "[ɛɾ fˈyːlt zɪç fˈʊɐçtbɑːɾ ʃˈʊldɪç]",
+                "it": "[sˌɪ sˈɛnte tˌɛrɾibilmˈente ˌin kˈolpa]",
+                "es": "[se ˈsjente teɾiˈβleˈmente kulˈpaβle]",
+                "nl": "[hɛɪ vˈult zɪx vrˈeːsələk sxˈɵldəx]",
+                "pt": "[ˌely sy sˈeɪŋtʃy tˌexivɛʊmˈeɪŋtʃy kˌuwpˈadʊ]",
+                "en": "[hiː fˈiːlz tˈɛɹəblɪ ɡˈɪlti]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-005",
             "text": {
                 "fr": "Je n'aurais jamais dû la laisser continuer seule",
-                "en": "I should have never let her continue alone",
+                "en": "I should never have let her continue alone",
                 "de": "Ich hätte sie nicht alleine weitergehen lassen dürfen.",
                 "it": "Non avrei mai dovuto lasciarla andare avanti da sola.",
                 "es": "Nunca debí dejarla continuar sola",
@@ -78,7 +153,7 @@
                 "es": "[ˈnunka ðeˈβi ðeˈxaɾla kontiˈnwaɾ ˈsola]",
                 "nl": "[ɪk hˈɑt haːr nˈoːjt ɑlˈeːn mˈutən lˈaːtən dɔːrɣˈaːn]",
                 "pt": "[nˌũŋkæ dˌeveɾˈiæ tˈelæ dˌeɪʃˈadʊ kˌoŋtʃinuˈar sˌozˈiɲæ]",
-                "en": "[aɪ ʃˌʊdəv nˈɛvə lˈɛt hɜː kəntˈɪnjuː ɐlˈəʊn]"
+                "en": "[aɪ ʃˌʊd nˈɛvə hav lˈɛt hɜː kəntˈɪnjuː ɐlˈəʊn]"
             },
             "provenance": {
                 "fr": "original",
@@ -91,7 +166,7 @@
             }
         },
         {
-            "id": "scene-12-003",
+            "id": "scene-12-006",
             "text": {
                 "fr": "J'aurais dû rester avec elle.",
                 "en": "I should have stayed with her.",
@@ -121,10 +196,101 @@
             }
         },
         {
-            "id": "scene-12-004",
+            "id": "scene-12-007",
+            "text": {
+                "fr": "Il marche pendant des heures, criant son nom, mais le brouillard absorbe tous les sons.",
+                "en": "He walks for hours, shouting her name, but the fog absorbs all sounds.",
+                "de": "Er läuft stundenlang, ruft ihren Namen, aber der Nebel schluckt alle Geräusche.",
+                "it": "Cammina per ore, gridando il suo nome, ma la nebbia assorbe tutti i suoni.",
+                "es": "Camina durante horas, gritando su nombre, pero la niebla absorbe todos los sonidos.",
+                "nl": "Hij loopt urenlang, roept haar naam, maar de mist absorbeert alle geluiden.",
+                "pt": "Ele caminha por horas, gritando o nome dela, mas a neblina absorve todos os sons."
+            },
+            "ipa": {
+                "fr": "il mˈaʁʃ pɑ̃dˈɑ̃ de-z ˈœʁ kʁiˈɑ̃ sɔ̃ nˈɔ̃ mɛ lə- bʁujˈaʁ absˈɔʁb tu le- sˈɔ̃",
+                "de": "[ɛɾ lˈɔøft ʃtˈʊndənlˌaŋ\n rˈʊft ˌiːrən nˈɑːmən\n ˌɑːbɜ dɛɾ nˈeːbəl ʃlˈʊkt ˈalə ɡərˈɔøʃə]",
+                "it": "[kammˈiːna pˌɛr ˈoːre\n ɡridˈando ˌil sˌʊo nˈoːme\n mˌa lˌa nˈebːia assˈɔːrbe tˈutːɪ ˌɪ sʊˈoːnɪ]",
+                "es": "[kaˈmina ðuˈɾante ˈoɾas | ɡɾiˈtando su ˈnomβɾe | ˈpeɾo la ˈnjεβla apˈsorβe ˈtoðos los soˈniðos]",
+                "nl": "[hɛɪ lˈoːpt ˈyrənlˌɑŋ\n rˈupt haːr nˈaːm\n maːr də mˈɪst ˌɑbsɔrbˈɪrt ˈɑlə ɣəlˈœydən]",
+                "pt": "[ˌely kˌæmˈiɲæ poɾ ˈɔɾæs\n ɡrˌitˈɐ̃ŋdw ʊ nˈomy dˈɛlæ\n maz a nˌeblˈinæ ˌabsˈɔɾəvy tˈodʊz ʊs sˈoŋs]",
+                "en": "[hiː wˈɔːks fɔːɹ ˈaʊəz ʃˈaʊtɪŋ hɜː nˈeɪm bˌʌt ðə fˈɒɡ ɐbsˈɔːbz ˈɔːl sˈaʊndz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-008",
+            "text": {
+                "fr": "Dans cette blancheur épaisse, il perd toute notion de direction.",
+                "en": "In this thick whiteness, he loses all sense of direction.",
+                "de": "In dieser dichten Weiße verliert er jegliches Gefühl für Richtung.",
+                "it": "In questa bianchezza densa, perde ogni nozione di direzione.",
+                "es": "En esa blancura espesa, pierde toda noción de dirección.",
+                "nl": "In deze dikke witheid verliest hij alle gevoel voor richting.",
+                "pt": "Nesta brancura espessa, ele perde toda noção de direção."
+            },
+            "ipa": {
+                "fr": "dɑ̃ sɛt blɑ̃ʃˈœʁ epˈɛs il pˈɛʁ tut nɔsjˈɔ̃ də- diʁɛksjˈɔ̃",
+                "de": "[ɪn dˌiːzɜ dˈɪçtən vˈaɪsə fɛɾlˈiːɾt ɛɾ jˈeːklɪçəs ɡəfˈyːl fyːɾ rˈɪçtʊŋ]",
+                "it": "[ˌin kwˌɛsta bjankˈetsːa dˈɛnsa\n pˈɛːrde ˈoɲʲɪ nˌɔtsiˈɔːne dˌɪ dˌiretsiˈɔːne]",
+                "es": "[en ˈesa βlanˈkuɾa esˈpesa | ˈpjɛɾðe ˈtoða noˈθjon de ðiɾekˈθjon]",
+                "nl": "[ɪn dˌeːzə dˈɪkə ʋˈɪtɛɪt vərlˈist hɛɪ ˈɑlə ɣəvˈul vɔːr rˈɪxtɪŋ]",
+                "pt": "[nˌɛstæ brˌɐ̃ŋkˈuɾæ ˌespˈesæ\n ˌely pˈɛɾədʒy tˈodæ nosˈɐ̃ʊ̃ dʒy dʒˌiɾesˈɐ̃ʊ̃]",
+                "en": "[ɪn ðɪs θˈɪk wˈaɪtnəs hiː lˈuːzɪz ˈɔːl sˈɛns ɒv daɪɹˈɛkʃən]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-009",
+            "text": {
+                "fr": "Le haut, le bas, la gauche, la droite—tout se confond.",
+                "en": "Up, down, left, right—everything blurs together.",
+                "de": "Oben, unten, links, rechts—alles verschwimmt.",
+                "it": "Su, giù, sinistra, destra—tutto si confonde.",
+                "es": "Arriba, abajo, izquierda, derecha—todo se confunde.",
+                "nl": "Boven, onder, links, rechts—alles loopt door elkaar.",
+                "pt": "O alto, o baixo, a esquerda, a direita—tudo se confunde.",
+                "en_pt": "Up, down, left, right—everything is confused."
+            },
+            "ipa": {
+                "fr": "lə- ˈo lə- bˈa la- ɡˈoʃ la- dʁwˈat tu sə- kɔ̃fˈɔ̃",
+                "de": "[ˈoːbən\n ˈʊntən\n lˈɪŋks\n rˈɛçts ˈaləs fɛɾʃvˈɪmt]",
+                "it": "[sˈu\n dʒˈu\n sinˈistra\n dˈɛstra tˈutːo sˌɪ konfˈonde]",
+                "es": "[aˈriβa | aˈβaxo | iθˈkjeɾða | ðeˈɾetʃa—ˈtoðo se konˈfunde]",
+                "nl": "[bˈoːvən\n ˈɔndər\n lˈɪŋks\n rˈɛxts ˈɑləs lˈoːpt doːr ˈɛlkaːr]",
+                "pt": "[u ˈaʊtʊ\n ʊ bˈaɪʃʊ\n a ˌeskˈeɾədæ\n a dʒˌiɾˈeɪtæ tˈudʊ sy kˌoŋfˈũŋdʒy]",
+                "en": "[ˈʌp dˈaʊn lˈɛft ɹˈaɪt ˈɛvɹɪθˌɪŋ blˈɜːz təɡˈɛðə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-010",
             "text": {
                 "fr": "Je ne vois presque plus le sentier",
-                "en": "I can hardly see the trail anymore",
+                "en": "I can barely see the trail anymore",
                 "de": "Ich kann den Weg kaum noch sehen.",
                 "it": "Vedo a malapena il sentiero.",
                 "es": "Casi no veo el sendero",
@@ -139,7 +305,7 @@
                 "es": "[ˈkasi no ˈβeo el senˈðeɾo]",
                 "nl": "[ɪk zˈi hət pˈɑt bˈɛɪnˌaː nˈit mˌeːr]",
                 "pt": "[kwˈazy nˌɐ̃ʊ̃ vˈeʒʊ mˈaɪz a trˈiljæ]",
-                "en": "[aɪ kan hˈɑːdli sˈiː ðə tɹˈeɪl ˌɛnɪmˈɔː]"
+                "en": "[aɪ kan bˈeəli sˈiː ðə tɹˈeɪl ˌɛnɪmˈɔː]"
             },
             "provenance": {
                 "fr": "original",
@@ -152,7 +318,22 @@
             }
         },
         {
-            "id": "scene-12-005",
+            "id": "scene-12-011",
+            "text": {
+                "pt": "Não é esta nossa condição humana?",
+                "en": "Isn't this our human condition?"
+            },
+            "ipa": {
+                "pt": "[nˌɐ̃ʊ̃ ɛ ˌɛstæ nˌɔsæ kˌoŋdʒisˈɐ̃ʊ̃ ˌumˈɐ̃næ]",
+                "en": "[ˌɪzənt ðɪs aʊə hjˈuːmən kəndˈɪʃən]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-012",
             "text": {
                 "fr": "N'est-ce pas notre condition humaine? Nous avançons tous dans l'incertitude.",
                 "en": "Isn't that our human condition? We all move forward in uncertainty.",
@@ -183,740 +364,10 @@
             }
         },
         {
-            "id": "scene-12-006",
-            "text": {
-                "fr": "Il faut que je trouve de l'aide.",
-                "en": "I need to find help.",
-                "de": "Ich muss Hilfe finden.",
-                "it": "Devo trovare aiuto.",
-                "es": "Tengo que encontrar ayuda.",
-                "nl": "Ik moet hulp vinden.",
-                "pt": "Preciso encontrar ajuda."
-            },
-            "ipa": {
-                "fr": "il fo kə ʒə- tʁˈuv də- lˈɛd",
-                "de": "[ɪç mˈʊs hˈɪlfə fˈɪndən]",
-                "it": "[dˈɛːvo trovˈaːre ajˈuːto]",
-                "es": "[ˈteŋɡo ke enkonˈtɾaɾ aˈʝuða]",
-                "nl": "[ɪk mˈut hˈɵlp vˈɪndən]",
-                "pt": "[prˌesˈizw ˌeɪŋkoŋtrˈaɾ ˌaʒˈudæ]",
-                "en": "[aɪ nˈiːd tə fˈaɪnd hˈɛlp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-007",
-            "text": {
-                "fr": "Le village ne peut pas être très loin",
-                "en": "The village can't be far away",
-                "de": "Das Dorf kann nicht weit sein.",
-                "it": "Il villaggio non può essere molto lontano.",
-                "es": "El pueblo no puede estar muy lejos",
-                "nl": "Het dorp kan niet ver weg zijn",
-                "pt": "O vilarejo não pode estar muito longe.",
-                "en_pt": "The village can't be too far."
-            },
-            "ipa": {
-                "fr": "lə- vilˈaʒ nə- pˈø paz ˈɛtʁ tʁɛ lwˈɛ̃",
-                "de": "[das dˈɔɾf kˌan nˈɪçt vˈaɪt zaɪn]",
-                "it": "[ˌil villˈadʒːo nˌon pʊˈɔ ˈɛssere mˈolto lontˈaːno]",
-                "es": "[el ˈpweβlo no ˈpweðe esˈtaɾ muʝ ˈlexos]",
-                "nl": "[hə tˈɔrp kɑn nˌit vˈɛr ʋˈɛx zɛɪn]",
-                "pt": "[ʊ vˌilaɾˈeʒʊ nˌɐ̃ʊ̃ pˌɔdʒj estˌar mwˈiŋtʊ lˈoŋʒy]",
-                "en": "[ðə vˈɪlɪdʒ kˈɑːnt biː fˈɑːɹ ɐwˈeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-008",
-            "text": {
-                "fr": "Si je descends, c'est par là.",
-                "en": "If I go down, it's that way.",
-                "de": "Wenn ich hinuntergehe, dann hier entlang.",
-                "it": "Se scendo, è di qua.",
-                "es": "Si bajo, es por aquí.",
-                "nl": "Als ik naar beneden ga, is het die kant op.",
-                "pt": "Se eu descer, é por ali."
-            },
-            "ipa": {
-                "fr": "sˈi ʒə- dɛsˈɑ̃ sɛ paʁ lˈa",
-                "de": "[vˌɛn ɪç hɪnˈʊntɜɡˌeːə\n dan hˈiːɾ ɛntlˈaŋ]",
-                "it": "[sˌe ʃˈɛndo\n ˌɛ dˌɪ kwˈa]",
-                "es": "[si ˈbaxo | es poɾ aˈki]",
-                "nl": "[ɑls ɪk naːr bənˈeːdən ɣˈaː\n ɪs hət di kˈɑnt ˈɔp]",
-                "pt": "[sj eʊ desˈer\n ɛ poɾ alˈi]",
-                "en": "[ɪf aɪ ɡˌəʊ dˈaʊn ɪts ðat wˈeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-009",
-            "text": {
-                "fr": "Mais dans quelle direction exactement?",
-                "en": "But in which exact direction?",
-                "de": "Aber in welche Richtung genau?",
-                "it": "Ma in quale direzione esattamente?",
-                "es": "¿Pero en qué dirección exactamente?",
-                "nl": "Maar in welke richting precies?",
-                "pt": "Mas em qual direção exatamente?",
-                "en_pt": "But in which direction exactly?"
-            },
-            "ipa": {
-                "fr": "mɛ dɑ̃ kɛl diʁɛksjˈɔ̃ ɛɡzaktəmˈɑ̃",
-                "de": "[ˌɑːbɜ ɪn vˈɛlçə rˈɪçtʊŋ ɡənˈaʊ]",
-                "it": "[mˌa ˌin kwˈaːle dˌiretsiˈɔːne ˌezatːamˈente]",
-                "es": "[ˈpeɾo en ke diɾekˈθjon eksakˈtamente]",
-                "nl": "[maːr ɪn ʋˈɛlkə rˈɪxtɪŋ preːsˈis]",
-                "pt": "[maz ˈeɪŋ kwˈaʊ dʒˌiɾesˈɐ̃ʊ̃ ˌezatæmˈeɪŋtʃy]",
-                "en": "[bˌʌt ɪn wˌɪtʃ ɛɡzˈakt daɪɹˈɛkʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-010",
-            "text": {
-                "fr": "Une chèvre! Elle me regarde fixement.",
-                "en": "A goat! It's staring at me.",
-                "de": "Eine Ziege! Sie starrt mich an.",
-                "it": "Una capra! Mi sta guardando fisso.",
-                "es": "¡Una cabra! Me está mirando fijamente.",
-                "nl": "Een geit! Ze kijkt me strak aan.",
-                "pt": "Ela está me olhando fixamente.",
-                "en_pt": "She's staring at me."
-            },
-            "ipa": {
-                "fr": "yn ʃˈɛvʁ ɛl mə- ʁəɡˈaʁd fiksmˈɑ̃",
-                "de": "[ˌaɪnə tsˈiːɡə\n ziː ʃtˈaɾt mɪç ˈan]",
-                "it": "[ˌʊna kˈaːpra\n mˌɪ stˈa ɡwardˈando fˈisso]",
-                "es": "[ˈuna ˈkaβɾa | me esˈta miˈɾando fixaˈmente]",
-                "nl": "[ən ɣˈɛɪt\n zə kˈɛɪkt mə strˈɑk ˈaːn]",
-                "pt": "[ˌɛlæ estˌa mj ˌoljˈɐ̃ŋdʊ fˌiksæmˈeɪŋtʃy]",
-                "en": "[ɐ ɡˈəʊt ɪts stˈeəɹɪŋ at mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-011",
-            "text": {
-                "fr": "Elle commence à descendre un sentier que je n'avais pas vu.",
-                "en": "It starts to descend a path I hadn't seen.",
-                "de": "Sie beginnt, einen Pfad hinunterzusteigen, den ich nicht gesehen hatte.",
-                "it": "Comincia a scendere un sentiero che non avevo visto.",
-                "es": "Empieza a bajar por un sendero que no había visto.",
-                "nl": "Ze begint een pad af te dalen dat ik niet had gezien.",
-                "pt": "Ela está começando a descer por uma trilha que eu não tinha visto.",
-                "en_pt": "She's starting to descend a trail I hadn't seen."
-            },
-            "ipa": {
-                "fr": "ɛl kɔmˈɑ̃s a dɛsˈɑ̃dʁ œ̃ sɑ̃tjˈe kə ʒə- navˈɛ pa vˈy",
-                "de": "[ziː bəɡˈɪnt\n ˌaɪnən pfˈɑːt hɪnˈʊntɜtsuːʃtˌaɪɡən\n deːn ɪç nˈɪçt ɡəzˈeːən hˌatə]",
-                "it": "[komˈintʃa ˌa ʃˈendere ˌʊn sˌentiˈɛːro kˌe nˌon avˌɛvo vˈisto]",
-                "es": "[emˈpjeθa a βaˈxaɾ poɾ un senˈðeɾo ke no aˈβia ˈβisto]",
-                "nl": "[zə bəɣˈɪnt ən pˈɑt ˈɑf tə dˈaːlən dɑt ɪk nˌit hˈɑt ɣəzˈin]",
-                "pt": "[ˌɛlæ estˌa kˌomesˈɐ̃ŋdw a desˈer poɾ ˌumæ trˈiljæ ky eʊ nˌɐ̃ʊ̃ tʃˌiɲæ vˈistʊ]",
-                "en": "[ɪt stˈɑːts tə dɪsˈɛnd ɐ pˈaθ aɪ hˈadənt sˈiːn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-012",
-            "text": {
-                "fr": "Devrais-je la suivre? Les animaux connaissent les chemins sûrs.",
-                "en": "Should I follow it? Animals know the safe paths.",
-                "de": "Sollte ich ihr folgen? Tiere kennen die sicheren Wege.",
-                "it": "Dovrei seguirla? Gli animali conoscono le vie sicure.",
-                "es": "¿Debería seguirla? Los animales conocen los caminos seguros.",
-                "nl": "Zou ik haar moeten volgen? Dieren kennen de veilige paden.",
-                "pt": "Os animais conhecem os caminhos seguros.",
-                "en_pt": "Animals know the safe paths."
-            },
-            "ipa": {
-                "fr": "dəvʁˈɛʒ la- syˈivʁ le-z animˈo kɔnˈɛs le- ʃəmˈɛ̃ sˈyːʁ",
-                "de": "[zˌɔltə ɪç iːɾ fˈɔlɡən\n tˈiːrə kˈɛnən diː zˈɪçərən vˈeːɡə]",
-                "it": "[dovrˈeːɪ seɡwˈiːrla\n ʎˌɪ ˌanimˈaːlɪ konˈoskono lˌe vˈiːe sikˈuːre]",
-                "es": "[deˈβeɾja seˈɣiɾla | los aˈnimalɛs koˈnoθen los kaˈminos seˈɣuɾos]",
-                "nl": "[zʌʊ ɪk haːr mˈutən vˈɔlɣən\n dˈirən kˈɛnən də vˈɛɪləɣə pˈaːdən]",
-                "pt": "[ʊz ˌænimˈaɪs kˌoɲˈɛseɪŋ ʊs kˌæmˈiɲʊs sˌeɡˈuɾʊs]",
-                "en": "[ʃˌʊd aɪ fˈɒləʊ ɪt ˈanɪməlz nˈəʊ ðə sˈeɪf pˈaθs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-12-013",
             "text": {
-                "fr": "Ou bien..",
-                "en": "Or maybe..",
-                "de": "Oder...",
-                "it": "O magari...",
-                "es": "O quizás...",
-                "nl": "Of misschien.."
-            },
-            "ipa": {
-                "fr": "u bjˈɛ̃",
-                "de": "[ˈoːdɜ]",
-                "it": "[ˌo maɡˈaːrɪ]",
-                "es": "[o kiˈθas]",
-                "nl": "[ɔf mɪsxˈin]",
-                "en": "[ɔː mˈeɪbiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-014",
-            "text": {
-                "fr": "est-ce simplement une chèvre qui rentre à sa ferme? Est-ce que je projette une intentionnalité sur un comportement animal ordinaire?",
-                "en": "is it just a goat going back to its farm? Am I projecting intention onto ordinary animal behavior?",
-                "de": "ist es einfach nur eine Ziege, die nach Hause geht? Projiziere ich eine Absicht auf normales tierisches Verhalten?",
-                "it": "è semplicemente una capra che torna alla sua fattoria? Sto proiettando intenzioni su un comportamento animale ordinario?",
-                "es": "¿es simplemente una cabra que vuelve a su granja? ¿Estoy proyectando una intención en un comportamiento animal común?",
-                "nl": "is het gewoon een geit die naar haar boerderij terugkeert? Projecteer ik een intentie op gewoon diergedrag?",
-                "pt": "Estou projetando intenção em um comportamento animal comum?",
-                "en_pt": "Am I projecting intention onto common animal behavior?"
-            },
-            "ipa": {
-                "fr": "ɛs sɛ̃pləmˈɑ̃ yn ʃˈɛvʁ ki ʁˈɑ̃tʁ a sa- fˈɛʁm ɛs kə ʒə- pʁɔʒˈɛt yn ɛ̃tɑ̃sjɔnalitˈe syʁ œ̃ kɔ̃pɔʁtəmˈɑ̃ animˈal ɔʁdinˈɛʁ",
-                "de": "[ɪst ɛs ˈaɪnfˌax nˈuːɾ ˌaɪnə tsˈiːɡə\n diː nɑːx hˈaʊzə ɡˈeːt\n proːjiːtsˈiːrə ɪç ˌaɪnə ˈapzˌɪçt aʊf nˈɔɾmɑːləs tˈiːrɪʃəs fɛɾhˈaltən]",
-                "it": "[ˌɛ sˌemplitʃemˈente ˌʊna kˈaːpra kˌe tˈoːrna ˌalla sˌʊa fˌatːorˈiːa\n stˈo prˌɔɪetːˈando ˌintentsiˈɔːnɪ sˌʊ ˌʊn kˌomportamˈento ˌanimˈaːle ˌɔrdinˈario]",
-                "es": "[es simˈplemente ˈuna ˈkaβɾa ke ˈbwelβe a su ˈɡɾanxa | ˈestoj pɾoʝekˈtando ˈuna intenˈθjon en un kompoɾtaˈmjento aˈnimal koˈmun]",
-                "nl": "[ɪs hət ɣəʋˈoːn ən ɣˈɛɪt di naːr haːr bˌurdərˈɛɪ tərˈɵxkˌɪːrt\n prˌoːjɛktˈɪr ɪk ən ˈɪntˌɛntsi ɔp ɣəʋˈoːn dˈirɣɛdrˌɑx]",
-                "pt": "[estˌow prˌoʒetˈɐ̃ŋdw ˌiŋteɪŋsˈɐ̃ʊ̃ ˈeɪŋ ũŋ kˌompoɾətæmˈeɪŋtw ˌænimˈaʊ komˈũŋ]",
-                "en": "[ɪz ɪt dʒˈʌst ɐ ɡˈəʊt ɡˌəʊɪŋ bˈak tʊ ɪts fˈɑːm am aɪ pɹədʒˈɛktɪŋ ɪntˈɛnʃən ˌɒntʊ ˈɔːdɪnəɹi ˈanɪməl bɪhˈeɪvjə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-015",
-            "text": {
-                "fr": "J'ai l'impression qu'elle veut me montrer quelque chose.",
-                "en": "I feel like it wants to show me something.",
-                "de": "Ich habe das Gefühl, sie will mir etwas zeigen.",
-                "it": "Ho l'impressione che voglia mostrarmi qualcosa.",
-                "es": "Tengo la impresión de que quiere mostrarme algo.",
-                "nl": "Ik heb het gevoel dat ze me iets wil laten zien.",
-                "pt": "Tenho a impressão de que ela quer me mostrar algo.",
-                "en_pt": "I have the impression that she wants to show me something."
-            },
-            "ipa": {
-                "fr": "ʒe lɛ̃pʁɛsjˈɔ̃ kɛl vˈø mə- mɔ̃tʁˈe kˌɛlkə ʃˈoz",
-                "de": "[ɪç hɑːbə das ɡəfˈyːl\n ziː vɪl miːɾ ˈɛtvɑːs tsˈaɪɡən]",
-                "it": "[ˌo lˌimpressiˈoːne kˌe vˈoːʎa mostrˈaːrmɪ kwalkˈɔːza]",
-                "es": "[ˈteŋɡo la impreˈsjon de ke ˈkjeɾe mosˈtɾaɾme ˈalɡo]",
-                "nl": "[ɪk hɛp hət ɣəvˈul dɑt zə mə ˈits ʋɪl lˈaːtən zˈin]",
-                "pt": "[tˌeɲʊ a ˌimpresˈɐ̃ʊ̃ dʒy ky ˌɛlæ kˈɛr my mostrˈaɾ ˈaʊɡʊ]",
-                "en": "[aɪ fˈiːl lˈaɪk ɪt wˈɒnts tə ʃˈəʊ mˌiː sˈʌmθɪŋ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-016",
-            "text": {
-                "fr": "Peut-être que dans notre désespoir, nous voyons des signes partout",
-                "en": "Maybe in our despair, we see signs everywhere",
-                "de": "Vielleicht sehen wir in unserer Verzweiflung überall Zeichen.",
-                "it": "Forse nel nostro disperazione, vediamo segni ovunque.",
-                "es": "Quizás en nuestro desespero, vemos señales por todas partes",
-                "nl": "Misschien zien we overal tekenen in ons wanhoop",
-                "pt": "Talvez no nosso desespero vejamos sinais em todo lugar.",
-                "en_pt": "Maybe in our desperation we see signs everywhere."
-            },
-            "ipa": {
-                "fr": "pˈøtˈɛtʁ kə dɑ̃ nɔtʁ dezɛspwˈaʁ nu vwajˈɔ̃ de- sˈinj paʁtˈu",
-                "de": "[fiːllˈaɪçt zˈeːən viːɾ ɪn ˈʊnzərɜ fɛɾtsvˈaɪflʊŋ ˌyːbɜˈal tsˈaɪçən]",
-                "it": "[fˈoːrse nˌɛl nˌɔstro dˌisperˌatsiˈɔːne\n vedjˈaːmo sˈeɲʲɪ ovˈunkwe]",
-                "es": "[kiˈθas en ˈnwestɾo ðesezˈpeɾo | ˈβemos seˈɲales poɾ ˈtoðas ˈpaɾtes]",
-                "nl": "[mɪsxˈin zˈin ʋə ˌoːvərˈɑl tˈeːkənən ɪn ɔns ʋˈɑnhˌoːp]",
-                "pt": "[taʊvˈez nʊ nˌɔsʊ dˌezespˈeɾʊ vˌeʒˈɐ̃mʊs sinˈaɪz ˈeɪŋ tˈodʊ luɡˈar]",
-                "en": "[mˈeɪbiː ɪn aʊə dɪspˈeə wiː sˈiː sˈaɪnz ˈɛvɹɪwˌeə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-017",
-            "text": {
-                "fr": "Mais peu importe.",
-                "en": "But it doesn't matter.",
-                "de": "Aber das ist egal.",
-                "it": "Ma poco importa.",
-                "es": "Pero no importa.",
-                "nl": "Maar dat maakt niet uit.",
-                "pt": "Mas não importa—preciso escolher confiar.",
-                "en_pt": "But it doesn't matter—I need to choose to trust."
-            },
-            "ipa": {
-                "fr": "mɛ pø ɛ̃pˈɔʁt",
-                "de": "[ˌɑːbɜ das ɪst eːɡˈɑːl]",
-                "it": "[mˌa pˈɔːko impˈɔːrta]",
-                "es": "[ˈpeɾo no impoɾˈta]",
-                "nl": "[maːr dɑt mˈaːkt nˌit ˈœyt]",
-                "pt": "[maz nˌɐ̃ʊ̃ ˌimpˈɔɾətæ prˌesˈizw ˌeskoljˈer kˌoŋfiˈar]",
-                "en": "[bˌʌt ɪt dˈʌzənt mˈatə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-018",
-            "text": {
-                "fr": "je dois choisir de faire confiance.",
-                "en": "I must choose to trust.",
-                "de": "ich muss mich entscheiden, zu vertrauen.",
-                "it": "devo scegliere di fidarmi.",
-                "es": "tengo que decidir confiar.",
-                "nl": "ik moet ervoor kiezen om te vertrouwen."
-            },
-            "ipa": {
-                "fr": "ʒə- dwˈa ʃwazˈiʁ də- fˈɛʁ kɔ̃fjˈɑ̃s",
-                "de": "[ɪç mˈʊs mɪç ɛntʃˈaɪdən\n tsuː fɛɾtɾˈaʊən]",
-                "it": "[dˈɛːvo ʃˈeʎere dˌɪ fidˈaːrmɪ]",
-                "es": "[ˈteŋɡo ke ðeθiˈðiɾ konˈfjaɾ]",
-                "nl": "[ɪk mˈut ɛrvˈɔːr kˈizən ɔm tə vərtrˈʌʊən]",
-                "en": "[aɪ mˈʌst tʃˈuːz tə tɹˈʌst]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-019",
-            "text": {
-                "fr": "Même si c'est étrange, je dois lui faire confiance",
-                "en": "Even if it's strange, I must trust her",
-                "de": "Selbst wenn es seltsam ist, ich muss ihr vertrauen.",
-                "it": "Anche se è strano, devo fidarmi di lei.",
-                "es": "Aunque sea extraño, tengo que confiar en ella.",
-                "nl": "Zelfs als het vreemd is, moet ik haar vertrouwen",
-                "pt": "Mesmo sendo estranho, preciso confiar nela.",
-                "en_pt": "Even though it's strange, I need to trust her."
-            },
-            "ipa": {
-                "fr": "mˈɛm sˈi sɛt etʁˈɑ̃ʒ ʒə- dwˈa lyˌi fˈɛʁ kɔ̃fjˈɑ̃s",
-                "de": "[zˈɛlpst vˌɛn ɛs zˈɛltzɑːm ɪst\n ɪç mˈʊs iːɾ fɛɾtɾˈaʊən]",
-                "it": "[ˈanke sˌe ˌɛ strˈaːno\n dˈɛːvo fidˈaːrmɪ dˌɪ lˈɛj]",
-                "es": "[ˈawŋke ˈse.a eksˈtɾaɲo | ˈteŋɡo ke konˈfjaɾ en ˈeʎa]",
-                "nl": "[zˈɛlfs ɑls hət vrˈeːmt ɪs\n mˈut ɪk haːr vərtrˈʌʊən]",
-                "pt": "[mˈezmʊ sˈeɪŋdw ˌestrˈɐ̃ɲʊ\n prˌesˈizʊ kˌoŋfiˈar nˈɛlæ]",
-                "en": "[ˈiːvən ɪf ɪts stɹˈeɪndʒ aɪ mˈʌst tɹˈʌst hɜː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-020",
-            "text": {
-                "fr": "Je n'ai pas d'autre choix.",
-                "en": "I have no other choice.",
-                "de": "Ich habe keine andere Wahl.",
-                "it": "Non ho altra scelta.",
-                "es": "No tengo otra opción.",
-                "nl": "Ik heb geen andere keuze.",
-                "pt": "Não tenho outra escolha."
-            },
-            "ipa": {
-                "fr": "ʒə- ne pa dotʁ ʃwˈa",
-                "de": "[ɪç hɑːbə kˈaɪnə ˈandərə vˈɑːl]",
-                "it": "[nˌon ˌo ˈaltra ʃˈelta]",
-                "es": "[no ˈteŋɡo ˈotɾa opˈθjon]",
-                "nl": "[ɪk hɛp ɣˈeːn ˈɑndərə kˈøːzə]",
-                "pt": "[nˌɐ̃ʊ̃ tˌeɲʊ ˈowtræ ˌeskˈoljæ]",
-                "en": "[aɪ hav nˈəʊ ˈʌðə tʃˈɔɪs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-021",
-            "text": {
-                "fr": "Elle s'arrête et attend que je la suive.",
-                "en": "It stops and waits for me to follow.",
-                "de": "Sie hält an und wartet darauf, dass ich ihr folge.",
-                "it": "Si ferma e aspetta che la segua.",
-                "es": "Se detiene y espera que la siga.",
-                "nl": "Ze stopt en wacht tot ik haar volg.",
-                "pt": "Ela para e espera que eu a siga.",
-                "en_pt": "She stops and waits for me to follow."
-            },
-            "ipa": {
-                "fr": "ɛl saʁˈɛt e atˈɑ̃ kə ʒə- la- syˈiv",
-                "de": "[ziː hˈɛlt an ʊnt vˈaɾtət dɑːrˈaʊf\n das ɪç iːɾ fˈɔlɡə]",
-                "it": "[sˌɪ fˈeːrma ˌe aspˈɛtːa kˌe lˌa sˈeɡwa]",
-                "es": "[se ðeˈtjene i esˈpeɾa ke la ˈsiɣa]",
-                "nl": "[zə stˈɔpt ɛn ʋˈɑx tɔt ɪk haːr vˈɔlx]",
-                "pt": "[ˌɛlæ pˌaɾæ i ˌespˈɛɾæ ky eʊ a sˈiɡæ]",
-                "en": "[ɪt stˈɒps and wˈeɪts fɔː mˌiː tə fˈɒləʊ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-022",
-            "text": {
-                "fr": "Sophie compte sur moi, je ne peux pas l'abandonner.",
-                "en": "Sophie is counting on me, I can't let her down.",
-                "de": "Sophie zählt auf mich, ich kann sie nicht im Stich lassen.",
-                "it": "Sophie conta su di me, non posso abbandonarla.",
-                "es": "Sophie cuenta conmigo, no puedo abandonarla.",
-                "nl": "Sophie rekent op mij, ik kan haar niet in de steek laten.",
-                "pt": "Sophie conta comigo, não posso abandoná-la.",
-                "en_pt": "Sophie is counting on me, I can't abandon her."
-            },
-            "ipa": {
-                "fr": "sɔfˈi kˈɔ̃t syʁ mwˈa ʒə- nə- pˈø pa labɑ̃dɔnˈe",
-                "de": "[zoːfˈiː tsˈɛːlt aʊf mɪç\n ɪç kˌan ziː nˈɪçt ɪm ʃtˈɪç lˈasən]",
-                "it": "[sˈopje kˈonta sˌʊ dˌɪ mˈe\n nˌon pˈɔsso ˌabːandonˈaːrla]",
-                "es": "[ˈsofi ˈkwenta ˈkonmiɣo | no ˈpwedo aβanðoˈnaɾla]",
-                "nl": "[sɔphˈi rˈeːkənt ɔp mˈɛɪ\n ɪk kɑn haːr nˌit ɪn də stˈeːk lˈaːtən]",
-                "pt": "[sˌofˈiy kˈoŋtæ kˌomˈiɡʊ\n nˌɐ̃ʊ̃ pˌɔsʊ ˌabɐ̃ŋdonˈalæ]",
-                "en": "[sˈəʊfi ɪz kˈaʊntɪŋ ˈɒn mˌiː aɪ kˈɑːnt lˈɛt hɜː dˈaʊn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-023",
-            "text": {
-                "fr": "Voilà une lumière au loin! La chèvre m'a guidé!",
-                "en": "There's a light in the distance! The goat has guided me!",
-                "de": "Da ist ein Licht in der Ferne! Die Ziege hat mich geführt!",
-                "it": "Ecco una luce in lontananza! La capra mi ha guidato!",
-                "es": "¡Ahí hay una luz a lo lejos! ¡La cabra me ha guiado!",
-                "nl": "Daar is een licht in de verte! De geit heeft me geleid!",
-                "pt": "Tem uma luz lá embaixo!",
-                "en_pt": "There's a light down there!"
-            },
-            "ipa": {
-                "fr": "vwalˌa yn lymjˈɛʁ o lwˈɛ̃ la- ʃˈɛvʁ ma ɡidˈe",
-                "de": "[dɑː ɪst aɪn lˈɪçt ɪn dɛɾ fˈɛɾnə\n diː tsˈiːɡə hat mɪç ɡəfˈyːɾt]",
-                "it": "[ˈɛkːo ˌʊna lˈuːtʃe ˌin lˌontanˈantsa\n lˌa kˈaːpra mˌɪ ˌa ɡwidˈaːto]",
-                "es": "[aˈi ai ˈuna luθ a lo ˈlexos | la ˈkaβɾa me a ɣiˈaðo]",
-                "nl": "[dˈaːr ɪs ən lˈɪxt ɪn də vˈɛrtə\n də ɣˈɛɪt heːft mə ɣəlˈɛɪt]",
-                "pt": "[teɪŋ ˌumæ lˈuz lˈa ˌeɪmbˈaɪʃʊ]",
-                "en": "[ðeəz ɐ lˈaɪt ɪnðə dˈɪstəns ðə ɡˈəʊt hɐz ɡˈaɪdɪd mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-024",
-            "text": {
-                "fr": "À l'aide! J'ai besoin d'aide!",
-                "en": "Help! I need help!",
-                "de": "Zu Hilfe! Ich brauche Hilfe!",
-                "it": "Aiuto! Ho bisogno di aiuto!",
-                "es": "¡Ayuda! ¡Necesito ayuda!",
-                "nl": "Help! Ik heb hulp nodig!",
-                "pt": "Preciso de ajuda!",
-                "en_pt": "I need help!"
-            },
-            "ipa": {
-                "fr": "a lˈɛd ʒe bəzwˈɛ̃ dˈɛd",
-                "de": "[tsuː hˈɪlfə\n ɪç brˈaʊxə hˈɪlfə]",
-                "it": "[ajˈuːto\n ˌo bizˈoɲʲo dˌɪ ajˈuːto]",
-                "es": "[aˈʝuða | neˈθesito aˈʝuða]",
-                "nl": "[hˈɛlp\n ɪk hɛp hˈɵlp nˈoːdəx]",
-                "pt": "[prˌesˈizʊ dʒj ˌaʒˈudæ]",
-                "en": "[hˈɛlp aɪ nˈiːd hˈɛlp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-025",
-            "text": {
-                "fr": "Pendant ce temps, Lucas cherche désespérément Sophie dans le brouillard.",
-                "en": "Meanwhile, Lucas is desperately searching for Sophie in the fog.",
-                "de": "Unterdessen sucht Lucas verzweifelt im Nebel nach Sophie.",
-                "it": "Intanto, Lucas cerca disperatamente Sophie nella nebbia.",
-                "es": "Mientras tanto, Lucas busca desesperadamente a Sophie en la niebla.",
-                "nl": "Ondertussen zoekt Lucas wanhopig naar Sophie in de mist.",
-                "pt": "Enquanto isso, Lucas procura desesperadamente Sophie na neblina.",
-                "en_pt": "Meanwhile, Lucas desperately searches for Sophie in the fog."
-            },
-            "ipa": {
-                "fr": "pɑ̃dˈɑ̃ sə- tˈɑ̃ lykˈa ʃˈɛʁʃ dezɛspeʁemˈɑ̃ sɔfˈi dɑ̃ lə- bʁujˈaʁ",
-                "de": "[ˌʊntɜdˈɛsən zˈuːxt lˈuːkɑːs fɛɾtsvˈaɪfəlt ɪm nˈeːbəl nɑːx zoːfˈiː]",
-                "it": "[intˈanto\n lˈuːkas tʃˈeːrka dˌisperˌatamˈente sˈopje nˌɛlla nˈebːia]",
-                "es": "[mjenˈtɾas ˈtanto | ˈlukas ˈbuska ðesezpeɾaˈðamente a ˈsofi en la ˈnjεβla]",
-                "nl": "[ˈɔndərtˌɵsən zˈukt lˈykɑs ʋɑnhˈoːpəx naːr sɔphˈi ɪn də mˈɪst]",
-                "pt": "[ˌeɪŋkwˈɐ̃ŋtw ˈisʊ\n lˈukæs prˌokˈuɾæ dˌezespˌeɾadæmˈeɪŋtʃy sˌofˈiy na nˌeblˈinæ]",
-                "en": "[mˈiːnwaɪl lˈuːkəz ɪz dˈɛspəɹətli sˈɜːtʃɪŋ fɔː sˈəʊfi ɪnðə fˈɒɡ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-026",
-            "text": {
-                "fr": "Il se sent terriblement coupable.",
-                "en": "He feels terribly guilty.",
-                "de": "Er fühlt sich furchtbar schuldig.",
-                "it": "Si sente terribilmente in colpa.",
-                "es": "Se siente terriblemente culpable.",
-                "nl": "Hij voelt zich vreselijk schuldig.",
-                "pt": "Ele se sente terrivelmente culpado."
-            },
-            "ipa": {
-                "fr": "il sə- sˈɑ̃ tɛʁibləmˈɑ̃ kupˈabl",
-                "de": "[ɛɾ fˈyːlt zɪç fˈʊɐçtbɑːɾ ʃˈʊldɪç]",
-                "it": "[sˌɪ sˈɛnte tˌɛrɾibilmˈente ˌin kˈolpa]",
-                "es": "[se ˈsjente teɾiˈβleˈmente kulˈpaβle]",
-                "nl": "[hɛɪ vˈult zɪx vrˈeːsələk sxˈɵldəx]",
-                "pt": "[ˌely sy sˈeɪŋtʃy tˌexivɛʊmˈeɪŋtʃy kˌuwpˈadʊ]",
-                "en": "[hiː fˈiːlz tˈɛɹəblɪ ɡˈɪlti]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-027",
-            "text": {
-                "fr": "Il marche pendant des heures, criant son nom, mais le brouillard absorbe tous les sons.",
-                "en": "He walks for hours, shouting her name, but the fog absorbs all sounds.",
-                "de": "Er läuft stundenlang, ruft ihren Namen, aber der Nebel schluckt alle Geräusche.",
-                "it": "Cammina per ore, gridando il suo nome, ma la nebbia assorbe tutti i suoni.",
-                "es": "Camina durante horas, gritando su nombre, pero la niebla absorbe todos los sonidos.",
-                "nl": "Hij loopt urenlang, roept haar naam, maar de mist absorbeert alle geluiden.",
-                "pt": "Ele caminha por horas, gritando o nome dela, mas a neblina absorve todos os sons."
-            },
-            "ipa": {
-                "fr": "il mˈaʁʃ pɑ̃dˈɑ̃ de-z ˈœʁ kʁiˈɑ̃ sɔ̃ nˈɔ̃ mɛ lə- bʁujˈaʁ absˈɔʁb tu le- sˈɔ̃",
-                "de": "[ɛɾ lˈɔøft ʃtˈʊndənlˌaŋ\n rˈʊft ˌiːrən nˈɑːmən\n ˌɑːbɜ dɛɾ nˈeːbəl ʃlˈʊkt ˈalə ɡərˈɔøʃə]",
-                "it": "[kammˈiːna pˌɛr ˈoːre\n ɡridˈando ˌil sˌʊo nˈoːme\n mˌa lˌa nˈebːia assˈɔːrbe tˈutːɪ ˌɪ sʊˈoːnɪ]",
-                "es": "[kaˈmina ðuˈɾante ˈoɾas | ɡɾiˈtando su ˈnomβɾe | ˈpeɾo la ˈnjεβla apˈsorβe ˈtoðos los soˈniðos]",
-                "nl": "[hɛɪ lˈoːpt ˈyrənlˌɑŋ\n rˈupt haːr nˈaːm\n maːr də mˈɪst ˌɑbsɔrbˈɪrt ˈɑlə ɣəlˈœydən]",
-                "pt": "[ˌely kˌæmˈiɲæ poɾ ˈɔɾæs\n ɡrˌitˈɐ̃ŋdw ʊ nˈomy dˈɛlæ\n maz a nˌeblˈinæ ˌabsˈɔɾəvy tˈodʊz ʊs sˈoŋs]",
-                "en": "[hiː wˈɔːks fɔːɹ ˈaʊəz ʃˈaʊtɪŋ hɜː nˈeɪm bˌʌt ðə fˈɒɡ ɐbsˈɔːbz ˈɔːl sˈaʊndz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-028",
-            "text": {
-                "fr": "Dans cette blancheur épaisse, il perd toute notion de direction.",
-                "en": "In this thick whiteness, he loses all sense of direction.",
-                "de": "In dieser dichten Weiße verliert er jegliches Gefühl für Richtung.",
-                "it": "In questa bianchezza densa, perde ogni nozione di direzione.",
-                "es": "En esa blancura espesa, pierde toda noción de dirección.",
-                "nl": "In deze dikke witheid verliest hij alle gevoel voor richting.",
-                "pt": "Nesta brancura espessa, ele perde toda noção de direção."
-            },
-            "ipa": {
-                "fr": "dɑ̃ sɛt blɑ̃ʃˈœʁ epˈɛs il pˈɛʁ tut nɔsjˈɔ̃ də- diʁɛksjˈɔ̃",
-                "de": "[ɪn dˌiːzɜ dˈɪçtən vˈaɪsə fɛɾlˈiːɾt ɛɾ jˈeːklɪçəs ɡəfˈyːl fyːɾ rˈɪçtʊŋ]",
-                "it": "[ˌin kwˌɛsta bjankˈetsːa dˈɛnsa\n pˈɛːrde ˈoɲʲɪ nˌɔtsiˈɔːne dˌɪ dˌiretsiˈɔːne]",
-                "es": "[en ˈesa βlanˈkuɾa esˈpesa | ˈpjɛɾðe ˈtoða noˈθjon de ðiɾekˈθjon]",
-                "nl": "[ɪn dˌeːzə dˈɪkə ʋˈɪtɛɪt vərlˈist hɛɪ ˈɑlə ɣəvˈul vɔːr rˈɪxtɪŋ]",
-                "pt": "[nˌɛstæ brˌɐ̃ŋkˈuɾæ ˌespˈesæ\n ˌely pˈɛɾədʒy tˈodæ nosˈɐ̃ʊ̃ dʒy dʒˌiɾesˈɐ̃ʊ̃]",
-                "en": "[ɪn ðɪs θˈɪk wˈaɪtnəs hiː lˈuːzɪz ˈɔːl sˈɛns ɒv daɪɹˈɛkʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-029",
-            "text": {
-                "fr": "Le haut, le bas, la gauche, la droite—tout se confond.",
-                "en": "Up, down, left, right—everything gets mixed up.",
-                "de": "Oben, unten, links, rechts—alles verschwimmt.",
-                "it": "Su, giù, sinistra, destra—tutto si confonde.",
-                "es": "Arriba, abajo, izquierda, derecha—todo se confunde.",
-                "nl": "Boven, onder, links, rechts—alles loopt door elkaar.",
-                "pt": "O alto, o baixo, a esquerda, a direita—tudo se confunde.",
-                "en_pt": "Up, down, left, right—everything is confused."
-            },
-            "ipa": {
-                "fr": "lə- ˈo lə- bˈa la- ɡˈoʃ la- dʁwˈat tu sə- kɔ̃fˈɔ̃",
-                "de": "[ˈoːbən\n ˈʊntən\n lˈɪŋks\n rˈɛçts ˈaləs fɛɾʃvˈɪmt]",
-                "it": "[sˈu\n dʒˈu\n sinˈistra\n dˈɛstra tˈutːo sˌɪ konfˈonde]",
-                "es": "[aˈriβa | aˈβaxo | iθˈkjeɾða | ðeˈɾetʃa—ˈtoðo se konˈfunde]",
-                "nl": "[bˈoːvən\n ˈɔndər\n lˈɪŋks\n rˈɛxts ˈɑləs lˈoːpt doːr ˈɛlkaːr]",
-                "pt": "[u ˈaʊtʊ\n ʊ bˈaɪʃʊ\n a ˌeskˈeɾədæ\n a dʒˌiɾˈeɪtæ tˈudʊ sy kˌoŋfˈũŋdʒy]",
-                "en": "[ˈʌp dˈaʊn lˈɛft ɹˈaɪt ˈɛvɹɪθˌɪŋ ɡˈɛts mˈɪkst ˈʌp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-030",
-            "text": {
                 "fr": "Finalement, il doit prendre une décision.",
-                "en": "Eventually, he has to make a decision.",
+                "en": "Finally, he must make a decision.",
                 "de": "Schließlich muss er eine Entscheidung treffen.",
                 "it": "Alla fine, deve prendere una decisione.",
                 "es": "Finalmente, tiene que tomar una decisión.",
@@ -931,7 +382,7 @@
                 "es": "[finaˈlmente | ˈtjene ke toˈmaɾ una ðeθiˈsjon]",
                 "nl": "[ˈœytˌɛɪndələk mˈut hɛɪ ən bəslˈɪsɪŋ nˈeːmən]",
                 "pt": "[fˌinaʊmˈeɪŋtʃy\n ˌely prˌesˈizæ tomˈaɾ ˌumæ dˌesizˈɐ̃ʊ̃]",
-                "en": "[ɪvˈɛntʃuːəli hiː hɐz tə mˌeɪk ɐ dɪsˈɪʒən]"
+                "en": "[fˈaɪnəli hiː mˈʌst mˌeɪk ɐ dɪsˈɪʒən]"
             },
             "provenance": {
                 "fr": "original",
@@ -944,10 +395,41 @@
             }
         },
         {
-            "id": "scene-12-031",
+            "id": "scene-12-014",
+            "text": {
+                "fr": "Il faut que je trouve de l'aide.",
+                "en": "I must find help.",
+                "de": "Ich muss Hilfe finden.",
+                "it": "Devo trovare aiuto.",
+                "es": "Tengo que encontrar ayuda.",
+                "nl": "Ik moet hulp vinden.",
+                "pt": "Preciso encontrar ajuda.",
+                "en_pt": "I need to find help."
+            },
+            "ipa": {
+                "fr": "il fo kə ʒə- tʁˈuv də- lˈɛd",
+                "de": "[ɪç mˈʊs hˈɪlfə fˈɪndən]",
+                "it": "[dˈɛːvo trovˈaːre ajˈuːto]",
+                "es": "[ˈteŋɡo ke enkonˈtɾaɾ aˈʝuða]",
+                "nl": "[ɪk mˈut hˈɵlp vˈɪndən]",
+                "pt": "[prˌesˈizw ˌeɪŋkoŋtrˈaɾ ˌaʒˈudæ]",
+                "en": "[aɪ mˈʌst fˈaɪnd hˈɛlp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-015",
             "text": {
                 "fr": "Il essaie de s'orienter.",
-                "en": "He tries to find his way.",
+                "en": "He tries to get his bearings.",
                 "de": "Er versucht, sich zu orientieren.",
                 "it": "Sta cercando di orientarsi.",
                 "es": "Intenta orientarse.",
@@ -962,7 +444,7 @@
                 "es": "[inˈtenta oɾjenˈtaɾse]",
                 "nl": "[hɛɪ proːbˈɪrt zɛɪn ʋˈɛx tə vˈɪndən]",
                 "pt": "[ˌely tˈeɪŋtæ sj ˌoɾieɪŋtˈar]",
-                "en": "[hiː tɹˈaɪz tə fˈaɪnd hɪz wˈeɪ]"
+                "en": "[hiː tɹˈaɪz tə ɡɛt hɪz bˈeəɹɪŋz]"
             },
             "provenance": {
                 "fr": "original",
@@ -975,16 +457,107 @@
             }
         },
         {
-            "id": "scene-12-032",
+            "id": "scene-12-016",
+            "text": {
+                "fr": "Le village ne peut pas être très loin",
+                "en": "The village can't be very far",
+                "de": "Das Dorf kann nicht weit sein.",
+                "it": "Il villaggio non può essere molto lontano.",
+                "es": "El pueblo no puede estar muy lejos",
+                "nl": "Het dorp kan niet ver weg zijn",
+                "pt": "O vilarejo não pode estar muito longe.",
+                "en_pt": "The village can't be too far."
+            },
+            "ipa": {
+                "fr": "lə- vilˈaʒ nə- pˈø paz ˈɛtʁ tʁɛ lwˈɛ̃",
+                "de": "[das dˈɔɾf kˌan nˈɪçt vˈaɪt zaɪn]",
+                "it": "[ˌil villˈadʒːo nˌon pʊˈɔ ˈɛssere mˈolto lontˈaːno]",
+                "es": "[el ˈpweβlo no ˈpweðe esˈtaɾ muʝ ˈlexos]",
+                "nl": "[hə tˈɔrp kɑn nˌit vˈɛr ʋˈɛx zɛɪn]",
+                "pt": "[ʊ vˌilaɾˈeʒʊ nˌɐ̃ʊ̃ pˌɔdʒj estˌar mwˈiŋtʊ lˈoŋʒy]",
+                "en": "[ðə vˈɪlɪdʒ kˈɑːnt biː vˈɛɹɪ fˈɑː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-017",
+            "text": {
+                "fr": "Si je descends, c'est par là.",
+                "en": "If I go downhill, it's that way.",
+                "de": "Wenn ich hinuntergehe, dann hier entlang.",
+                "it": "Se scendo, è di qua.",
+                "es": "Si bajo, es por aquí.",
+                "nl": "Als ik naar beneden ga, is het die kant op.",
+                "pt": "Se eu descer, é por ali.",
+                "en_pt": "If I go down, it's that way."
+            },
+            "ipa": {
+                "fr": "sˈi ʒə- dɛsˈɑ̃ sɛ paʁ lˈa",
+                "de": "[vˌɛn ɪç hɪnˈʊntɜɡˌeːə\n dan hˈiːɾ ɛntlˈaŋ]",
+                "it": "[sˌe ʃˈɛndo\n ˌɛ dˌɪ kwˈa]",
+                "es": "[si ˈbaxo | es poɾ aˈki]",
+                "nl": "[ɑls ɪk naːr bənˈeːdən ɣˈaː\n ɪs hət di kˈɑnt ˈɔp]",
+                "pt": "[sj eʊ desˈer\n ɛ poɾ alˈi]",
+                "en": "[ɪf aɪ ɡˌəʊ dˈaʊnhɪl ɪts ðat wˈeɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-018",
+            "text": {
+                "fr": "Mais dans quelle direction exactement?",
+                "en": "But in which direction exactly?",
+                "de": "Aber in welche Richtung genau?",
+                "it": "Ma in quale direzione esattamente?",
+                "es": "¿Pero en qué dirección exactamente?",
+                "nl": "Maar in welke richting precies?",
+                "pt": "Mas em qual direção exatamente?"
+            },
+            "ipa": {
+                "fr": "mɛ dɑ̃ kɛl diʁɛksjˈɔ̃ ɛɡzaktəmˈɑ̃",
+                "de": "[ˌɑːbɜ ɪn vˈɛlçə rˈɪçtʊŋ ɡənˈaʊ]",
+                "it": "[mˌa ˌin kwˈaːle dˌiretsiˈɔːne ˌezatːamˈente]",
+                "es": "[ˈpeɾo en ke diɾekˈθjon eksakˈtamente]",
+                "nl": "[maːr ɪn ʋˈɛlkə rˈɪxtɪŋ preːsˈis]",
+                "pt": "[maz ˈeɪŋ kwˈaʊ dʒˌiɾesˈɐ̃ʊ̃ ˌezatæmˈeɪŋtʃy]",
+                "en": "[bˌʌt ɪn wˌɪtʃ daɪɹˈɛkʃən ɛɡzˈaktli]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-019",
             "text": {
                 "fr": "Le brouillard rend l'orientation impossible.",
-                "en": "The fog makes it impossible to orient.",
+                "en": "The fog makes orientation impossible.",
                 "de": "Der Nebel macht die Orientierung unmöglich.",
                 "it": "La nebbia rende impossibile orientarsi.",
                 "es": "La niebla hace imposible orientarse.",
                 "nl": "De mist maakt het onmogelijk om te oriënteren.",
-                "pt": "A neblina torna a orientação impossível.",
-                "en_pt": "The fog makes orientation impossible."
+                "pt": "A neblina torna a orientação impossível."
             },
             "ipa": {
                 "fr": "lə- bʁujˈaʁ ʁˈɑ̃ lɔʁjɑ̃tasjˈɔ̃ ɛ̃pɔsˈibl",
@@ -993,7 +566,7 @@
                 "es": "[la ˈnjεβla aˈθe impoˈsiβle oɾjenˈtaɾse]",
                 "nl": "[də mˈɪst mˈaːkt hət ɔnmˈoːɣələk ɔm tə ˌoːriəntˈɪːrən]",
                 "pt": "[a nˌeblˈinæ tˈɔɾənæ a ˌoɾiˌeɪŋtasˈɐ̃ʊ̃ ˌimposˈiveʊ]",
-                "en": "[ðə fˈɒɡ mˌeɪks ɪt ɪmpˈɒsəbəl tʊ ˈɔːɹiənt]"
+                "en": "[ðə fˈɒɡ mˌeɪks ˌɔːɹiəntˈeɪʃən ɪmpˈɒsəbəl]"
             },
             "provenance": {
                 "fr": "original",
@@ -1006,10 +579,10 @@
             }
         },
         {
-            "id": "scene-12-033",
+            "id": "scene-12-020",
             "text": {
                 "fr": "Il pourrait tourner en rond pendant des heures.",
-                "en": "He could walk around for hours.",
+                "en": "He could wander in circles for hours.",
                 "de": "Er könnte stundenlang im Kreis laufen.",
                 "it": "Potrebbe girare in tondo per ore.",
                 "es": "Podría estar dando vueltas durante horas.",
@@ -1024,7 +597,7 @@
                 "es": "[poˈðɾia esˈtaɾ ˈðando ˈbweltas ðuˈɾante ˈoɾas]",
                 "nl": "[hɛɪ zʌʊ ˈyrənlˌɑŋ rˈɔnt kˌɵnən lˈoːpən]",
                 "pt": "[ˌely pˌodeɾˈiæ fikˈaɾ ˌɐ̃ŋdˈɐ̃ŋdw ˈeɪŋ sˈiɾəkulʊs poɾ ˈɔɾæs]",
-                "en": "[hiː kʊd wˈɔːk ɐɹˈaʊnd fɔːɹ ˈaʊəz]"
+                "en": "[hiː kʊd wˈɒndəɹ ɪn sˈɜːkəlz fɔːɹ ˈaʊəz]"
             },
             "provenance": {
                 "fr": "original",
@@ -1037,7 +610,7 @@
             }
         },
         {
-            "id": "scene-12-034",
+            "id": "scene-12-021",
             "text": {
                 "fr": "Soudain, il entend un bêlement.",
                 "en": "Suddenly, he hears a bleating.",
@@ -1068,7 +641,7 @@
             }
         },
         {
-            "id": "scene-12-035",
+            "id": "scene-12-022",
             "text": {
                 "fr": "Une forme apparaît dans le brouillard.",
                 "en": "A shape appears in the fog.",
@@ -1098,25 +671,40 @@
             }
         },
         {
-            "id": "scene-12-036",
+            "id": "scene-12-023",
             "text": {
-                "fr": "L'animal ne semble pas effrayé.",
-                "en": "The animal does not seem scared.",
-                "de": "Das Tier scheint nicht ängstlich zu sein.",
-                "it": "L'animale non sembra spaventato.",
-                "es": "El animal no parece asustado.",
-                "nl": "Het dier lijkt niet bang te zijn.",
-                "pt": "O animal não parece assustado.",
-                "en_pt": "The animal doesn't seem frightened."
+                "pt": "Uma cabra!",
+                "en": "A goat!"
             },
             "ipa": {
-                "fr": "lanimˈal nə- sˈɑ̃bl paz efʁɛjˈe",
-                "de": "[das tˈiːɾ ʃˈaɪnt nˈɪçt ˈɛŋstlɪç tsuː zaɪn]",
-                "it": "[lˌanimˈaːle nˌon sˈembra spˌaventˈaːto]",
-                "es": "[el aˈnimal no paˈɾeθe asusˈtaðo]",
-                "nl": "[hə tˈir lˈɛɪkt nˌit bˈɑŋ tə zɛɪn]",
-                "pt": "[u ˌænimˈaʊ nˌɐ̃ʊ̃ pˌaɾˈɛsj ˌasustˈadʊ]",
-                "en": "[ðɪ ˈanɪməl dʌznˌɒt sˈiːm skˈeəd]"
+                "pt": "[ˌumæ kˈabræ]",
+                "en": "[ɐ ɡˈəʊt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-024",
+            "text": {
+                "fr": "Une chèvre! Elle me regarde fixement.",
+                "en": "A goat! It's staring at me.",
+                "de": "Eine Ziege! Sie starrt mich an.",
+                "it": "Una capra! Mi sta guardando fisso.",
+                "es": "¡Una cabra! Me está mirando fijamente.",
+                "nl": "Een geit! Ze kijkt me strak aan.",
+                "pt": "Ela está me olhando fixamente.",
+                "en_pt": "She's staring at me."
+            },
+            "ipa": {
+                "fr": "yn ʃˈɛvʁ ɛl mə- ʁəɡˈaʁd fiksmˈɑ̃",
+                "de": "[ˌaɪnə tsˈiːɡə\n ziː ʃtˈaɾt mɪç ˈan]",
+                "it": "[ˌʊna kˈaːpra\n mˌɪ stˈa ɡwardˈando fˈisso]",
+                "es": "[ˈuna ˈkaβɾa | me esˈta miˈɾando fixaˈmente]",
+                "nl": "[ən ɣˈɛɪt\n zə kˈɛɪkt mə strˈɑk ˈaːn]",
+                "pt": "[ˌɛlæ estˌa mj ˌoljˈɐ̃ŋdʊ fˌiksæmˈeɪŋtʃy]",
+                "en": "[ɐ ɡˈəʊt ɪts stˈeəɹɪŋ at mˌiː]"
             },
             "provenance": {
                 "fr": "original",
@@ -1129,10 +717,40 @@
             }
         },
         {
-            "id": "scene-12-037",
+            "id": "scene-12-025",
+            "text": {
+                "fr": "L'animal ne semble pas effrayé.",
+                "en": "The animal doesn't seem frightened.",
+                "de": "Das Tier scheint nicht ängstlich zu sein.",
+                "it": "L'animale non sembra spaventato.",
+                "es": "El animal no parece asustado.",
+                "nl": "Het dier lijkt niet bang te zijn.",
+                "pt": "O animal não parece assustado."
+            },
+            "ipa": {
+                "fr": "lanimˈal nə- sˈɑ̃bl paz efʁɛjˈe",
+                "de": "[das tˈiːɾ ʃˈaɪnt nˈɪçt ˈɛŋstlɪç tsuː zaɪn]",
+                "it": "[lˌanimˈaːle nˌon sˈembra spˌaventˈaːto]",
+                "es": "[el aˈnimal no paˈɾeθe asusˈtaðo]",
+                "nl": "[hə tˈir lˈɛɪkt nˌit bˈɑŋ tə zɛɪn]",
+                "pt": "[u ˌænimˈaʊ nˌɐ̃ʊ̃ pˌaɾˈɛsj ˌasustˈadʊ]",
+                "en": "[ðɪ ˈanɪməl dˈʌzənt sˈiːm fɹˈaɪtənd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-026",
             "text": {
                 "fr": "Au contraire, elle s'approche, puis se retourne et commence à descendre un sentier.",
-                "en": "On the contrary, it comes closer, then turns around and starts to descend a path.",
+                "en": "On the contrary, it approaches, then turns around and starts down a path.",
                 "de": "Im Gegenteil, es nähert sich, dreht sich dann um und beginnt, einen Pfad hinunterzusteigen.",
                 "it": "Al contrario, si avvicina, poi si gira e inizia a scendere un sentiero.",
                 "es": "Al contrario, se acerca, luego se da la vuelta y empieza a bajar un sendero.",
@@ -1147,7 +765,7 @@
                 "es": "[al konˈtɾaɾjo | se aˈθɛɾka | ˈlweɣo se ða la ˈbwelta i emˈpjeθa a βaˈxaɾ un senˈðeɾo]",
                 "nl": "[ˈɪntˌeːɣəndˌeːl\n hət kˈɔm tˌɪxtərbˈɛɪ\n drˈaːjt zɪx ɔm ɛn bəɣˈɪnt ən pˈɑt ˈɑf tə dˈaːlən]",
                 "pt": "[pˈelʊ kˌoŋtrˈaɾjʊ\n ˌɛlæ sj ˌaprosˈimæ\n depˈoɪs sy vˈiɾæ i kˌomˈɛsæ a desˈer poɾ ˌumæ trˈiljæ]",
-                "en": "[ɒnðə kˈɒntɹəɹˌɪ ɪt kˈʌmz klˈəʊsə ðˈɛn tˈɜːnz ɐɹˈaʊnd and stˈɑːts tə dɪsˈɛnd ɐ pˈaθ]"
+                "en": "[ɒnðə kˈɒntɹəɹˌɪ ɪt ɐpɹˈəʊtʃɪz ðˈɛn tˈɜːnz ɐɹˈaʊnd and stˈɑːts dˌaʊn ɐ pˈaθ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1160,10 +778,163 @@
             }
         },
         {
-            "id": "scene-12-038",
+            "id": "scene-12-027",
+            "text": {
+                "fr": "Elle commence à descendre un sentier que je n'avais pas vu.",
+                "en": "It starts down a path I hadn't seen.",
+                "de": "Sie beginnt, einen Pfad hinunterzusteigen, den ich nicht gesehen hatte.",
+                "it": "Comincia a scendere un sentiero che non avevo visto.",
+                "es": "Empieza a bajar por un sendero que no había visto.",
+                "nl": "Ze begint een pad af te dalen dat ik niet had gezien.",
+                "pt": "Ela está começando a descer por uma trilha que eu não tinha visto.",
+                "en_pt": "She's starting to descend a trail I hadn't seen."
+            },
+            "ipa": {
+                "fr": "ɛl kɔmˈɑ̃s a dɛsˈɑ̃dʁ œ̃ sɑ̃tjˈe kə ʒə- navˈɛ pa vˈy",
+                "de": "[ziː bəɡˈɪnt\n ˌaɪnən pfˈɑːt hɪnˈʊntɜtsuːʃtˌaɪɡən\n deːn ɪç nˈɪçt ɡəzˈeːən hˌatə]",
+                "it": "[komˈintʃa ˌa ʃˈendere ˌʊn sˌentiˈɛːro kˌe nˌon avˌɛvo vˈisto]",
+                "es": "[emˈpjeθa a βaˈxaɾ poɾ un senˈðeɾo ke no aˈβia ˈβisto]",
+                "nl": "[zə bəɣˈɪnt ən pˈɑt ˈɑf tə dˈaːlən dɑt ɪk nˌit hˈɑt ɣəzˈin]",
+                "pt": "[ˌɛlæ estˌa kˌomesˈɐ̃ŋdw a desˈer poɾ ˌumæ trˈiljæ ky eʊ nˌɐ̃ʊ̃ tʃˌiɲæ vˈistʊ]",
+                "en": "[ɪt stˈɑːts dˌaʊn ɐ pˈaθ aɪ hˈadənt sˈiːn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-028",
+            "text": {
+                "pt": "Lucas hesita.",
+                "en": "Lucas hesitates."
+            },
+            "ipa": {
+                "pt": "[lˈukæs ˌezˈitæ]",
+                "en": "[lˈuːkəz hˈɛsɪtˌeɪts]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-029",
+            "text": {
+                "pt": "Devo segui-la?",
+                "en": "Should I follow her?"
+            },
+            "ipa": {
+                "pt": "[dˈevʊ seɡˈilæ]",
+                "en": "[ʃˌʊd aɪ fˈɒləʊ hɜː]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-030",
+            "text": {
+                "fr": "Devrais-je la suivre? Les animaux connaissent les chemins sûrs.",
+                "en": "Should I follow it? Animals know the safe paths.",
+                "de": "Sollte ich ihr folgen? Tiere kennen die sicheren Wege.",
+                "it": "Dovrei seguirla? Gli animali conoscono le vie sicure.",
+                "es": "¿Debería seguirla? Los animales conocen los caminos seguros.",
+                "nl": "Zou ik haar moeten volgen? Dieren kennen de veilige paden.",
+                "pt": "Os animais conhecem os caminhos seguros.",
+                "en_pt": "Animals know the safe paths."
+            },
+            "ipa": {
+                "fr": "dəvʁˈɛʒ la- syˈivʁ le-z animˈo kɔnˈɛs le- ʃəmˈɛ̃ sˈyːʁ",
+                "de": "[zˌɔltə ɪç iːɾ fˈɔlɡən\n tˈiːrə kˈɛnən diː zˈɪçərən vˈeːɡə]",
+                "it": "[dovrˈeːɪ seɡwˈiːrla\n ʎˌɪ ˌanimˈaːlɪ konˈoskono lˌe vˈiːe sikˈuːre]",
+                "es": "[deˈβeɾja seˈɣiɾla | los aˈnimalɛs koˈnoθen los kaˈminos seˈɣuɾos]",
+                "nl": "[zʌʊ ɪk haːr mˈutən vˈɔlɣən\n dˈirən kˈɛnən də vˈɛɪləɣə pˈaːdən]",
+                "pt": "[ʊz ˌænimˈaɪs kˌoɲˈɛseɪŋ ʊs kˌæmˈiɲʊs sˌeɡˈuɾʊs]",
+                "en": "[ʃˌʊd aɪ fˈɒləʊ ɪt ˈanɪməlz nˈəʊ ðə sˈeɪf pˈaθs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-031",
+            "text": {
+                "pt": "Ou será...",
+                "en": "Or is it..."
+            },
+            "ipa": {
+                "pt": "[ow seɾˈa]",
+                "en": "[ɔːɹ ɪz ˈɪt]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-032",
+            "text": {
+                "pt": "é simplesmente uma cabra voltando para sua fazenda?",
+                "en": "just a goat going back to its farm?"
+            },
+            "ipa": {
+                "pt": "[ɛ sˌimplezmˈeɪŋtʃj ˌumæ kˈabræ vˌowtˈɐ̃ŋdʊ pˌaɾæ sˌuæ fˌazˈeɪŋdæ]",
+                "en": "[dʒˈʌst ɐ ɡˈəʊt ɡˌəʊɪŋ bˈak tʊ ɪts fˈɑːm]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-033",
+            "text": {
+                "fr": "est-ce simplement une chèvre qui rentre à sa ferme? Est-ce que je projette une intentionnalité sur un comportement animal ordinaire?",
+                "en": "is it simply a goat returning to its farm? Am I projecting intentionality onto ordinary animal behavior?",
+                "de": "ist es einfach nur eine Ziege, die nach Hause geht? Projiziere ich eine Absicht auf normales tierisches Verhalten?",
+                "it": "è semplicemente una capra che torna alla sua fattoria? Sto proiettando intenzioni su un comportamento animale ordinario?",
+                "es": "¿es simplemente una cabra que vuelve a su granja? ¿Estoy proyectando una intención en un comportamiento animal común?",
+                "nl": "is het gewoon een geit die naar haar boerderij terugkeert? Projecteer ik een intentie op gewoon diergedrag?",
+                "pt": "Estou projetando intenção em um comportamento animal comum?",
+                "en_pt": "Am I projecting intention onto common animal behavior?"
+            },
+            "ipa": {
+                "fr": "ɛs sɛ̃pləmˈɑ̃ yn ʃˈɛvʁ ki ʁˈɑ̃tʁ a sa- fˈɛʁm ɛs kə ʒə- pʁɔʒˈɛt yn ɛ̃tɑ̃sjɔnalitˈe syʁ œ̃ kɔ̃pɔʁtəmˈɑ̃ animˈal ɔʁdinˈɛʁ",
+                "de": "[ɪst ɛs ˈaɪnfˌax nˈuːɾ ˌaɪnə tsˈiːɡə\n diː nɑːx hˈaʊzə ɡˈeːt\n proːjiːtsˈiːrə ɪç ˌaɪnə ˈapzˌɪçt aʊf nˈɔɾmɑːləs tˈiːrɪʃəs fɛɾhˈaltən]",
+                "it": "[ˌɛ sˌemplitʃemˈente ˌʊna kˈaːpra kˌe tˈoːrna ˌalla sˌʊa fˌatːorˈiːa\n stˈo prˌɔɪetːˈando ˌintentsiˈɔːnɪ sˌʊ ˌʊn kˌomportamˈento ˌanimˈaːle ˌɔrdinˈario]",
+                "es": "[es simˈplemente ˈuna ˈkaβɾa ke ˈbwelβe a su ˈɡɾanxa | ˈestoj pɾoʝekˈtando ˈuna intenˈθjon en un kompoɾtaˈmjento aˈnimal koˈmun]",
+                "nl": "[ɪs hət ɣəʋˈoːn ən ɣˈɛɪt di naːr haːr bˌurdərˈɛɪ tərˈɵxkˌɪːrt\n prˌoːjɛktˈɪr ɪk ən ˈɪntˌɛntsi ɔp ɣəʋˈoːn dˈirɣɛdrˌɑx]",
+                "pt": "[estˌow prˌoʒetˈɐ̃ŋdw ˌiŋteɪŋsˈɐ̃ʊ̃ ˈeɪŋ ũŋ kˌompoɾətæmˈeɪŋtw ˌænimˈaʊ komˈũŋ]",
+                "en": "[ɪz ɪt sˈɪmpli ɐ ɡˈəʊt ɹɪtˈɜːnɪŋ tʊ ɪts fˈɑːm am aɪ pɹədʒˈɛktɪŋ ɪntˌɛnʃənˈalɪti ˌɒntʊ ˈɔːdɪnəɹi ˈanɪməl bɪhˈeɪvjə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-034",
             "text": {
                 "fr": "La chèvre s'arrête et se retourne, comme pour vérifier s'il suit.",
-                "en": "The goat stops and turns around, as if to check if he is following.",
+                "en": "The goat stops and turns around, as if to check if he's following.",
                 "de": "Die Ziege hält an und dreht sich um, als wolle sie überprüfen, ob er folgt.",
                 "it": "La capra si ferma e si gira, come per verificare se lui la segue.",
                 "es": "La cabra se detiene y se vuelve, como para comprobar si la sigue.",
@@ -1178,7 +949,131 @@
                 "es": "[la ˈkaβɾa se ðeˈtjene i se ˈbwelβe | ˈkomo paɾa kompɾoˈβaɾ si la ˈsiɣe]",
                 "nl": "[də ɣˈɛɪt stˈɔpt ɛn drˈaːjt zɪx ˈɔm\n ˈɑlsɔf zə kˌɔntroːlˈɪrt ɔf hɛɪ vˈɔlxt]",
                 "pt": "[a kˈabræ pˌaɾæ i sy vˈiɾæ\n kˌomʊ pˌaɾæ vˌeɾifikˈar sj ˌely estˌa sˌeɡˈiŋdʊ]",
-                "en": "[ðə ɡˈəʊt stˈɒps and tˈɜːnz ɐɹˈaʊnd az ɪf tə tʃˈɛk ɪf hiː ɪz fˈɒləʊɪŋ]"
+                "en": "[ðə ɡˈəʊt stˈɒps and tˈɜːnz ɐɹˈaʊnd az ɪf tə tʃˈɛk ɪf hiːz fˈɒləʊɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-035",
+            "text": {
+                "fr": "J'ai l'impression qu'elle veut me montrer quelque chose.",
+                "en": "I have the feeling it wants to show me something.",
+                "de": "Ich habe das Gefühl, sie will mir etwas zeigen.",
+                "it": "Ho l'impressione che voglia mostrarmi qualcosa.",
+                "es": "Tengo la impresión de que quiere mostrarme algo.",
+                "nl": "Ik heb het gevoel dat ze me iets wil laten zien.",
+                "pt": "Tenho a impressão de que ela quer me mostrar algo.",
+                "en_pt": "I have the impression that she wants to show me something."
+            },
+            "ipa": {
+                "fr": "ʒe lɛ̃pʁɛsjˈɔ̃ kɛl vˈø mə- mɔ̃tʁˈe kˌɛlkə ʃˈoz",
+                "de": "[ɪç hɑːbə das ɡəfˈyːl\n ziː vɪl miːɾ ˈɛtvɑːs tsˈaɪɡən]",
+                "it": "[ˌo lˌimpressiˈoːne kˌe vˈoːʎa mostrˈaːrmɪ kwalkˈɔːza]",
+                "es": "[ˈteŋɡo la impreˈsjon de ke ˈkjeɾe mosˈtɾaɾme ˈalɡo]",
+                "nl": "[ɪk hɛp hət ɣəvˈul dɑt zə mə ˈits ʋɪl lˈaːtən zˈin]",
+                "pt": "[tˌeɲʊ a ˌimpresˈɐ̃ʊ̃ dʒy ky ˌɛlæ kˈɛr my mostrˈaɾ ˈaʊɡʊ]",
+                "en": "[aɪ hav ðə fˈiːlɪŋ ɪt wˈɒnts tə ʃˈəʊ mˌiː sˈʌmθɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-036",
+            "text": {
+                "fr": "Peut-être que dans notre désespoir, nous voyons des signes partout",
+                "en": "Perhaps in our despair, we see signs everywhere",
+                "de": "Vielleicht sehen wir in unserer Verzweiflung überall Zeichen.",
+                "it": "Forse nel nostro disperazione, vediamo segni ovunque.",
+                "es": "Quizás en nuestro desespero, vemos señales por todas partes",
+                "nl": "Misschien zien we overal tekenen in ons wanhoop",
+                "pt": "Talvez no nosso desespero vejamos sinais em todo lugar.",
+                "en_pt": "Maybe in our desperation we see signs everywhere."
+            },
+            "ipa": {
+                "fr": "pˈøtˈɛtʁ kə dɑ̃ nɔtʁ dezɛspwˈaʁ nu vwajˈɔ̃ de- sˈinj paʁtˈu",
+                "de": "[fiːllˈaɪçt zˈeːən viːɾ ɪn ˈʊnzərɜ fɛɾtsvˈaɪflʊŋ ˌyːbɜˈal tsˈaɪçən]",
+                "it": "[fˈoːrse nˌɛl nˌɔstro dˌisperˌatsiˈɔːne\n vedjˈaːmo sˈeɲʲɪ ovˈunkwe]",
+                "es": "[kiˈθas en ˈnwestɾo ðesezˈpeɾo | ˈβemos seˈɲales poɾ ˈtoðas ˈpaɾtes]",
+                "nl": "[mɪsxˈin zˈin ʋə ˌoːvərˈɑl tˈeːkənən ɪn ɔns ʋˈɑnhˌoːp]",
+                "pt": "[taʊvˈez nʊ nˌɔsʊ dˌezespˈeɾʊ vˌeʒˈɐ̃mʊs sinˈaɪz ˈeɪŋ tˈodʊ luɡˈar]",
+                "en": "[pəhˈaps ɪn aʊə dɪspˈeə wiː sˈiː sˈaɪnz ˈɛvɹɪwˌeə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-037",
+            "text": {
+                "fr": "Mais peu importe.",
+                "en": "But it doesn't matter.",
+                "de": "Aber das ist egal.",
+                "it": "Ma poco importa.",
+                "es": "Pero no importa.",
+                "nl": "Maar dat maakt niet uit.",
+                "pt": "Mas não importa—preciso escolher confiar.",
+                "en_pt": "But it doesn't matter—I need to choose to trust."
+            },
+            "ipa": {
+                "fr": "mɛ pø ɛ̃pˈɔʁt",
+                "de": "[ˌɑːbɜ das ɪst eːɡˈɑːl]",
+                "it": "[mˌa pˈɔːko impˈɔːrta]",
+                "es": "[ˈpeɾo no impoɾˈta]",
+                "nl": "[maːr dɑt mˈaːkt nˌit ˈœyt]",
+                "pt": "[maz nˌɐ̃ʊ̃ ˌimpˈɔɾətæ prˌesˈizw ˌeskoljˈer kˌoŋfiˈar]",
+                "en": "[bˌʌt ɪt dˈʌzənt mˈatə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-038",
+            "text": {
+                "fr": "Même si c'est étrange, je dois lui faire confiance",
+                "en": "Even if it's strange, I must trust it",
+                "de": "Selbst wenn es seltsam ist, ich muss ihr vertrauen.",
+                "it": "Anche se è strano, devo fidarmi di lei.",
+                "es": "Aunque sea extraño, tengo que confiar en ella.",
+                "nl": "Zelfs als het vreemd is, moet ik haar vertrouwen",
+                "pt": "Mesmo sendo estranho, preciso confiar nela.",
+                "en_pt": "Even though it's strange, I need to trust her."
+            },
+            "ipa": {
+                "fr": "mˈɛm sˈi sɛt etʁˈɑ̃ʒ ʒə- dwˈa lyˌi fˈɛʁ kɔ̃fjˈɑ̃s",
+                "de": "[zˈɛlpst vˌɛn ɛs zˈɛltzɑːm ɪst\n ɪç mˈʊs iːɾ fɛɾtɾˈaʊən]",
+                "it": "[ˈanke sˌe ˌɛ strˈaːno\n dˈɛːvo fidˈaːrmɪ dˌɪ lˈɛj]",
+                "es": "[ˈawŋke ˈse.a eksˈtɾaɲo | ˈteŋɡo ke konˈfjaɾ en ˈeʎa]",
+                "nl": "[zˈɛlfs ɑls hət vrˈeːmt ɪs\n mˈut ɪk haːr vərtrˈʌʊən]",
+                "pt": "[mˈezmʊ sˈeɪŋdw ˌestrˈɐ̃ɲʊ\n prˌesˈizʊ kˌoŋfiˈar nˈɛlæ]",
+                "en": "[ˈiːvən ɪf ɪts stɹˈeɪndʒ aɪ mˈʌst tɹˈʌst ɪt]"
             },
             "provenance": {
                 "fr": "original",
@@ -1193,23 +1088,22 @@
         {
             "id": "scene-12-039",
             "text": {
-                "fr": "Il suit la chèvre qui descend le sentier avec assurance.",
-                "en": "He follows the goat that descends the path with certainty.",
-                "de": "Er folgt der Ziege, die selbstsicher den Pfad hinuntergeht.",
-                "it": "Segue la capra che scende il sentiero con sicurezza.",
-                "es": "Sigue a la cabra que baja el sendero con seguridad.",
-                "nl": "Hij volgt de geit die met zekerheid het pad afdaalt.",
-                "pt": "Ele segue a cabra que desce a trilha com segurança.",
-                "en_pt": "He follows the goat as she descends the trail confidently."
+                "fr": "Je n'ai pas d'autre choix.",
+                "en": "I have no other choice.",
+                "de": "Ich habe keine andere Wahl.",
+                "it": "Non ho altra scelta.",
+                "es": "No tengo otra opción.",
+                "nl": "Ik heb geen andere keuze.",
+                "pt": "Não tenho outra escolha."
             },
             "ipa": {
-                "fr": "il syˈi la- ʃˈɛvʁ ki dɛsˈɑ̃ lə- sɑ̃tjˈe avˌɛk asyʁˈɑ̃s",
-                "de": "[ɛɾ fˈɔlkt dɛɾ tsˈiːɡə\n diː zˈɛlpstsɪçɜ deːn pfˈɑːt hɪnˈʊntɜɡˌeːt]",
-                "it": "[sˈeɡwe lˌa kˈaːpra kˌe ʃˈɛnde ˌil sˌentiˈɛːro kˌon sˌikʊrˈetsːa]",
-                "es": "[ˈsiɣe a la ˈkaβɾa ke ˈbaxa el senˈðeɾo kon seɣuɾiˈðað]",
-                "nl": "[hɛɪ vˈɔlx tə ɣˈɛɪt di mɛt zˈeːkərhˌɛɪt hət pˈɑt ˈɑfdˌaːlt]",
-                "pt": "[ˌely sˈɛɡj a kˈabræ ky dˈɛsj a trˈiljæ koŋ sˌeɡuɾˈɐ̃ŋsæ]",
-                "en": "[hiː fˈɒləʊz ðə ɡˈəʊt ðat dɪsˈɛndz ðə pˈaθ wɪð sˈɜːtənti]"
+                "fr": "ʒə- ne pa dotʁ ʃwˈa",
+                "de": "[ɪç hɑːbə kˈaɪnə ˈandərə vˈɑːl]",
+                "it": "[nˌon ˌo ˈaltra ʃˈelta]",
+                "es": "[no ˈteŋɡo ˈotɾa opˈθjon]",
+                "nl": "[ɪk hɛp ɣˈeːn ˈɑndərə kˈøːzə]",
+                "pt": "[nˌɐ̃ʊ̃ tˌeɲʊ ˈowtræ ˌeskˈoljæ]",
+                "en": "[aɪ hav nˈəʊ ˈʌðə tʃˈɔɪs]"
             },
             "provenance": {
                 "fr": "original",
@@ -1224,22 +1118,23 @@
         {
             "id": "scene-12-040",
             "text": {
-                "fr": "Ils descendent ainsi pendant une heure.",
-                "en": "They descend like this for an hour.",
-                "de": "Sie steigen so für eine Stunde ab.",
-                "it": "Scendono così per un'ora.",
-                "es": "Bajan así durante una hora.",
-                "nl": "Zo dalen ze een uur lang af.",
-                "pt": "Eles descem assim por uma hora."
+                "fr": "Il suit la chèvre qui descend le sentier avec assurance.",
+                "en": "He follows the goat as it confidently descends the path.",
+                "de": "Er folgt der Ziege, die selbstsicher den Pfad hinuntergeht.",
+                "it": "Segue la capra che scende il sentiero con sicurezza.",
+                "es": "Sigue a la cabra que baja el sendero con seguridad.",
+                "nl": "Hij volgt de geit die met zekerheid het pad afdaalt.",
+                "pt": "Ele segue a cabra que desce a trilha com segurança.",
+                "en_pt": "He follows the goat as she descends the trail confidently."
             },
             "ipa": {
-                "fr": "il dɛsˈɑ̃dt ɛ̃sˌi pɑ̃dˈɑ̃ yn ˈœʁ",
-                "de": "[ziː ʃtˈaɪɡən zoː fyːɾ ˌaɪnə ʃtˈʊndə ˈap]",
-                "it": "[ʃˈendono kozˈi pˌɛr ʊnˈɔːra]",
-                "es": "[ˈbaxan aˈsi ðuˈɾante ˈuna ˈoɾa]",
-                "nl": "[zoː dˈaːlən zə ən ˈyr lˈɑŋ ˈɑf]",
-                "pt": "[ˌelyz dˈɛseɪŋ asˈiŋ poɾ ˌumæ ˈɔɾæ]",
-                "en": "[ðeɪ dɪsˈɛnd lˈaɪk ðɪs fəɹən ˈaʊə]"
+                "fr": "il syˈi la- ʃˈɛvʁ ki dɛsˈɑ̃ lə- sɑ̃tjˈe avˌɛk asyʁˈɑ̃s",
+                "de": "[ɛɾ fˈɔlkt dɛɾ tsˈiːɡə\n diː zˈɛlpstsɪçɜ deːn pfˈɑːt hɪnˈʊntɜɡˌeːt]",
+                "it": "[sˈeɡwe lˌa kˈaːpra kˌe ʃˈɛnde ˌil sˌentiˈɛːro kˌon sˌikʊrˈetsːa]",
+                "es": "[ˈsiɣe a la ˈkaβɾa ke ˈbaxa el senˈðeɾo kon seɣuɾiˈðað]",
+                "nl": "[hɛɪ vˈɔlx tə ɣˈɛɪt di mɛt zˈeːkərhˌɛɪt hət pˈɑt ˈɑfdˌaːlt]",
+                "pt": "[ˌely sˈɛɡj a kˈabræ ky dˈɛsj a trˈiljæ koŋ sˌeɡuɾˈɐ̃ŋsæ]",
+                "en": "[hiː fˈɒləʊz ðə ɡˈəʊt az ɪt kˈɒnfɪdəntli dɪsˈɛndz ðə pˈaθ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1254,8 +1149,69 @@
         {
             "id": "scene-12-041",
             "text": {
+                "fr": "Elle s'arrête et attend que je la suive.",
+                "en": "She stops and waits for me to follow.",
+                "de": "Sie hält an und wartet darauf, dass ich ihr folge.",
+                "it": "Si ferma e aspetta che la segua.",
+                "es": "Se detiene y espera que la siga.",
+                "nl": "Ze stopt en wacht tot ik haar volg.",
+                "pt": "Ela para e espera que eu a siga."
+            },
+            "ipa": {
+                "fr": "ɛl saʁˈɛt e atˈɑ̃ kə ʒə- la- syˈiv",
+                "de": "[ziː hˈɛlt an ʊnt vˈaɾtət dɑːrˈaʊf\n das ɪç iːɾ fˈɔlɡə]",
+                "it": "[sˌɪ fˈeːrma ˌe aspˈɛtːa kˌe lˌa sˈeɡwa]",
+                "es": "[se ðeˈtjene i esˈpeɾa ke la ˈsiɣa]",
+                "nl": "[zə stˈɔpt ɛn ʋˈɑx tɔt ɪk haːr vˈɔlx]",
+                "pt": "[ˌɛlæ pˌaɾæ i ˌespˈɛɾæ ky eʊ a sˈiɡæ]",
+                "en": "[ʃiː stˈɒps and wˈeɪts fɔː mˌiː tə fˈɒləʊ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-042",
+            "text": {
+                "fr": "Ils descendent ainsi pendant une heure.",
+                "en": "They descend this way for an hour.",
+                "de": "Sie steigen so für eine Stunde ab.",
+                "it": "Scendono così per un'ora.",
+                "es": "Bajan así durante una hora.",
+                "nl": "Zo dalen ze een uur lang af.",
+                "pt": "Eles descem assim por uma hora.",
+                "en_pt": "They descend like this for an hour."
+            },
+            "ipa": {
+                "fr": "il dɛsˈɑ̃dt ɛ̃sˌi pɑ̃dˈɑ̃ yn ˈœʁ",
+                "de": "[ziː ʃtˈaɪɡən zoː fyːɾ ˌaɪnə ʃtˈʊndə ˈap]",
+                "it": "[ʃˈendono kozˈi pˌɛr ʊnˈɔːra]",
+                "es": "[ˈbaxan aˈsi ðuˈɾante ˈuna ˈoɾa]",
+                "nl": "[zoː dˈaːlən zə ən ˈyr lˈɑŋ ˈɑf]",
+                "pt": "[ˌelyz dˈɛseɪŋ asˈiŋ poɾ ˌumæ ˈɔɾæ]",
+                "en": "[ðeɪ dɪsˈɛnd ðɪs wˈeɪ fəɹən ˈaʊə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-043",
+            "text": {
                 "fr": "Lucas pense constamment à Sophie.",
-                "en": "Lucas is constantly thinking of Sophie.",
+                "en": "Lucas constantly thinks of Sophie.",
                 "de": "Lucas denkt die ganze Zeit an Sophie.",
                 "it": "Lucas pensa costantemente a Sophie.",
                 "es": "Lucas piensa constantemente en Sophie.",
@@ -1270,7 +1226,7 @@
                 "es": "[ˈlukas ˈpjensa konstanˈtemente en ˈsofi]",
                 "nl": "[lˈykɑs dˈɛŋkt kɔnstˈɑnt aːn sɔphˈi]",
                 "pt": "[lˈukæs pˈeɪŋsæ kˌoŋstɐ̃ŋtemˈeɪŋtʃj ˈeɪŋ sˌofˈiy]",
-                "en": "[lˈuːkəz ɪz kˈɒnstəntli θˈɪŋkɪŋ ɒv sˈəʊfi]"
+                "en": "[lˈuːkəz kˈɒnstəntli θˈɪŋks ɒv sˈəʊfi]"
             },
             "provenance": {
                 "fr": "original",
@@ -1283,7 +1239,37 @@
             }
         },
         {
-            "id": "scene-12-042",
+            "id": "scene-12-044",
+            "text": {
+                "fr": "Sophie compte sur moi, je ne peux pas l'abandonner.",
+                "en": "Sophie is counting on me, I can't abandon her.",
+                "de": "Sophie zählt auf mich, ich kann sie nicht im Stich lassen.",
+                "it": "Sophie conta su di me, non posso abbandonarla.",
+                "es": "Sophie cuenta conmigo, no puedo abandonarla.",
+                "nl": "Sophie rekent op mij, ik kan haar niet in de steek laten.",
+                "pt": "Sophie conta comigo, não posso abandoná-la."
+            },
+            "ipa": {
+                "fr": "sɔfˈi kˈɔ̃t syʁ mwˈa ʒə- nə- pˈø pa labɑ̃dɔnˈe",
+                "de": "[zoːfˈiː tsˈɛːlt aʊf mɪç\n ɪç kˌan ziː nˈɪçt ɪm ʃtˈɪç lˈasən]",
+                "it": "[sˈopje kˈonta sˌʊ dˌɪ mˈe\n nˌon pˈɔsso ˌabːandonˈaːrla]",
+                "es": "[ˈsofi ˈkwenta ˈkonmiɣo | no ˈpwedo aβanðoˈnaɾla]",
+                "nl": "[sɔphˈi rˈeːkənt ɔp mˈɛɪ\n ɪk kɑn haːr nˌit ɪn də stˈeːk lˈaːtən]",
+                "pt": "[sˌofˈiy kˈoŋtæ kˌomˈiɡʊ\n nˌɐ̃ʊ̃ pˌɔsʊ ˌabɐ̃ŋdonˈalæ]",
+                "en": "[sˈəʊfi ɪz kˈaʊntɪŋ ˈɒn mˌiː aɪ kˈɑːnt ɐbˈandən hɜː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-045",
             "text": {
                 "fr": "Soudain, le brouillard devient moins dense.",
                 "en": "Suddenly, the fog becomes less dense.",
@@ -1313,16 +1299,15 @@
             }
         },
         {
-            "id": "scene-12-043",
+            "id": "scene-12-046",
             "text": {
                 "fr": "En bas, il voit quelque chose.",
-                "en": "Down below, he sees something.",
+                "en": "Below, he sees something.",
                 "de": "Unten sieht er etwas.",
                 "it": "In basso, vede qualcosa.",
                 "es": "Abajo, ve algo.",
                 "nl": "Beneden ziet hij iets.",
-                "pt": "Embaixo, ele vê algo.",
-                "en_pt": "Below, he sees something."
+                "pt": "Embaixo, ele vê algo."
             },
             "ipa": {
                 "fr": "ɑ̃ bˈa il vwˈa kˌɛlkə ʃˈoz",
@@ -1331,7 +1316,7 @@
                 "es": "[aˈβaxo | βe ˈalɡo]",
                 "nl": "[bənˈeːdən zˈit hɛɪ ˈits]",
                 "pt": "[ˌeɪmbˈaɪʃʊ\n ˌely vˈe ˈaʊɡʊ]",
-                "en": "[dˌaʊn bɪlˈəʊ hiː sˈiːz sˈʌmθɪŋ]"
+                "en": "[bɪlˈəʊ hiː sˈiːz sˈʌmθɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1344,7 +1329,68 @@
             }
         },
         {
-            "id": "scene-12-044",
+            "id": "scene-12-047",
+            "text": {
+                "fr": "Voilà une lumière au loin! La chèvre m'a guidé!",
+                "en": "There's a light in the distance! The goat guided me!",
+                "de": "Da ist ein Licht in der Ferne! Die Ziege hat mich geführt!",
+                "it": "Ecco una luce in lontananza! La capra mi ha guidato!",
+                "es": "¡Ahí hay una luz a lo lejos! ¡La cabra me ha guiado!",
+                "nl": "Daar is een licht in de verte! De geit heeft me geleid!",
+                "pt": "Tem uma luz lá embaixo!",
+                "en_pt": "There's a light down there!"
+            },
+            "ipa": {
+                "fr": "vwalˌa yn lymjˈɛʁ o lwˈɛ̃ la- ʃˈɛvʁ ma ɡidˈe",
+                "de": "[dɑː ɪst aɪn lˈɪçt ɪn dɛɾ fˈɛɾnə\n diː tsˈiːɡə hat mɪç ɡəfˈyːɾt]",
+                "it": "[ˈɛkːo ˌʊna lˈuːtʃe ˌin lˌontanˈantsa\n lˌa kˈaːpra mˌɪ ˌa ɡwidˈaːto]",
+                "es": "[aˈi ai ˈuna luθ a lo ˈlexos | la ˈkaβɾa me a ɣiˈaðo]",
+                "nl": "[dˈaːr ɪs ən lˈɪxt ɪn də vˈɛrtə\n də ɣˈɛɪt heːft mə ɣəlˈɛɪt]",
+                "pt": "[teɪŋ ˌumæ lˈuz lˈa ˌeɪmbˈaɪʃʊ]",
+                "en": "[ðeəz ɐ lˈaɪt ɪnðə dˈɪstəns ðə ɡˈəʊt ɡˈaɪdɪd mˌiː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-048",
+            "text": {
+                "pt": "A cabra me guiou!",
+                "en": "The goat guided me!"
+            },
+            "ipa": {
+                "pt": "[a kˈabræ my ɡiˈow]",
+                "en": "[ðə ɡˈəʊt ɡˈaɪdɪd mˌiː]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-049",
+            "text": {
+                "pt": "É uma fazenda.",
+                "en": "It's a farm."
+            },
+            "ipa": {
+                "pt": "[ɛ ˌumæ fˌazˈeɪŋdæ]",
+                "en": "[ɪts ɐ fˈɑːm]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-050",
             "text": {
                 "fr": "La chèvre bêle une dernière fois et s'en va.",
                 "en": "The goat bleats one last time and leaves.",
@@ -1375,10 +1421,10 @@
             }
         },
         {
-            "id": "scene-12-045",
+            "id": "scene-12-051",
             "text": {
                 "fr": "Lucas court vers la maison.",
-                "en": "Lucas runs towards the house.",
+                "en": "Lucas runs toward the house.",
                 "de": "Lucas läuft zum Haus.",
                 "it": "Lucas corre verso la casa.",
                 "es": "Lucas corre hacia la casa.",
@@ -1393,7 +1439,7 @@
                 "es": "[ˈlukas ˈkoɾe ˈaθja la ˈkasa]",
                 "nl": "[lˈykɑs rˈɛnt naːr hət hˈœys]",
                 "pt": "[lˈukæs kˈɔxy pˌaɾæ a kˈazæ]",
-                "en": "[lˈuːkəz ɹˈʌnz tʊwˈɔːdz ðə hˈaʊs]"
+                "en": "[lˈuːkəz ɹˈʌnz tʊwˈɔːd ðə hˈaʊs]"
             },
             "provenance": {
                 "fr": "original",
@@ -1406,7 +1452,53 @@
             }
         },
         {
-            "id": "scene-12-046",
+            "id": "scene-12-052",
+            "text": {
+                "pt": "Socorro!",
+                "en": "Help!"
+            },
+            "ipa": {
+                "pt": "[sˌokˈoxʊ]",
+                "en": "[hˈɛlp]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-053",
+            "text": {
+                "fr": "À l'aide! J'ai besoin d'aide!",
+                "en": "Help! I need help!",
+                "de": "Zu Hilfe! Ich brauche Hilfe!",
+                "it": "Aiuto! Ho bisogno di aiuto!",
+                "es": "¡Ayuda! ¡Necesito ayuda!",
+                "nl": "Help! Ik heb hulp nodig!",
+                "pt": "Preciso de ajuda!",
+                "en_pt": "I need help!"
+            },
+            "ipa": {
+                "fr": "a lˈɛd ʒe bəzwˈɛ̃ dˈɛd",
+                "de": "[tsuː hˈɪlfə\n ɪç brˈaʊxə hˈɪlfə]",
+                "it": "[ajˈuːto\n ˌo bizˈoɲʲo dˌɪ ajˈuːto]",
+                "es": "[aˈʝuða | neˈθesito aˈʝuða]",
+                "nl": "[hˈɛlp\n ɪk hɛp hˈɵlp nˈoːdəx]",
+                "pt": "[prˌesˈizʊ dʒj ˌaʒˈudæ]",
+                "en": "[hˈɛlp aɪ nˈiːd hˈɛlp]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-12-054",
             "text": {
                 "fr": "Un homme sort de la maison, surpris mais prêt à aider.",
                 "en": "A man comes out of the house, surprised but ready to help.",
@@ -1436,152 +1528,56 @@
             }
         },
         {
-            "id": "scene-12-047",
-            "text": {
-                "pt": "Como?",
-                "en": "How?"
-            },
-            "ipa": {
-                "pt": "[kˈomʊ]",
-                "en": "[hˈaʊ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-048",
-            "text": {
-                "pt": "Não é esta nossa condição humana?",
-                "en": "Isn't this our human condition?"
-            },
-            "ipa": {
-                "pt": "[nˌɐ̃ʊ̃ ɛ ˌɛstæ nˌɔsæ kˌoŋdʒisˈɐ̃ʊ̃ ˌumˈɐ̃næ]",
-                "en": "[ˌɪzənt ðɪs aʊə hjˈuːmən kəndˈɪʃən]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-049",
-            "text": {
-                "pt": "Uma cabra!",
-                "en": "A goat!"
-            },
-            "ipa": {
-                "pt": "[ˌumæ kˈabræ]",
-                "en": "[ɐ ɡˈəʊt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-050",
-            "text": {
-                "pt": "Lucas hesita.",
-                "en": "Lucas hesitates."
-            },
-            "ipa": {
-                "pt": "[lˈukæs ˌezˈitæ]",
-                "en": "[lˈuːkəz hˈɛsɪtˌeɪts]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-051",
-            "text": {
-                "pt": "Devo segui-la?",
-                "en": "Should I follow her?"
-            },
-            "ipa": {
-                "pt": "[dˈevʊ seɡˈilæ]",
-                "en": "[ʃˌʊd aɪ fˈɒləʊ hɜː]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-052",
-            "text": {
-                "pt": "Ou será...",
-                "en": "Or is it..."
-            },
-            "ipa": {
-                "pt": "[ow seɾˈa]",
-                "en": "[ɔːɹ ɪz ˈɪt]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-053",
-            "text": {
-                "pt": "é simplesmente uma cabra voltando para sua fazenda?",
-                "en": "just a goat going back to its farm?"
-            },
-            "ipa": {
-                "pt": "[ɛ sˌimplezmˈeɪŋtʃj ˌumæ kˈabræ vˌowtˈɐ̃ŋdʊ pˌaɾæ sˌuæ fˌazˈeɪŋdæ]",
-                "en": "[dʒˈʌst ɐ ɡˈəʊt ɡˌəʊɪŋ bˈak tʊ ɪts fˈɑːm]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-12-054",
-            "text": {
-                "pt": "A cabra me guiou!",
-                "en": "The goat guided me!"
-            },
-            "ipa": {
-                "pt": "[a kˈabræ my ɡiˈow]",
-                "en": "[ðə ɡˈəʊt ɡˈaɪdɪd mˌiː]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-12-055",
             "text": {
-                "pt": "É uma fazenda.",
-                "en": "It's a farm."
+                "fr": "Ou bien..",
+                "en": "Or perhaps..",
+                "de": "Oder...",
+                "it": "O magari...",
+                "es": "O quizás...",
+                "nl": "Of misschien.."
             },
             "ipa": {
-                "pt": "[ɛ ˌumæ fˌazˈeɪŋdæ]",
-                "en": "[ɪts ɐ fˈɑːm]"
+                "fr": "u bjˈɛ̃",
+                "de": "[ˈoːdɜ]",
+                "it": "[ˌo maɡˈaːrɪ]",
+                "es": "[o kiˈθas]",
+                "nl": "[ɔf mɪsxˈin]",
+                "en": "[ɔː pəhˈaps]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-12-056",
             "text": {
-                "pt": "Socorro!",
-                "en": "Help!"
+                "fr": "je dois choisir de faire confiance.",
+                "en": "I must choose to trust.",
+                "de": "ich muss mich entscheiden, zu vertrauen.",
+                "it": "devo scegliere di fidarmi.",
+                "es": "tengo que decidir confiar.",
+                "nl": "ik moet ervoor kiezen om te vertrouwen."
             },
             "ipa": {
-                "pt": "[sˌokˈoxʊ]",
-                "en": "[hˈɛlp]"
+                "fr": "ʒə- dwˈa ʃwazˈiʁ də- fˈɛʁ kɔ̃fjˈɑ̃s",
+                "de": "[ɪç mˈʊs mɪç ɛntʃˈaɪdən\n tsuː fɛɾtɾˈaʊən]",
+                "it": "[dˈɛːvo ʃˈeʎere dˌɪ fidˈaːrmɪ]",
+                "es": "[ˈteŋɡo ke ðeθiˈðiɾ konˈfjaɾ]",
+                "nl": "[ɪk mˈut ɛrvˈɔːr kˈizən ɔm tə vərtrˈʌʊən]",
+                "en": "[aɪ mˈʌst tʃˈuːz tə tɹˈʌst]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-13.json
+++ b/language_materials/unified/stories/scene-13.json
@@ -24,12 +24,74 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-13-001",
+            "text": {
+                "fr": "Lucas explique la situation au fermier, qui appelle immédiatement les secours de montagne.",
+                "en": "Lucas explains the situation to the farmer, who immediately calls the mountain rescue team.",
+                "de": "Lucas erklärt dem Bauern die Situation, der sofort die Bergwacht ruft.",
+                "it": "Lucas spiega la situazione al contadino, che chiama immediatamente i soccorsi alpini.",
+                "es": "Lucas explica la situación al granjero, quien llama inmediatamente a los servicios de montaña.",
+                "nl": "Lucas legt de situatie uit aan de boer, die meteen de bergredding belt.",
+                "pt": "Lucas explica a situação ao fazendeiro, que imediatamente liga para os socorros de montanha.",
+                "en_pt": "Lucas explains the situation to the farmer, who immediately calls mountain rescue."
+            },
+            "ipa": {
+                "fr": "lykˈaz ɛksplˈik la- sityasjˈɔ̃ o fɛʁmjˈe ki apˈɛl immedjatmˈɑ̃ le- səkˈuʁ də- mɔ̃tˈaɲ",
+                "de": "[ˈluːkas ɛɐ̯ˈklɛːɐ̯t deːm ˈbaʊ̯ɐn diː ˌzituˈaːtsi̯oːn deːɐ̯ ˈzoːfɔʁt diː ˈbɛʁkˌvaxt ˈʁʊft]",
+                "it": "[lˈuːkas spjˈeːɡa lˌa sˌitʊˌatsiˈɔːne ˌal kˌontadˈiːno\n kˌe kjˈaːma ˌimmedjˌatamˈente ˌɪ sokːˈoːrsɪ alpˈiːnɪ]",
+                "es": "[ˈlukas eksˈplika la situaˈθjon al ɣɾanˈxeɾo, kjen ˈʎama inmeðjataˈmente a los seɾˈβiθjos ðe monˈtaɲa]",
+                "nl": "[lˈykɑs lˈɛx tə sˌityˈaːtsi œyt aːn də bˈur\n di mɛtˈeːn də bərɣrˈɛdɪŋ bˈɛlt]",
+                "pt": "[lˈukæz ˌesplˈikæ a sˌituasˈɐ̃ʊ̃ aʊ fˌazeɪŋdˈeɪɾʊ\n ky ˌimedʒˌiatæmˈeɪŋtʃy lˈiɡæ pˌaɾæ ʊs sˌokˈoxʊz dʒy mˌoŋtˈɐ̃ɲæ]",
+                "en": "[lˈuːkəz ɛksplˈeɪnz ðə sˌɪtʃuːˈeɪʃən tə ðə fˈɑːmə hˌuː ɪmˈiːdɪətli kˈɔːlz ðə mˈaʊntɪn ɹˈɛskjuː tˈiːm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-002",
+            "text": {
+                "fr": "Ils arrivent rapidement au poste de secours du village.",
+                "en": "They arrive quickly at the village rescue station.",
+                "de": "Sie erreichen schnell die Rettungsstelle im Dorf.",
+                "it": "Arrivano rapidamente al posto di soccorso del villaggio.",
+                "es": "Llegan rápido al puesto de socorro del pueblo.",
+                "nl": "Ze komen snel aan bij het reddingsstation van het dorp.",
+                "pt": "Eles chegam rapidamente ao posto de resgate do vilarejo.",
+                "en_pt": "They quickly arrive at the village rescue post."
+            },
+            "ipa": {
+                "fr": "ilz aʁˈiv ʁapidmˈɑ̃ o pˈɔst də- səkˈuʁ dy- vilˈaʒ",
+                "de": "[ziː ɛɐ̯ˈʁaɪ̯çən ˈʃnɛl diː ˈʁɛtuŋsˌʃtɛlə ɪm dɔʁf]",
+                "it": "[arɾˈivano rˌapidamˈente ˌal pˈosto dˌɪ sokːˈoːrso dˌɛl villˈadʒːo]",
+                "es": "[ˈʎeɣan ˈrapido al ˈpwesto ðe soˈkoɾo ðel ˈpwɛβlo]",
+                "nl": "[zə kˈoːmən snˈɛl aːn bɛɪ hət rˌɛdɪŋstaːʃˈɔn vɑn hə tˈɔrp]",
+                "pt": "[ˌelys ʃˈeɡɐ̃ʊ̃ xˌapidæmˈeɪŋtʃj aʊ pˈostʊ dʒy xˌezɡˈatʃy dʊ vˌilaɾˈeʒʊ]",
+                "en": "[ðeɪ ɐɹˈaɪv kwˈɪkli at ðə vˈɪlɪdʒ ɹˈɛskjuː stˈeɪʃən]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-003",
             "text": {
                 "fr": "Il faut que nous organisions une équipe de recherche,",
                 "en": "We need to organize a search team,",
@@ -60,10 +122,10 @@
             }
         },
         {
-            "id": "scene-13-002",
+            "id": "scene-13-004",
             "text": {
                 "fr": "Bien qu'il fasse nuit, nous devons partir maintenant",
-                "en": "Even though it's night, we need to depart now",
+                "en": "Although it is night, we must leave now",
                 "de": "Obwohl es Nacht ist, müssen wir jetzt los.",
                 "it": "Anche se è notte, dobbiamo partire subito",
                 "es": "Aunque es de noche, tenemos que salir ahora",
@@ -78,7 +140,7 @@
                 "es": "[ˈauŋke es ðe ˈnoʧe, teˈnemos ke saˈliɾ aˈoɾa]",
                 "nl": "[huʋˈɛl hət nˈɑxt ɪs\n mˈutən ʋə nˈy vərtrˈɛkən]",
                 "pt": "[ˌeɪmbˈɔɾæ sˈeʒæ nˈoɪtʃy\n prˌesizˈɐ̃mʊs paɾətʃˈiɾ ˌaɡˈɔɾæ]",
-                "en": "[ˈiːvən ðˌəʊ ɪts nˈaɪt wiː nˈiːd tə dɪpˈɑːt nˈaʊ]"
+                "en": "[ɒlðˈəʊ ɪt ɪz nˈaɪt wiː mˈʌst lˈiːv nˈaʊ]"
             },
             "provenance": {
                 "fr": "original",
@@ -91,7 +153,7 @@
             }
         },
         {
-            "id": "scene-13-003",
+            "id": "scene-13-005",
             "text": {
                 "fr": "Chaque heure compte.",
                 "en": "Every hour counts.",
@@ -121,533 +183,7 @@
             }
         },
         {
-            "id": "scene-13-004",
-            "text": {
-                "fr": "Nous étions ici, vers ce refuge.",
-                "en": "We were here, near this shelter.",
-                "de": "Wir waren hier, in der Nähe dieser Schutzhütte.",
-                "it": "Eravamo qui, vicino a questo rifugio.",
-                "es": "Estábamos aquí, cerca de este refugio.",
-                "nl": "We waren hier, bij deze schuilplaats.",
-                "pt": "Estávamos aqui, perto deste refúgio.",
-                "en_pt": "We were here, near this refuge."
-            },
-            "ipa": {
-                "fr": "nuz etjˈɔ̃z isˈi vɛʁ sə- ʁəfˈyʒ",
-                "de": "[viːɐ̯ ˈvaːʁən hiːɐ̯ ɪn deːɐ̯ ˈnɛːə ˈdiːzɐ ˈʃʊt͡sˌhʏtə]",
-                "it": "[ˌɛravˈaːmo kwˈi\n vitʃˈiːno ˌa kwˌɛsto rifˈuːdʒo]",
-                "es": "[esˈtaβamos aˈki, ˈθeɾka ðe ˈeste reˈfuχjo]",
-                "nl": "[ʋə ʋˌaːrən hˈir\n bɛɪ dˌeːzə sxœylplˈaːts]",
-                "pt": "[estˌavæmʊz akˈi\n pˈɛɾətʊ dˈestʃy xˌefˈuʒjʊ]",
-                "en": "[wiː wɜː hˈiə nˌiə ðɪs ʃˈɛltə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-005",
-            "text": {
-                "fr": "Pourvu qu'elle ait trouvé un abri!",
-                "en": "Hopefully, she has found a shelter!",
-                "de": "Hoffentlich hat sie Unterschlupf gefunden!",
-                "it": "Speriamo che abbia trovato un riparo!",
-                "es": "¡Ojalá que haya encontrado un refugio!",
-                "nl": "Hopelijk heeft ze een schuilplaats gevonden!",
-                "pt": "Tomara que ela tenha encontrado abrigo!",
-                "en_pt": "I hope she found shelter!"
-            },
-            "ipa": {
-                "fr": "puʁvˈy kɛl ɛ tʁuvˈe œ̃n abʁˈi",
-                "de": "[ˈhoːfəntlɪç hat ziː ˈʊntɐˌʃlʊpf gəˈfʊndən]",
-                "it": "[spˌɛriˈaːmo kˌe ˌabːia trovˈaːto ˌʊn ripˈaːro]",
-                "es": "[oˈxala ke ˈaʝa enkonˈtɾaðo un reˈfuχjo]",
-                "nl": "[hˈoːpələk heːft zə ən sxœylplˈaːts ɣəvˈɔndən]",
-                "pt": "[tˌomˈaɾæ ky ˌɛlæ tˈeɲæ ˌeɪŋkoŋtrˈadw ˌabrˈiɡʊ]",
-                "en": "[hˈəʊpfəlɪ ʃiː hɐz fˈaʊnd ɐ ʃˈɛltə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-13-006",
-            "text": {
-                "fr": "Le jeune homme a dit qu'elle portait une veste rouge",
-                "en": "The young man said she was wearing a red jacket",
-                "de": "Der junge Mann sagte, sie trug eine rote Jacke",
-                "it": "Il ragazzo ha detto che indossava una giacca rossa",
-                "es": "El joven dijo que llevaba una chaqueta roja",
-                "nl": "De jongeman zei dat ze een rode jas droeg",
-                "pt": "O rapaz disse que ela estava com uma jaqueta vermelha.",
-                "en_pt": "The young man said she was wearing a red jacket."
-            },
-            "ipa": {
-                "fr": "lə- ʒˈøn ˈɔm a dˈi kɛl pɔʁtˈɛt yn vˈɛst ʁˈuʒ",
-                "de": "[deːɐ̯ ˈjʊŋə man ˈzaːktə ziː tʁuːk ˈaɪnə ˈʁoːtə ˈjakə]",
-                "it": "[ˌil raɡˈatsːo ˌa dˈetːo kˌe ˌindossˈaːva ˌʊna dʒˈakːa rˈossa]",
-                "es": "[el ˈxoβen ˈðixo ke ʝeˈβaβa ˈuna tʃaˈketa ˈroxa]",
-                "nl": "[də jˈɔŋəmˌɑn zˈɛɪ dɑt zə ən rˈoːdə jˈɑs drˈux]",
-                "pt": "[ʊ xapˈaz dʒˈisy ky ˌɛlæ estˌavæ koŋ ˌumæ ʒˌakˈetæ vˌeɾəmˈeljæ]",
-                "en": "[ðə jˈʌŋ mˈan sˈɛd ʃiː wɒz wˈeəɹɪŋ ɐ ɹˈɛd dʒˈakɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-007",
-            "text": {
-                "fr": "Ça nous aidera.",
-                "en": "That will help us.",
-                "de": "Das wird uns helfen.",
-                "it": "Ciò ci aiuterà.",
-                "es": "Eso nos ayudará.",
-                "nl": "Dat zal ons helpen.",
-                "pt": "Isso vai ajudar.",
-                "en_pt": "That will help."
-            },
-            "ipa": {
-                "fr": "sa nuz ɛdʁˈa",
-                "de": "[das vɪʁt ʊns ˈhɛlfən]",
-                "it": "[tʃˈɔ tʃˌɪ ˌajʊterˈa]",
-                "es": "[ˈeso nos aʝuˈðaɾa]",
-                "nl": "[dɑt zɑl ɔns hˈɛlpən]",
-                "pt": "[ˈisʊ vaɪ ˌaʒudˈar]",
-                "en": "[ðat wɪl hˈɛlp ˌʌs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-008",
-            "text": {
-                "fr": "J'espère qu'elle soit en sécurité.",
-                "en": "I hope she is safe.",
-                "de": "Ich hoffe, dass sie sicher ist.",
-                "it": "Spero che sia al sicuro.",
-                "es": "Espero que esté segura.",
-                "nl": "Ik hoop dat ze veilig is.",
-                "pt": "Espero que ela esteja segura.",
-                "en_pt": "I hope she's safe."
-            },
-            "ipa": {
-                "fr": "ʒɛspˈɛʁ kɛl swˌa ɑ̃ sekyʁitˈe",
-                "de": "[ɪç ˈhɔfə das ziː ˈzɪçɐ ɪst]",
-                "it": "[spˈɛːro kˌe sˌia ˌal sikˈuːro]",
-                "es": "[esˈpeɾo ke esˈte seˈɣuɾa]",
-                "nl": "[ɪk hˈoːp dɑt zə vˈɛɪləx ɪs]",
-                "pt": "[ˌespˈɛɾʊ ky ˌɛlæ ˌestˈeʒæ sˌeɡˈuɾæ]",
-                "en": "[aɪ hˈəʊp ʃiː ɪz sˈeɪf]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-009",
-            "text": {
-                "fr": "Nous avons besoin que vous nous montriez sur la carte exactement où vous étiez.",
-                "en": "We need you to show us exactly on the map where you were.",
-                "de": "Wir brauchen, dass ihr uns genau zeigt, wo ihr wart.",
-                "it": "Abbiamo bisogno che ci mostriate sulla mappa esattamente dove eravate.",
-                "es": "Necesitamos que nos muestres en el mapa exactamente donde estabas.",
-                "nl": "We hebben nodig dat je ons precies laat zien op de kaart waar je was.",
-                "pt": "Precisamos que você nos mostre no mapa exatamente onde vocês estavam.",
-                "en_pt": "We need you to show us on the map exactly where you were."
-            },
-            "ipa": {
-                "fr": "nuz avˈɔ̃ bəzwˈɛ̃ kə vu nu mɔ̃tʁiˈe syʁ la- kˈaʁt ɛɡzaktəmˈɑ̃ u vuz etjˈe",
-                "de": "[viːɐ̯ ˈbʁaʊ̯çn̩ das iːɐ̯ ʊns ɡəˈnaʊ̯ ˈtsaɪ̯kt voː iːɐ̯ vaːɐ̯t]",
-                "it": "[abːjˌamo bizˈoɲʲo kˌe tʃˌɪ mˌɔstriˈaːte sˌʊlla mˈapːa ˌezatːamˈente dˈoːve ˌɛravˈaːte]",
-                "es": "[neθeˈsitamos ke nos ˈmwestɾes en el ˈmapa eksakˈtamente ˈðonðe esˈtaβas]",
-                "nl": "[ʋə hˌɛbən nˈoːdəx dɑt jə ɔns preːsˈis lˈaːt zˈin ɔp də kˈaːrt ʋˈaːr jə ʋˈɑs]",
-                "pt": "[prˌesizˈɐ̃mʊs ky vosˌe nʊz mˈɔstry nʊ mˈapæ ˌezatæmˈeɪŋtʃj ˌoŋdʒy vosˌez estˌavɐ̃ʊ̃]",
-                "en": "[wiː nˈiːd juː tə ʃˈəʊ ˌʌs ɛɡzˈaktli ɒnðə mˈap wˈeə juː wɜː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-010",
-            "text": {
-                "fr": "Il est important que vous restiez calme",
-                "en": "It's important that you remain calm",
-                "de": "Es ist wichtig, dass du ruhig bleibst",
-                "it": "È importante che rimaniate calmo",
-                "es": "Es importante que te mantengas tranquilo",
-                "nl": "Het is belangrijk dat je rustig blijft",
-                "pt": "É importante que você fique calmo.",
-                "en_pt": "It's important that you stay calm."
-            },
-            "ipa": {
-                "fr": "il ɛt ɛ̃pɔʁtˈɑ̃ kə vu ʁɛstjˈe kˈalm",
-                "de": "[ɛs ɪst ˈvɪçtɪç das duː ˈʁuːɪç ˈblaɪ̯pst]",
-                "it": "[ˌɛ ˌimportˈante kˌe rˌimanjˈaːte kˈalmo]",
-                "es": "[es impoɾˈtante ke te manˈteŋɡas tɾanˈkilo]",
-                "nl": "[hət ɪs bəlˈɑŋrɛɪk dɑt jə rˈɵstəx blˈɛɪft]",
-                "pt": "[ɛ ˌimpoɾətˈɐ̃ŋtʃy ky vosˌe fˈiky kˈaʊmʊ]",
-                "en": "[ɪts ɪmpˈɔːtənt ðat juː ɹɪmˈeɪn kˈɑːm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-011",
-            "text": {
-                "fr": "Nous sommes des professionnels.",
-                "en": "We are professionals.",
-                "de": "Wir sind Profis.",
-                "it": "Siamo professionisti.",
-                "es": "Somos profesionales.",
-                "nl": "Wij zijn professionals.",
-                "pt": "Somos profissionais.",
-                "en_pt": "We're professionals."
-            },
-            "ipa": {
-                "fr": "nu sɔm de- pʁɔfɛsjɔnˈɛl",
-                "de": "[viːɐ̯ zɪnt ˈpʁoːfis]",
-                "it": "[sjˌamo prˌofessˌionˈistɪ]",
-                "es": "[ˈsomos pɾofesjoˈnales]",
-                "nl": "[ʋɛɪ zɛɪn prˈoːfɛʃˌoːnɑls]",
-                "pt": "[sˌomʊs prˌofisˌionˈaɪs]",
-                "en": "[wiː ɑː pɹəfˈɛʃənəlz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-012",
-            "text": {
-                "fr": "Quoi qu'il arrive, nous la retrouverons, n'est-ce pas?",
-                "en": "Whatever happens, we will find her, right?",
-                "de": "Egal was passiert, wir werden sie finden, nicht wahr?",
-                "it": "Qualsiasi cosa succeda, la ritroveremo, vero?",
-                "es": "Pase lo que pase, la encontraremos, ¿verdad?",
-                "nl": "Wat er ook gebeurt, we zullen haar vinden, toch?",
-                "pt": "Aconteça o que acontecer, vamos encontrá-la, não vamos?",
-                "en_pt": "Whatever happens, we'll find her, won't we?"
-            },
-            "ipa": {
-                "fr": "kwˌa kil aʁˈiv nu la- ʁətʁuvʁˈɔ̃ nˈɛs pˈa",
-                "de": "[ˈeːɡal vas paˈsiːɐ̯t viːɐ̯ ˈveːɐ̯dən ziː ˈfɪndən nɪçt vaːɐ̯]",
-                "it": "[kwalsˈiazɪ kˈɔːza sʊtʃːˈeːda\n lˌa rˌitroverˈɛːmo\n vˈeːro]",
-                "es": "[ˈpase lo ke ˈpase, la enkonˈtɾaɾemos, βeɾˈðað]",
-                "nl": "[ʋɑt ər oːk ɣəbˈøːrt\n ʋə zˌɵlən haːr vˈɪndən\n tˈɔx]",
-                "pt": "[ˌakoŋtˈesæ ʊ ky ˌakoŋtesˈer\n vˌɐ̃mʊz ˌeɪŋkoŋtrˈalæ\n nˌɐ̃ʊ̃ vˈɐ̃mʊs]",
-                "en": "[wɒtˈɛvə hˈapənz wiː wɪl fˈaɪnd hɜː ɹˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-013",
-            "text": {
-                "fr": "Oui. Nous connaissons ces montagnes comme notre poche.",
-                "en": "Yes. We know these mountains like the back of our hand.",
-                "de": "Ja. Wir kennen diese Berge wie unsere Westentasche.",
-                "it": "Sì. Conosciamo queste montagne come le nostre tasche.",
-                "es": "Sí. Conocemos estas montañas como la palma de nuestra mano.",
-                "nl": "Ja. We kennen deze bergen als onze broekzak.",
-                "pt": "Conhecemos essas montanhas como a palma da mão.",
-                "en_pt": "We know these mountains like the back of our hand."
-            },
-            "ipa": {
-                "fr": "wˈi nu kɔnɛsˈɔ̃ se mɔ̃tˈanj kɔm nɔtʁ pˈɔʃ",
-                "de": "[jaː viːɐ̯ ˈkɛnən ˈdiːzə ˈbɛʁɡə viː ʊnzəʁə ˈvɛstn̩ˌtaʃə]",
-                "it": "[sˈi\n kˌonoʃˈaːmo kwˌɛste montˈaɲɲe kˌome lˌe nˌɔstre tˈaske]",
-                "es": "[si koˈnoθemos ˈestas monˈtaɲas komo la ˈpalma ðe ˈnwestɾa ˈmano]",
-                "nl": "[jˈaː\n ʋə kˈɛnən dˌeːzə bˈɛrɣən ɑls ɔnzˌə brˈukzɑk]",
-                "pt": "[kˌoɲesˈemʊz ˈɛsæz mˌoŋtˈɐ̃ɲæs kˌomʊ a pˈaʊmæ da mˈɐ̃ʊ̃]",
-                "en": "[jˈɛs wiː nˈəʊ ðiːz mˈaʊntɪnz lˈaɪk ðə bˈak ɒv aʊə hˈand]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-014",
-            "text": {
-                "fr": "L'hélicoptère partira dès que le temps le permettra",
-                "en": "The helicopter will leave as soon as the weather permits",
-                "de": "Der Hubschrauber startet, sobald das Wetter es zulässt",
-                "it": "L'elicottero partirà non appena il tempo lo permetterà",
-                "es": "El helicóptero saldrá en cuanto el tiempo lo permita",
-                "nl": "De helikopter vertrekt zodra het weer het toelaat",
-                "pt": "O helicóptero vai partir assim que o tempo permitir.",
-                "en_pt": "The helicopter will leave as soon as the weather permits."
-            },
-            "ipa": {
-                "fr": "lelikɔptˈɛʁ paʁtiʁˈa dɛ kə lə- tˈɑ̃ lə- pɛʁmɛtʁˈa",
-                "de": "[deːɐ̯ ˈhʊpʃʁaʊ̯bɐ ʃtaʁˈtɛt zoˈbalt das ˈvɛtɐ ɛs ˈtsuːlɛst]",
-                "it": "[lˌɛlikˈɔtːero pˌartirˈa nˌon apːˈeːna ˌil tˈɛmpo lˌo pˌɛrmetːerˈa]",
-                "es": "[el elikoˈpteɾo salˈðɾa en ˈkwanto el ˈtjempo lo peɾˈmita]",
-                "nl": "[də hˈeːlikˌɔptər vərtrˈɛkt zɔdrˈaː hət ʋˈɪːr hə tˈulˌaːt]",
-                "pt": "[ʊ ˌelikˈɔpteɾʊ vaɪ paɾətʃˈiɾ asˈiŋ ky ʊ tˈeɪmpʊ pˌeɾəmitʃˈir]",
-                "en": "[ðə hˈɛlɪkˌɒptə wɪl lˈiːv az sˈuːn az ðə wˈɛðə pˈɜːmɪts]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-015",
-            "text": {
-                "fr": "Au lever du jour.",
-                "en": "At the break of dawn.",
-                "de": "Beim Tagesanbruch.",
-                "it": "All'alba.",
-                "es": "Al amanecer.",
-                "nl": "Bij het aanbreken van de dag.",
-                "pt": "Ao amanhecer.",
-                "en_pt": "At dawn."
-            },
-            "ipa": {
-                "fr": "o ləvˈe dy- ʒˈuʁ",
-                "de": "[baɪ̯m ˈtaːɡəsˈʔanbʁʊx]",
-                "it": "[allˈalba]",
-                "es": "[al amaneˈθeɾ]",
-                "nl": "[bɛɪ hət ˈaːnbrˌeːkən vɑn də dˈɑx]",
-                "pt": "[aʊ ˌæmɐ̃ɲesˈer]",
-                "en": "[at ðə bɹˈeɪk ɒv dˈɔːn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-016",
-            "text": {
-                "fr": "En attendant, reposez-vous et reprenez des forces",
-                "en": "In the meantime, rest and gather your strength",
-                "de": "In der Zwischenzeit, ruh dich aus und sammle Kräfte.",
-                "it": "Nel frattempo, riposatevi e recuperate le forze",
-                "es": "Mientras tanto, descansa y recupera fuerzas",
-                "nl": "Rust ondertussen uit en verzamel je krachten",
-                "pt": "Enquanto isso, descanse e recupere as forças.",
-                "en_pt": "Meanwhile, rest and recover your strength."
-            },
-            "ipa": {
-                "fr": "ɑ̃n atɑ̃dˈɑ̃ ʁəpozˈevuz e ʁəpʁənˈe de- fˈɔʁs",
-                "de": "[ɪn deːɐ̯ ˈtsvɪʃənˌtsaɪ̯t ˈʁuː dɪç aʊ̯s ʊnt ˈzamlə ˈkʁɛftə]",
-                "it": "[nˌɛl fratːˈɛmpo\n rˌipozˈatevɪ ˌe rˌɛkʊperˈaːte lˌe fˈɔːrtse]",
-                "es": "[mjẽnˈtɾas ˈtanto ðesˈkansa i rekuˈpeɾa ˈfweɾθas]",
-                "nl": "[rˈɵst ˈɔndərtˌɵsən œyt ɛn vərzˈaːməl jə krˈɑxtən]",
-                "pt": "[ˌeɪŋkwˈɐ̃ŋtw ˈisʊ\n dˌeskˈɐ̃ŋsj i xˌekupˈɛɾi as fˈoɾəsæs]",
-                "en": "[ɪnðə mˈiːntaɪm ɹˈɛst and ɡˈaðə jɔː stɹˈɛŋθ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-017",
-            "text": {
-                "fr": "Vous ne lui serez d'aucune aide si vous êtes épuisé.",
-                "en": "You won't be any help if you are exhausted.",
-                "de": "Du bist ihr keine Hilfe, wenn du erschöpft bist.",
-                "it": "Non sarai di alcun aiuto se sei esausto.",
-                "es": "No serás de ayuda si estás agotado.",
-                "nl": "Je bent geen hulp als je uitgeput bent.",
-                "pt": "Você não vai ajudá-la se estiver exausto.",
-                "en_pt": "You won't help her if you're exhausted."
-            },
-            "ipa": {
-                "fr": "vu nə- lyˌi səʁˈe dokˈyn ˈɛd sˈi vuz ɛtz epyizˈe",
-                "de": "[duː bɪst iːɐ̯ ˈkaɪ̯nə ˈhɪlfe vɛn duː ɛɐ̯ˈʃøpft bɪst]",
-                "it": "[nˌon sarˈaɪ dˌɪ alkˌʊn ajˈuːto sˌe sˌɛj ezˈaʊsto]",
-                "es": "[no seˈɾas ðe aˈʝuða si esˈtas aɣoˈtaðo]",
-                "nl": "[jə bɛnt ɣˈeːn hˈɵlp ɑls jə ˈœytɣəpˌɵt bɛnt]",
-                "pt": "[vosˌe nˌɐ̃ʊ̃ vaɪ ˌaʒudˈalæ sj ˌestʃivˌɛɾ ˌezˈaʊstʊ]",
-                "en": "[juː wəʊnt biː ˌɛni hˈɛlp ɪf juː ɑːɹ ɛɡzˈɔːstɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-018",
-            "text": {
-                "fr": "Lucas explique la situation au fermier, qui appelle immédiatement les secours de montagne.",
-                "en": "Lucas explains the situation to the farmer, who immediately calls mountain rescue.",
-                "de": "Lucas erklärt dem Bauern die Situation, der sofort die Bergwacht ruft.",
-                "it": "Lucas spiega la situazione al contadino, che chiama immediatamente i soccorsi alpini.",
-                "es": "Lucas explica la situación al granjero, quien llama inmediatamente a los servicios de montaña.",
-                "nl": "Lucas legt de situatie uit aan de boer, die meteen de bergredding belt.",
-                "pt": "Lucas explica a situação ao fazendeiro, que imediatamente liga para os socorros de montanha."
-            },
-            "ipa": {
-                "fr": "lykˈaz ɛksplˈik la- sityasjˈɔ̃ o fɛʁmjˈe ki apˈɛl immedjatmˈɑ̃ le- səkˈuʁ də- mɔ̃tˈaɲ",
-                "de": "[ˈluːkas ɛɐ̯ˈklɛːɐ̯t deːm ˈbaʊ̯ɐn diː ˌzituˈaːtsi̯oːn deːɐ̯ ˈzoːfɔʁt diː ˈbɛʁkˌvaxt ˈʁʊft]",
-                "it": "[lˈuːkas spjˈeːɡa lˌa sˌitʊˌatsiˈɔːne ˌal kˌontadˈiːno\n kˌe kjˈaːma ˌimmedjˌatamˈente ˌɪ sokːˈoːrsɪ alpˈiːnɪ]",
-                "es": "[ˈlukas eksˈplika la situaˈθjon al ɣɾanˈxeɾo, kjen ˈʎama inmeðjataˈmente a los seɾˈβiθjos ðe monˈtaɲa]",
-                "nl": "[lˈykɑs lˈɛx tə sˌityˈaːtsi œyt aːn də bˈur\n di mɛtˈeːn də bərɣrˈɛdɪŋ bˈɛlt]",
-                "pt": "[lˈukæz ˌesplˈikæ a sˌituasˈɐ̃ʊ̃ aʊ fˌazeɪŋdˈeɪɾʊ\n ky ˌimedʒˌiatæmˈeɪŋtʃy lˈiɡæ pˌaɾæ ʊs sˌokˈoxʊz dʒy mˌoŋtˈɐ̃ɲæ]",
-                "en": "[lˈuːkəz ɛksplˈeɪnz ðə sˌɪtʃuːˈeɪʃən tə ðə fˈɑːmə hˌuː ɪmˈiːdɪətli kˈɔːlz mˈaʊntɪn ɹˈɛskjuː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-019",
-            "text": {
-                "fr": "Ils arrivent rapidement au poste de secours du village.",
-                "en": "They quickly arrive at the village's rescue station.",
-                "de": "Sie erreichen schnell die Rettungsstelle im Dorf.",
-                "it": "Arrivano rapidamente al posto di soccorso del villaggio.",
-                "es": "Llegan rápido al puesto de socorro del pueblo.",
-                "nl": "Ze komen snel aan bij het reddingsstation van het dorp.",
-                "pt": "Eles chegam rapidamente ao posto de resgate do vilarejo.",
-                "en_pt": "They quickly arrive at the village rescue post."
-            },
-            "ipa": {
-                "fr": "ilz aʁˈiv ʁapidmˈɑ̃ o pˈɔst də- səkˈuʁ dy- vilˈaʒ",
-                "de": "[ziː ɛɐ̯ˈʁaɪ̯çən ˈʃnɛl diː ˈʁɛtuŋsˌʃtɛlə ɪm dɔʁf]",
-                "it": "[arɾˈivano rˌapidamˈente ˌal pˈosto dˌɪ sokːˈoːrso dˌɛl villˈadʒːo]",
-                "es": "[ˈʎeɣan ˈrapido al ˈpwesto ðe soˈkoɾo ðel ˈpwɛβlo]",
-                "nl": "[zə kˈoːmən snˈɛl aːn bɛɪ hət rˌɛdɪŋstaːʃˈɔn vɑn hə tˈɔrp]",
-                "pt": "[ˌelys ʃˈeɡɐ̃ʊ̃ xˌapidæmˈeɪŋtʃj aʊ pˈostʊ dʒy xˌezɡˈatʃy dʊ vˌilaɾˈeʒʊ]",
-                "en": "[ðeɪ kwˈɪkli ɐɹˈaɪv at ðə vˈɪlɪdʒz ɹˈɛskjuː stˈeɪʃən]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-020",
-            "text": {
-                "fr": "dit le chef des secouristes.",
-                "en": "says the head of the rescue team.",
-                "de": "sagt der Leiter der Rettungskräfte.",
-                "it": "dice il capo dei soccorritori.",
-                "es": "dice el jefe de los socorristas.",
-                "nl": "zegt de leider van de reddingswerkers.",
-                "pt": "diz um dos socorristas.",
-                "en_pt": "says one of the rescuers."
-            },
-            "ipa": {
-                "fr": "dˈi lə- ʃˈɛf de- səkuʁˈist",
-                "de": "[zaːkt deːɐ̯ ˈlaɪ̯tɐ deːɐ̯ ʁɛˈtuŋsˌkʁɛftə]",
-                "it": "[dˈiːtʃe ˌil kˈaːpo dˌɛj sˌokːorɾitˈoːrɪ]",
-                "es": "[ðiθe el ˈxefe ðe los soˈkoristas]",
-                "nl": "[zˈɛx tə lˈɛɪdər vɑn də rˈɛdɪŋsʋˌɛrkərs]",
-                "pt": "[dʒˈiz ũŋ dʊs sˌokoxˈistæs]",
-                "en": "[sˈɛz ðə hˈɛd ɒvðə ɹˈɛskjuː tˈiːm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-021",
             "text": {
                 "fr": "Lucas montre la carte en tremblant.",
                 "en": "Lucas shows the map while trembling.",
@@ -678,22 +214,25 @@
             }
         },
         {
-            "id": "scene-13-022",
+            "id": "scene-13-007",
             "text": {
-                "fr": "dit un des secouristes.",
-                "en": "says one of the rescuers.",
-                "de": "sagt einer der Rettungskräfte.",
-                "it": "dice uno dei soccorritori.",
-                "es": "dice uno de los socorristas.",
-                "nl": "zegt een van de reddingswerkers."
+                "fr": "Nous étions ici, vers ce refuge.",
+                "en": "We were here, near this shelter.",
+                "de": "Wir waren hier, in der Nähe dieser Schutzhütte.",
+                "it": "Eravamo qui, vicino a questo rifugio.",
+                "es": "Estábamos aquí, cerca de este refugio.",
+                "nl": "We waren hier, bij deze schuilplaats.",
+                "pt": "Estávamos aqui, perto deste refúgio.",
+                "en_pt": "We were here, near this refuge."
             },
             "ipa": {
-                "fr": "dˈi œ̃ de- səkuʁˈist",
-                "de": "[zaːkt ˈaɪ̯nɐ deːɐ̯ ʁɛˈtuŋsˌkʁɛftə]",
-                "it": "[dˈiːtʃe ˈuːno dˌɛj sˌokːorɾitˈoːrɪ]",
-                "es": "[ðiθe ˈuno ðe los soˈkoristas]",
-                "nl": "[zˈɛxt ˈeːn vɑn də rˈɛdɪŋsʋˌɛrkərs]",
-                "en": "[sˈɛz wˈɒn ɒvðə ɹˈɛskjuːəz]"
+                "fr": "nuz etjˈɔ̃z isˈi vɛʁ sə- ʁəfˈyʒ",
+                "de": "[viːɐ̯ ˈvaːʁən hiːɐ̯ ɪn deːɐ̯ ˈnɛːə ˈdiːzɐ ˈʃʊt͡sˌhʏtə]",
+                "it": "[ˌɛravˈaːmo kwˈi\n vitʃˈiːno ˌa kwˌɛsto rifˈuːdʒo]",
+                "es": "[esˈtaβamos aˈki, ˈθeɾka ðe ˈeste reˈfuχjo]",
+                "nl": "[ʋə ʋˌaːrən hˈir\n bɛɪ dˌeːzə sxœylplˈaːts]",
+                "pt": "[estˌavæmʊz akˈi\n pˈɛɾətʊ dˈestʃy xˌefˈuʒjʊ]",
+                "en": "[wiː wɜː hˈiə nˌiə ðɪs ʃˈɛltə]"
             },
             "provenance": {
                 "fr": "original",
@@ -701,11 +240,151 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
+                "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-13-023",
+            "id": "scene-13-008",
+            "text": {
+                "fr": "Pourvu qu'elle ait trouvé un abri!",
+                "en": "Let's hope she found shelter!",
+                "de": "Hoffentlich hat sie Unterschlupf gefunden!",
+                "it": "Speriamo che abbia trovato un riparo!",
+                "es": "¡Ojalá que haya encontrado un refugio!",
+                "nl": "Hopelijk heeft ze een schuilplaats gevonden!",
+                "pt": "Tomara que ela tenha encontrado abrigo!",
+                "en_pt": "I hope she found shelter!"
+            },
+            "ipa": {
+                "fr": "puʁvˈy kɛl ɛ tʁuvˈe œ̃n abʁˈi",
+                "de": "[ˈhoːfəntlɪç hat ziː ˈʊntɐˌʃlʊpf gəˈfʊndən]",
+                "it": "[spˌɛriˈaːmo kˌe ˌabːia trovˈaːto ˌʊn ripˈaːro]",
+                "es": "[oˈxala ke ˈaʝa enkonˈtɾaðo un reˈfuχjo]",
+                "nl": "[hˈoːpələk heːft zə ən sxœylplˈaːts ɣəvˈɔndən]",
+                "pt": "[tˌomˈaɾæ ky ˌɛlæ tˈeɲæ ˌeɪŋkoŋtrˈadw ˌabrˈiɡʊ]",
+                "en": "[lˈɛts hˈəʊp ʃiː fˈaʊnd ʃˈɛltə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-009",
+            "text": {
+                "fr": "dit le chef des secouristes.",
+                "en": "says le chef des secouristes.",
+                "de": "sagt der Leiter der Rettungskräfte.",
+                "it": "dice il capo dei soccorritori.",
+                "es": "dice el jefe de los socorristas.",
+                "nl": "zegt de leider van de reddingswerkers.",
+                "pt": "diz um dos socorristas.",
+                "en_pt": "says one of the rescuers."
+            },
+            "ipa": {
+                "fr": "dˈi lə- ʃˈɛf de- səkuʁˈist",
+                "de": "[zaːkt deːɐ̯ ˈlaɪ̯tɐ deːɐ̯ ʁɛˈtuŋsˌkʁɛftə]",
+                "it": "[dˈiːtʃe ˌil kˈaːpo dˌɛj sˌokːorɾitˈoːrɪ]",
+                "es": "[ðiθe el ˈxefe ðe los soˈkoristas]",
+                "nl": "[zˈɛx tə lˈɛɪdər vɑn də rˈɛdɪŋsʋˌɛrkərs]",
+                "pt": "[dʒˈiz ũŋ dʊs sˌokoxˈistæs]",
+                "en": "[sˈɛz lə ʃˈɛf dˈɛs sˌɛkəɹˈiːsts]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-010",
+            "text": {
+                "pt": "Lucas descreve Sophie.",
+                "en": "Lucas describes Sophie."
+            },
+            "ipa": {
+                "pt": "[lˈukæz dˌeskrˈɛvy sˌofˈiy]",
+                "en": "[lˈuːkəz dɪskɹˈaɪbz sˈəʊfi]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-011",
+            "text": {
+                "fr": "Le jeune homme a dit qu'elle portait une veste rouge",
+                "en": "The young man said she was wearing a red jacket",
+                "de": "Der junge Mann sagte, sie trug eine rote Jacke",
+                "it": "Il ragazzo ha detto che indossava una giacca rossa",
+                "es": "El joven dijo que llevaba una chaqueta roja",
+                "nl": "De jongeman zei dat ze een rode jas droeg",
+                "pt": "O rapaz disse que ela estava com uma jaqueta vermelha.",
+                "en_pt": "The young man said she was wearing a red jacket."
+            },
+            "ipa": {
+                "fr": "lə- ʒˈøn ˈɔm a dˈi kɛl pɔʁtˈɛt yn vˈɛst ʁˈuʒ",
+                "de": "[deːɐ̯ ˈjʊŋə man ˈzaːktə ziː tʁuːk ˈaɪnə ˈʁoːtə ˈjakə]",
+                "it": "[ˌil raɡˈatsːo ˌa dˈetːo kˌe ˌindossˈaːva ˌʊna dʒˈakːa rˈossa]",
+                "es": "[el ˈxoβen ˈðixo ke ʝeˈβaβa ˈuna tʃaˈketa ˈroxa]",
+                "nl": "[də jˈɔŋəmˌɑn zˈɛɪ dɑt zə ən rˈoːdə jˈɑs drˈux]",
+                "pt": "[ʊ xapˈaz dʒˈisy ky ˌɛlæ estˌavæ koŋ ˌumæ ʒˌakˈetæ vˌeɾəmˈeljæ]",
+                "en": "[ðə jˈʌŋ mˈan sˈɛd ʃiː wɒz wˈeəɹɪŋ ɐ ɹˈɛd dʒˈakɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-012",
+            "text": {
+                "fr": "Ça nous aidera.",
+                "en": "That will help us.",
+                "de": "Das wird uns helfen.",
+                "it": "Ciò ci aiuterà.",
+                "es": "Eso nos ayudará.",
+                "nl": "Dat zal ons helpen.",
+                "pt": "Isso vai ajudar.",
+                "en_pt": "That will help."
+            },
+            "ipa": {
+                "fr": "sa nuz ɛdʁˈa",
+                "de": "[das vɪʁt ʊns ˈhɛlfən]",
+                "it": "[tʃˈɔ tʃˌɪ ˌajʊterˈa]",
+                "es": "[ˈeso nos aʝuˈðaɾa]",
+                "nl": "[dɑt zɑl ɔns hˈɛlpən]",
+                "pt": "[ˈisʊ vaɪ ˌaʒudˈar]",
+                "en": "[ðat wɪl hˈɛlp ˌʌs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-013",
             "text": {
                 "fr": "Un autre secouriste prépare l'équipement.",
                 "en": "Another rescuer prepares the equipment.",
@@ -735,10 +414,41 @@
             }
         },
         {
-            "id": "scene-13-024",
+            "id": "scene-13-014",
+            "text": {
+                "fr": "J'espère qu'elle soit en sécurité.",
+                "en": "I hope she is safe.",
+                "de": "Ich hoffe, dass sie sicher ist.",
+                "it": "Spero che sia al sicuro.",
+                "es": "Espero que esté segura.",
+                "nl": "Ik hoop dat ze veilig is.",
+                "pt": "Espero que ela esteja segura.",
+                "en_pt": "I hope she's safe."
+            },
+            "ipa": {
+                "fr": "ʒɛspˈɛʁ kɛl swˌa ɑ̃ sekyʁitˈe",
+                "de": "[ɪç ˈhɔfə das ziː ˈzɪçɐ ɪst]",
+                "it": "[spˈɛːro kˌe sˌia ˌal sikˈuːro]",
+                "es": "[esˈpeɾo ke esˈte seˈɣuɾa]",
+                "nl": "[ɪk hˈoːp dɑt zə vˈɛɪləx ɪs]",
+                "pt": "[ˌespˈɛɾʊ ky ˌɛlæ ˌestˈeʒæ sˌeɡˈuɾæ]",
+                "en": "[aɪ hˈəʊp ʃiː ɪz sˈeɪf]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-015",
             "text": {
                 "fr": "Le chef s'adresse à Lucas avec fermeté mais gentillesse.",
-                "en": "The leader addresses Lucas with firmness but kindness.",
+                "en": "The chief addresses Lucas with firmness but kindness.",
                 "de": "Der Leiter spricht mit Lucas fest aber freundlich.",
                 "it": "Il capo si rivolge a Lucas con fermezza ma gentilezza.",
                 "es": "El jefe habla a Lucas con firmeza pero amabilidad.",
@@ -753,7 +463,7 @@
                 "es": "[el ˈxefe ˈaβla a ˈlukas kon fiɾˈmeθa peˈɾo amaβiliˈðað]",
                 "nl": "[də lˈɛɪdər sprˈeːkt lˈykɑs aːn mɛt vˈɑstbɪːrˌaːdənhˌɛɪt maːr vrˈindələkhˌɛɪt]",
                 "pt": "[ʊ ʃˈɛfy sy dʒˌiɾˈiʒj a lˈukæs koŋ fˌiɾəmˈezæ maz ʒˌeɪŋtʃilˈezæ]",
-                "en": "[ðə lˈiːdəɹ ɐdɹˈɛsɪz lˈuːkəz wɪð fˈɜːmnəs bˌʌt kˈaɪndnəs]"
+                "en": "[ðə tʃˈiːf ɐdɹˈɛsɪz lˈuːkəz wɪð fˈɜːmnəs bˌʌt kˈaɪndnəs]"
             },
             "provenance": {
                 "fr": "original",
@@ -766,22 +476,25 @@
             }
         },
         {
-            "id": "scene-13-025",
+            "id": "scene-13-016",
             "text": {
-                "fr": "Lucas respire profondément.",
-                "en": "Lucas takes a deep breath.",
-                "de": "Lucas atmet tief ein.",
-                "it": "Lucas respira profondamente.",
-                "es": "Lucas respira profundamente.",
-                "nl": "Lucas haalt diep adem."
+                "fr": "Nous avons besoin que vous nous montriez sur la carte exactement où vous étiez.",
+                "en": "We need you to show us exactly where you were on the map.",
+                "de": "Wir brauchen, dass ihr uns genau zeigt, wo ihr wart.",
+                "it": "Abbiamo bisogno che ci mostriate sulla mappa esattamente dove eravate.",
+                "es": "Necesitamos que nos muestres en el mapa exactamente donde estabas.",
+                "nl": "We hebben nodig dat je ons precies laat zien op de kaart waar je was.",
+                "pt": "Precisamos que você nos mostre no mapa exatamente onde vocês estavam.",
+                "en_pt": "We need you to show us on the map exactly where you were."
             },
             "ipa": {
-                "fr": "lykˈa ʁɛspˈiʁ pʁɔfɔ̃demˈɑ̃",
-                "de": "[ˈluːkas ˈaːtmət tiːf ˈaɪ̯n]",
-                "it": "[lˈuːkas respˈiːra prˌofondamˈente]",
-                "es": "[ˈlukas resˈpiɾa pɾofunˈdaˈmente]",
-                "nl": "[lˈykɑs hˈaːl tˈip ˈaːdəm]",
-                "en": "[lˈuːkəz tˈeɪks ɐ dˈiːp bɹˈɛθ]"
+                "fr": "nuz avˈɔ̃ bəzwˈɛ̃ kə vu nu mɔ̃tʁiˈe syʁ la- kˈaʁt ɛɡzaktəmˈɑ̃ u vuz etjˈe",
+                "de": "[viːɐ̯ ˈbʁaʊ̯çn̩ das iːɐ̯ ʊns ɡəˈnaʊ̯ ˈtsaɪ̯kt voː iːɐ̯ vaːɐ̯t]",
+                "it": "[abːjˌamo bizˈoɲʲo kˌe tʃˌɪ mˌɔstriˈaːte sˌʊlla mˈapːa ˌezatːamˈente dˈoːve ˌɛravˈaːte]",
+                "es": "[neθeˈsitamos ke nos ˈmwestɾes en el ˈmapa eksakˈtamente ˈðonðe esˈtaβas]",
+                "nl": "[ʋə hˌɛbən nˈoːdəx dɑt jə ɔns preːsˈis lˈaːt zˈin ɔp də kˈaːrt ʋˈaːr jə ʋˈɑs]",
+                "pt": "[prˌesizˈɐ̃mʊs ky vosˌe nʊz mˈɔstry nʊ mˈapæ ˌezatæmˈeɪŋtʃj ˌoŋdʒy vosˌez estˌavɐ̃ʊ̃]",
+                "en": "[wiː nˈiːd juː tə ʃˈəʊ ˌʌs ɛɡzˈaktli wˌeə juː wɜːɹ ɒnðə mˈap]"
             },
             "provenance": {
                 "fr": "original",
@@ -789,26 +502,74 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-13-026",
-            "text": {
-                "pt": "Lucas descreve Sophie.",
-                "en": "Lucas describes Sophie."
-            },
-            "ipa": {
-                "pt": "[lˈukæz dˌeskrˈɛvy sˌofˈiy]",
-                "en": "[lˈuːkəz dɪskɹˈaɪbz sˈəʊfi]"
-            },
-            "provenance": {
                 "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-13-027",
+            "id": "scene-13-017",
+            "text": {
+                "fr": "Il est important que vous restiez calme",
+                "en": "It is important that you remain calm",
+                "de": "Es ist wichtig, dass du ruhig bleibst",
+                "it": "È importante che rimaniate calmo",
+                "es": "Es importante que te mantengas tranquilo",
+                "nl": "Het is belangrijk dat je rustig blijft",
+                "pt": "É importante que você fique calmo.",
+                "en_pt": "It's important that you stay calm."
+            },
+            "ipa": {
+                "fr": "il ɛt ɛ̃pɔʁtˈɑ̃ kə vu ʁɛstjˈe kˈalm",
+                "de": "[ɛs ɪst ˈvɪçtɪç das duː ˈʁuːɪç ˈblaɪ̯pst]",
+                "it": "[ˌɛ ˌimportˈante kˌe rˌimanjˈaːte kˈalmo]",
+                "es": "[es impoɾˈtante ke te manˈteŋɡas tɾanˈkilo]",
+                "nl": "[hət ɪs bəlˈɑŋrɛɪk dɑt jə rˈɵstəx blˈɛɪft]",
+                "pt": "[ɛ ˌimpoɾətˈɐ̃ŋtʃy ky vosˌe fˈiky kˈaʊmʊ]",
+                "en": "[ɪt ɪz ɪmpˈɔːtənt ðat juː ɹɪmˈeɪn kˈɑːm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-018",
+            "text": {
+                "fr": "Nous sommes des professionnels.",
+                "en": "We are professionals.",
+                "de": "Wir sind Profis.",
+                "it": "Siamo professionisti.",
+                "es": "Somos profesionales.",
+                "nl": "Wij zijn professionals.",
+                "pt": "Somos profissionais.",
+                "en_pt": "We're professionals."
+            },
+            "ipa": {
+                "fr": "nu sɔm de- pʁɔfɛsjɔnˈɛl",
+                "de": "[viːɐ̯ zɪnt ˈpʁoːfis]",
+                "it": "[sjˌamo prˌofessˌionˈistɪ]",
+                "es": "[ˈsomos pɾofesjoˈnales]",
+                "nl": "[ʋɛɪ zɛɪn prˈoːfɛʃˌoːnɑls]",
+                "pt": "[sˌomʊs prˌofisˌionˈaɪs]",
+                "en": "[wiː ɑː pɹəfˈɛʃənəlz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-019",
             "text": {
                 "pt": "Lucas respira fundo.",
                 "en": "Lucas takes a deep breath."
@@ -823,7 +584,38 @@
             }
         },
         {
-            "id": "scene-13-028",
+            "id": "scene-13-020",
+            "text": {
+                "fr": "Quoi qu'il arrive, nous la retrouverons, n'est-ce pas?",
+                "en": "Whatever happens, we will find her, won't we?",
+                "de": "Egal was passiert, wir werden sie finden, nicht wahr?",
+                "it": "Qualsiasi cosa succeda, la ritroveremo, vero?",
+                "es": "Pase lo que pase, la encontraremos, ¿verdad?",
+                "nl": "Wat er ook gebeurt, we zullen haar vinden, toch?",
+                "pt": "Aconteça o que acontecer, vamos encontrá-la, não vamos?",
+                "en_pt": "Whatever happens, we'll find her, won't we?"
+            },
+            "ipa": {
+                "fr": "kwˌa kil aʁˈiv nu la- ʁətʁuvʁˈɔ̃ nˈɛs pˈa",
+                "de": "[ˈeːɡal vas paˈsiːɐ̯t viːɐ̯ ˈveːɐ̯dən ziː ˈfɪndən nɪçt vaːɐ̯]",
+                "it": "[kwalsˈiazɪ kˈɔːza sʊtʃːˈeːda\n lˌa rˌitroverˈɛːmo\n vˈeːro]",
+                "es": "[ˈpase lo ke ˈpase, la enkonˈtɾaɾemos, βeɾˈðað]",
+                "nl": "[ʋɑt ər oːk ɣəbˈøːrt\n ʋə zˌɵlən haːr vˈɪndən\n tˈɔx]",
+                "pt": "[ˌakoŋtˈesæ ʊ ky ˌakoŋtesˈer\n vˌɐ̃mʊz ˌeɪŋkoŋtrˈalæ\n nˌɐ̃ʊ̃ vˈɐ̃mʊs]",
+                "en": "[wɒtˈɛvə hˈapənz wiː wɪl fˈaɪnd hɜː wˈəʊnt wiː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-021",
             "text": {
                 "pt": "Sim.",
                 "en": "Yes."
@@ -834,6 +626,215 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-022",
+            "text": {
+                "fr": "Oui. Nous connaissons ces montagnes comme notre poche.",
+                "en": "Yes. We know these mountains like the back of our hand.",
+                "de": "Ja. Wir kennen diese Berge wie unsere Westentasche.",
+                "it": "Sì. Conosciamo queste montagne come le nostre tasche.",
+                "es": "Sí. Conocemos estas montañas como la palma de nuestra mano.",
+                "nl": "Ja. We kennen deze bergen als onze broekzak.",
+                "pt": "Conhecemos essas montanhas como a palma da mão.",
+                "en_pt": "We know these mountains like the back of our hand."
+            },
+            "ipa": {
+                "fr": "wˈi nu kɔnɛsˈɔ̃ se mɔ̃tˈanj kɔm nɔtʁ pˈɔʃ",
+                "de": "[jaː viːɐ̯ ˈkɛnən ˈdiːzə ˈbɛʁɡə viː ʊnzəʁə ˈvɛstn̩ˌtaʃə]",
+                "it": "[sˈi\n kˌonoʃˈaːmo kwˌɛste montˈaɲɲe kˌome lˌe nˌɔstre tˈaske]",
+                "es": "[si koˈnoθemos ˈestas monˈtaɲas komo la ˈpalma ðe ˈnwestɾa ˈmano]",
+                "nl": "[jˈaː\n ʋə kˈɛnən dˌeːzə bˈɛrɣən ɑls ɔnzˌə brˈukzɑk]",
+                "pt": "[kˌoɲesˈemʊz ˈɛsæz mˌoŋtˈɐ̃ɲæs kˌomʊ a pˈaʊmæ da mˈɐ̃ʊ̃]",
+                "en": "[jˈɛs wiː nˈəʊ ðiːz mˈaʊntɪnz lˈaɪk ðə bˈak ɒv aʊə hˈand]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-023",
+            "text": {
+                "fr": "L'hélicoptère partira dès que le temps le permettra",
+                "en": "The helicopter will leave as soon as the weather allows it",
+                "de": "Der Hubschrauber startet, sobald das Wetter es zulässt",
+                "it": "L'elicottero partirà non appena il tempo lo permetterà",
+                "es": "El helicóptero saldrá en cuanto el tiempo lo permita",
+                "nl": "De helikopter vertrekt zodra het weer het toelaat",
+                "pt": "O helicóptero vai partir assim que o tempo permitir.",
+                "en_pt": "The helicopter will leave as soon as the weather permits."
+            },
+            "ipa": {
+                "fr": "lelikɔptˈɛʁ paʁtiʁˈa dɛ kə lə- tˈɑ̃ lə- pɛʁmɛtʁˈa",
+                "de": "[deːɐ̯ ˈhʊpʃʁaʊ̯bɐ ʃtaʁˈtɛt zoˈbalt das ˈvɛtɐ ɛs ˈtsuːlɛst]",
+                "it": "[lˌɛlikˈɔtːero pˌartirˈa nˌon apːˈeːna ˌil tˈɛmpo lˌo pˌɛrmetːerˈa]",
+                "es": "[el elikoˈpteɾo salˈðɾa en ˈkwanto el ˈtjempo lo peɾˈmita]",
+                "nl": "[də hˈeːlikˌɔptər vərtrˈɛkt zɔdrˈaː hət ʋˈɪːr hə tˈulˌaːt]",
+                "pt": "[ʊ ˌelikˈɔpteɾʊ vaɪ paɾətʃˈiɾ asˈiŋ ky ʊ tˈeɪmpʊ pˌeɾəmitʃˈir]",
+                "en": "[ðə hˈɛlɪkˌɒptə wɪl lˈiːv az sˈuːn az ðə wˈɛðəɹ ɐlˈaʊz ɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-024",
+            "text": {
+                "fr": "Au lever du jour.",
+                "en": "At daybreak.",
+                "de": "Beim Tagesanbruch.",
+                "it": "All'alba.",
+                "es": "Al amanecer.",
+                "nl": "Bij het aanbreken van de dag.",
+                "pt": "Ao amanhecer.",
+                "en_pt": "At dawn."
+            },
+            "ipa": {
+                "fr": "o ləvˈe dy- ʒˈuʁ",
+                "de": "[baɪ̯m ˈtaːɡəsˈʔanbʁʊx]",
+                "it": "[allˈalba]",
+                "es": "[al amaneˈθeɾ]",
+                "nl": "[bɛɪ hət ˈaːnbrˌeːkən vɑn də dˈɑx]",
+                "pt": "[aʊ ˌæmɐ̃ɲesˈer]",
+                "en": "[at dˈeɪbɹeɪk]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-025",
+            "text": {
+                "fr": "En attendant, reposez-vous et reprenez des forces",
+                "en": "In the meantime, rest and regain your strength",
+                "de": "In der Zwischenzeit, ruh dich aus und sammle Kräfte.",
+                "it": "Nel frattempo, riposatevi e recuperate le forze",
+                "es": "Mientras tanto, descansa y recupera fuerzas",
+                "nl": "Rust ondertussen uit en verzamel je krachten",
+                "pt": "Enquanto isso, descanse e recupere as forças.",
+                "en_pt": "Meanwhile, rest and recover your strength."
+            },
+            "ipa": {
+                "fr": "ɑ̃n atɑ̃dˈɑ̃ ʁəpozˈevuz e ʁəpʁənˈe de- fˈɔʁs",
+                "de": "[ɪn deːɐ̯ ˈtsvɪʃənˌtsaɪ̯t ˈʁuː dɪç aʊ̯s ʊnt ˈzamlə ˈkʁɛftə]",
+                "it": "[nˌɛl fratːˈɛmpo\n rˌipozˈatevɪ ˌe rˌɛkʊperˈaːte lˌe fˈɔːrtse]",
+                "es": "[mjẽnˈtɾas ˈtanto ðesˈkansa i rekuˈpeɾa ˈfweɾθas]",
+                "nl": "[rˈɵst ˈɔndərtˌɵsən œyt ɛn vərzˈaːməl jə krˈɑxtən]",
+                "pt": "[ˌeɪŋkwˈɐ̃ŋtw ˈisʊ\n dˌeskˈɐ̃ŋsj i xˌekupˈɛɾi as fˈoɾəsæs]",
+                "en": "[ɪnðə mˈiːntaɪm ɹˈɛst and ɹɪɡˈeɪn jɔː stɹˈɛŋθ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-026",
+            "text": {
+                "fr": "Vous ne lui serez d'aucune aide si vous êtes épuisé.",
+                "en": "You will be of no help to her if you are exhausted.",
+                "de": "Du bist ihr keine Hilfe, wenn du erschöpft bist.",
+                "it": "Non sarai di alcun aiuto se sei esausto.",
+                "es": "No serás de ayuda si estás agotado.",
+                "nl": "Je bent geen hulp als je uitgeput bent.",
+                "pt": "Você não vai ajudá-la se estiver exausto.",
+                "en_pt": "You won't help her if you're exhausted."
+            },
+            "ipa": {
+                "fr": "vu nə- lyˌi səʁˈe dokˈyn ˈɛd sˈi vuz ɛtz epyizˈe",
+                "de": "[duː bɪst iːɐ̯ ˈkaɪ̯nə ˈhɪlfe vɛn duː ɛɐ̯ˈʃøpft bɪst]",
+                "it": "[nˌon sarˈaɪ dˌɪ alkˌʊn ajˈuːto sˌe sˌɛj ezˈaʊsto]",
+                "es": "[no seˈɾas ðe aˈʝuða si esˈtas aɣoˈtaðo]",
+                "nl": "[jə bɛnt ɣˈeːn hˈɵlp ɑls jə ˈœytɣəpˌɵt bɛnt]",
+                "pt": "[vosˌe nˌɐ̃ʊ̃ vaɪ ˌaʒudˈalæ sj ˌestʃivˌɛɾ ˌezˈaʊstʊ]",
+                "en": "[juː wɪl biː ɒv nˈəʊ hˈɛlp tə hɜː ɪf juː ɑːɹ ɛɡzˈɔːstɪd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-027",
+            "text": {
+                "fr": "dit un des secouristes.",
+                "en": "says un des secouristes.",
+                "de": "sagt einer der Rettungskräfte.",
+                "it": "dice uno dei soccorritori.",
+                "es": "dice uno de los socorristas.",
+                "nl": "zegt een van de reddingswerkers."
+            },
+            "ipa": {
+                "fr": "dˈi œ̃ de- səkuʁˈist",
+                "de": "[zaːkt ˈaɪ̯nɐ deːɐ̯ ʁɛˈtuŋsˌkʁɛftə]",
+                "it": "[dˈiːtʃe ˈuːno dˌɛj sˌokːorɾitˈoːrɪ]",
+                "es": "[ðiθe ˈuno ðe los soˈkoristas]",
+                "nl": "[zˈɛxt ˈeːn vɑn də rˈɛdɪŋsʋˌɛrkərs]",
+                "en": "[sˈɛz ˈʌn dˈɛs sˌɛkəɹˈiːsts]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-13-028",
+            "text": {
+                "fr": "Lucas respire profondément.",
+                "en": "Lucas breathes deeply.",
+                "de": "Lucas atmet tief ein.",
+                "it": "Lucas respira profondamente.",
+                "es": "Lucas respira profundamente.",
+                "nl": "Lucas haalt diep adem."
+            },
+            "ipa": {
+                "fr": "lykˈa ʁɛspˈiʁ pʁɔfɔ̃demˈɑ̃",
+                "de": "[ˈluːkas ˈaːtmət tiːf ˈaɪ̯n]",
+                "it": "[lˈuːkas respˈiːra prˌofondamˈente]",
+                "es": "[ˈlukas resˈpiɾa pɾofunˈdaˈmente]",
+                "nl": "[lˈykɑs hˈaːl tˈip ˈaːdəm]",
+                "en": "[lˈuːkəz bɹˈiːðz dˈiːpli]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-14.json
+++ b/language_materials/unified/stories/scene-14.json
@@ -24,30 +24,30 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-14-001",
             "text": {
-                "fr": "Cette épreuve m'a fait comprendre quelque chose sur moi-même.",
-                "en": "This ordeal made me understand something about myself.",
-                "de": "Diese Herausforderung hat mir etwas über mich selbst gezeigt.",
-                "it": "Questa prova mi ha fatto capire qualcosa su me stessa.",
-                "es": "Esta prueba me ha hecho entender algo sobre mí misma.",
-                "nl": "Die ervaring heeft me iets over mezelf laten inzien.",
-                "pt": "Esta prova me fez compreender algo sobre mim mesma.",
-                "en_pt": "This trial made me understand something about myself."
+                "fr": "Au lever du jour, Sophie est toujours dans la cabane.",
+                "en": "At daybreak, Sophie is still in the cabin.",
+                "de": "Beim Sonnenaufgang ist Sophie immer noch in der Hütte.",
+                "it": "All'alba, Sophie è ancora nella baita.",
+                "es": "Al amanecer, Sophie sigue en la cabaña.",
+                "nl": "Bij het aanbreken van de dag is Sophie nog steeds in de hut.",
+                "pt": "Ao amanhecer, Sophie ainda está na cabana.",
+                "en_pt": "At dawn, Sophie is still in the cabin."
             },
             "ipa": {
-                "fr": "sɛt epʁˈøv ma fˈɛ kɔ̃pʁˈɑ̃dʁ kˌɛlkə ʃˈoz syʁ mwˌamˈɛm",
-                "de": "[ˈdiːzə hɛˈʁaʊ̯sˌfɔʁdəʁʊŋ hat miːɐ̯ ˈɛtvas ˈyːbɐ mɪç zɛlpst ɡəˈt͡saɪ̯kt]",
-                "it": "[kwˌɛsta prˈɔːva mˌɪ ˌa fˈatːo kapˈiːre kwalkˈɔːza sˌʊ mˌe stˈessa]",
-                "es": "[ˈesta ˈpɾweβa me a ˈeʃo en.tenˈdeɾ ˈalɣo soˈβɾe ˈmi ˈmiz.ma]",
-                "nl": "[di ɛrvˈaːrɪŋ heːft mə ˈits ˈoːvər məsˈɛlf lˈaːtən ˈɪnzˌin]",
-                "pt": "[ˌɛstæ prˈɔvæ my fˈes kˌompreeɪŋdˈeɾ ˈaʊɡʊ sˈobry mˈiŋ mˈezmæ]",
-                "en": "[ðɪs ɔːdˈiəl mˌeɪd mˌiː ˌʌndəstˈand sˈʌmθɪŋ ɐbˌaʊt maɪsˈɛlf]"
+                "fr": "o ləvˈe dy- ʒˈuʁ sɔfˈi ɛ tuʒˌuʁ dɑ̃ la- kabˈan",
+                "de": "[baɪ̯m ˈzɔnənˈaʊ̯fɡaŋ ɪst zɔˈfiː ˈɪmɐ nɔx ɪn deːɐ̯ ˈhʏtə]",
+                "it": "[allˈalba\n sˈopje ˌɛ ankˈoːra nˌɛlla bˈaɪːta]",
+                "es": "[al amaˈneθeɾ ˈsofi ˈsiɣe en la kaˈβaɲa]",
+                "nl": "[bɛɪ hət ˈaːnbrˌeːkən vɑn də dˈɑx ɪ sɔphˈi nˈɔx stˈeːts ɪn də hˈɵt]",
+                "pt": "[aʊ ˌæmɐ̃ɲesˈer\n sˌofˈij ˌaˈiŋdæ estˌa na kˌabˈɐ̃næ]",
+                "en": "[at dˈeɪbɹeɪk sˈəʊfi ɪz stˈɪl ɪnðə kˈabɪn]"
             },
             "provenance": {
                 "fr": "original",
@@ -61,575 +61,6 @@
         },
         {
             "id": "scene-14-002",
-            "text": {
-                "fr": "Je n'aurais jamais cru être capable de survivre seule",
-                "en": "I never thought I would be able to survive on my own.",
-                "de": "Ich hätte nie gedacht, dass ich alleine überleben könnte.",
-                "it": "Non avrei mai creduto di essere capace di sopravvivere da sola.",
-                "es": "Nunca habría creído ser capaz de sobrevivir sola.",
-                "nl": "Ik had nooit gedacht dat ik alleen zou kunnen overleven."
-            },
-            "ipa": {
-                "fr": "ʒə- noʁˈɛ ʒamˌɛ kʁˈy ˈɛtʁ kapˈabl də- syʁvˈivʁ sˈœl",
-                "de": "[ɪç ˈhɛtə niː ɡəˈdaxt das ɪç aˈlaɪ̯nə ˈyːbɐˌleːbn̩ ˈkøntə]",
-                "it": "[nˌon avrˈeːɪ mˌaɪ kredˈuːto dˌɪ ˈɛssere kapˈaːtʃe dˌɪ sˌɔpravvˈivere dˌa sˈoːla]",
-                "es": "[ˈnunka aˈβɾi.a kɾeˈiðo seɾ kaˈpaθ ðe soβɾeˈβiβiɾ ˈsola]",
-                "nl": "[ɪk hˈɑt nˈoːjt ɣədˈɑxt dɑt ɪk ɑlˈeːn zʌʊ kˌɵnən ˌoːvərlˈeːvən]",
-                "en": "[aɪ nˈɛvə θˈɔːt aɪ wʊd biː ˈeɪbəl tə səvˈaɪv ˌɒn maɪ ˈəʊn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-003",
-            "text": {
-                "fr": "Quoi que la vie me réserve, je saurai mieux y faire face",
-                "en": "Whatever life has in store for me, I'll be able to handle it better.",
-                "de": "Was auch immer das Leben für mich bereithält, ich werde besser damit umgehen können.",
-                "it": "Qualunque cosa la vita mi riservi, saprò affrontarla meglio.",
-                "es": "Sea lo que sea que me depare la vida, sabré enfrentarlo mejor.",
-                "nl": "Wat het leven ook voor me in petto heeft, ik zal er beter mee kunnen omgaan.",
-                "pt": "Seja o que for que a vida me reserva, saberei lidar melhor.",
-                "en_pt": "Whatever life has in store for me, I'll know how to deal with it better."
-            },
-            "ipa": {
-                "fr": "kwˌa kə la- vˈi mə- ʁezˈɛʁv ʒə- soʁˈe mjˌø i fˈɛʁ fˈas",
-                "de": "[vas ˈaʊ̯x ˈɪmɐ das ˈleːbn̩ fʏʁ mɪç bəˈʁaɪ̯tˌhɛlt ɪç ˈvɛʁdə ˈbɛsɐ daˈmɪt ˈʊmˌɡeːən ˈkœnən]",
-                "it": "[kwalˈunkwe kˈɔːza lˌa vˈiːta mˌɪ rizˈɛːrvɪ\n saprˈɔ ˌaffrontˈaːrla mˈɛːʎo]",
-                "es": "[ˈsea lo ke ˈsea ke me ðeˈpaɾe la ˈβiða ˈsaβɾe en.fɾenˈtaɾ.lo meˈxoɾ]",
-                "nl": "[ʋɑt hət lˈeːvən oːk vɔːr mə ɪn pˈɛtoː heːft\n ɪk zɑl ər bˈeːtər mˈeː kˌɵnən ɔmɣˈaːn]",
-                "pt": "[sˈeʒæ ʊ ky fˈor ky a vˈidæ my xˌezˈɛɾəvæ\n sˌabeɾˈeɪ lidˈar meljˈɔr]",
-                "en": "[wɒtˈɛvə lˈaɪf hɐz ɪn stˈɔː fɔː mˌiː aɪl biː ˈeɪbəl tə hˈandəl ɪt bˈɛtə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-004",
-            "text": {
-                "fr": "Mais je ne serai jamais prête",
-                "en": "But I will never be completely ready.",
-                "de": "Aber ich werde niemals bereit sein.",
-                "it": "Ma non sarò mai pronta.",
-                "es": "Pero nunca estaré completamente preparada.",
-                "nl": "Maar ik zal nooit helemaal klaar zijn.",
-                "pt": "Mas nunca estarei \"completamente\" pronta.",
-                "en_pt": "But I'll never be \"completely\" ready."
-            },
-            "ipa": {
-                "fr": "mɛ ʒə- nə- səʁˈe ʒamˈɛ pʁˈɛt",
-                "de": "[ˈaːbɐ ɪç ˈvɛʁdə ˈniːmals bəˈʁaɪ̯t zaɪ̯n]",
-                "it": "[mˌa nˌon sarˈɔ mˌaɪ prˈonta]",
-                "es": "[ˈpeɾo ˈnunka es.taˈɾe kom.ple.taˈmente pɾepaˈɾaða]",
-                "nl": "[maːr ɪk zɑl nˈoːjt hˌeːləmˈaːl klˈaːr zɛɪn]",
-                "pt": "[maz nˌũŋkæ ˌestaɾˌeɪ kˌompletæmˈeɪŋtʃy prˈoŋtæ]",
-                "en": "[bˌʌt aɪ wɪl nˈɛvə biː kəmplˈiːtli ɹˈɛdi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-005",
-            "text": {
-                "fr": "Il n'est pas nécessaire d'avoir toujours quelqu'un à ses côtés.",
-                "en": "It's not necessary to always have someone by your side.",
-                "de": "Es ist nicht nötig, immer jemanden an seiner Seite zu haben.",
-                "it": "Non è necessario avere sempre qualcuno al proprio fianco.",
-                "es": "No es necesario tener siempre a alguien al lado.",
-                "nl": "Het is niet nodig om altijd iemand aan je zijde te hebben.",
-                "pt": "Não é necessário ter sempre alguém ao lado."
-            },
-            "ipa": {
-                "fr": "il nɛ pa nesɛsˈɛʁ davwˈaʁ tuʒˌuʁ kɛlkˌœ̃ a se- kotˈe",
-                "de": "[ɛs ɪst nɪçt ˈnøːtɪç ˈɪmɐ ˈjeːmandn̩ an ˈzaɪ̯nɐ ˈzaɪ̯tə tsu ˈhaːbn̩]",
-                "it": "[nˌon ˌɛ nˌetʃessˈario avˈeːre sˈɛmpre kwalkˈuːno ˌal prˈɔprio fjˈanko]",
-                "es": "[no es neseˈsaɾjo ˈteneɾ ˈsjem.pɾe a alˈɣjen al ˈlaðo]",
-                "nl": "[hət ɪs nˌit nˈoːdəx ɔm ˈɑltɛɪt ˈimɑnd aːn jə zˈɛɪdə tə hˌɛbən]",
-                "pt": "[nˌɐ̃ʊ̃ ɛ nˌesesˈaɾjʊ ter sˌeɪmpri aʊɡˈeɪŋ aʊ lˈadʊ]",
-                "en": "[ɪts nˌɒt nˈɛsəsəɹi tʊ ˈɔːlweɪz hav sˈʌmwɒn baɪ jɔː sˈaɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-006",
-            "text": {
-                "fr": "Bien que Lucas me manque terriblement, je me sens plus entière qu'avant",
-                "en": "Although I terribly miss Lucas, I feel more whole than before.",
-                "de": "Obwohl ich Lucas schrecklich vermisse, fühle ich mich vollständiger als vorher.",
-                "it": "Anche se Lucas mi manca tantissimo, mi sento più completa di prima.",
-                "es": "Aunque echo mucho de menos a Lucas, me siento más completa que antes.",
-                "nl": "Hoewel ik Lucas vreselijk mis, voel ik me completer dan voorheen.",
-                "pt": "Embora Lucas me faça muita falta, me sinto mais completa do que antes.",
-                "en_pt": "Although I miss Lucas very much, I feel more complete than before."
-            },
-            "ipa": {
-                "fr": "bjˈɛ̃ kə lykˈa mə- mˈɑ̃k tɛʁibləmˈɑ̃ ʒə- mə- sˈɑ̃ plyz ɑ̃tjˈɛʁ kavˈɑ̃",
-                "de": "[ˈɔpvoːl ɪç ˈluːkas ˈʃʁɛklɪç fɛɐ̯ˈmɪsə fˈyːlə ɪç mɪç ˈfɔlˌʃtɛndɪɡɐ als ˈfoːɐ̯heːɐ]",
-                "it": "[ˈanke sˌe lˈuːkas mˌɪ mˈanka tantˈissimo\n mˌɪ sˈɛnto pjˌʊ komplˈɛːta dˌɪ prˈiːma]",
-                "es": "[aˈunke ˈeʧo ˈmuʧo ðe ˈmenos a ˈlukas me ˈsjento ˈmas komˈpleta ke anˈtes]",
-                "nl": "[huʋˈɛl ɪk lˈykɑs vrˈeːsələk mˈɪs\n vˈul ɪk mə kˈɔmplətər dˈɑn vˈɔːrhˌeːn]",
-                "pt": "[ˌeɪmbˈɔɾæ lˈukæz my fˈasæ mwˈiŋtæ fˈaʊtæ\n my sˈiŋtʊ mˈaɪs kˌomplˈɛtæ dʊ ky ˈɐ̃ŋtʃys]",
-                "en": "[ɒlðˈəʊ aɪ tˈɛɹəblɪ mˈɪs lˈuːkəz aɪ fˈiːl mˈɔː hˈəʊl ðɐn bɪfˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-007",
-            "text": {
-                "fr": "Mais ne signifie pas",
-                "en": "But that does not mean",
-                "de": "Aber das bedeutet nicht",
-                "it": "Ma non significa...",
-                "es": "Pero no significa",
-                "nl": "Maar dat betekent niet"
-            },
-            "ipa": {
-                "fr": "mˈɛ nə- siɲifˈi pˈa",
-                "de": "[ˈaːbɐ das bəˈdɔɪ̯tət nɪçt]",
-                "it": "[mˌa nˌon siɲˈifika]",
-                "es": "[ˈpeɾo no siɣniˈfika]",
-                "nl": "[maːr dɑt bətˈeːkənt nˈit]",
-                "en": "[bˌʌt ðat dʌznˌɒt mˈiːn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-008",
-            "text": {
-                "fr": "—cela signifie",
-                "en": "—it means",
-                "de": "—das bedeutet",
-                "it": "—significa",
-                "es": "—eso significa",
-                "nl": "—dat betekent"
-            },
-            "ipa": {
-                "fr": "səlˌa siɲifˈi",
-                "de": "[—das bəˈdɔɪ̯tət]",
-                "it": "[siɲˈifika]",
-                "es": "[—ˈeso siɣniˈfika]",
-                "nl": "[dɑt bətˈeːkənt]",
-                "en": "[ɪt mˈiːnz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-009",
-            "text": {
-                "fr": "C'est comme si j'avais retrouvé une partie de moi-même que j'avais perdue",
-                "en": "It's as if I've rediscovered a part of myself that I had lost.",
-                "de": "Es ist, als hätte ich einen Teil von mir wiedergefunden, den ich verloren hatte.",
-                "it": "È come se avessi ritrovato una parte di me stessa che avevo perso.",
-                "es": "Es como si hubiera recuperado una parte de mí misma que había perdido.",
-                "nl": "Het is alsof ik een deel van mezelf heb teruggevonden dat ik kwijt was.",
-                "pt": "É como se tivesse encontrado uma parte de mim que tinha perdido.",
-                "en_pt": "It's as if I had found a part of myself that I had lost."
-            },
-            "ipa": {
-                "fr": "sɛ kɔm sˈi ʒavˈɛ ʁətʁuvˈe yn paʁtˈi də- mwˌamˈɛm kə ʒavˈɛ pɛʁdˈy",
-                "de": "[ɛs ɪst als ˈhɛtə ɪç ˈaɪ̯nən taɪ̯l fɔn miːɐ ˈviːdɐɡəˌfʊndn̩ den ɪç fɛɐ̯ˈloːʁən ˈhatə]",
-                "it": "[ˌɛ kˌome sˌe avˌɛssɪ rˌitrovˈaːto ˌʊna pˈaːrte dˌɪ mˌe stˈessa kˌe avˌɛvo pˈɛːrso]",
-                "es": "[es ˈkomo si uˈβjeɾa ɾekupeˈɾaðo ˈuna ˈpaɾte ðe ˈmi ˈmiz.ma ke aˈβi.a perˈðiðo]",
-                "nl": "[hət ɪs ˈɑlsɔf ɪk ən dˈeːl vɑn məsˈɛlf hɛp tərˈɵxəvˌɔndən dɑt ɪk kʋˈɛɪt ʋˈɑs]",
-                "pt": "[ɛ kˌomʊ sy tʃˌivˈɛsj ˌeɪŋkoŋtrˈadw ˌumæ pˈaɾətʃy dʒy mˈiŋ ky tʃˌiɲæ pˌeɾədʒˈidʊ]",
-                "en": "[ɪts az ɪf aɪv ɹˌiːdɪskˈʌvəd ɐ pˈɑːt ɒv maɪsˈɛlf ðat aɪ hɐd lˈɒst]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-010",
-            "text": {
-                "fr": "Mais combien d'autres parties reste-t-il à découvrir?",
-                "en": "But how many other parts are there left to discover?",
-                "de": "Aber wie viele andere Teile gibt es noch zu entdecken?",
-                "it": "Ma quante altre parti restano ancora da scoprire?",
-                "es": "Pero, ¿cuántas partes más quedan por descubrir?",
-                "nl": "Maar hoeveel andere delen zijn er nog te ontdekken?",
-                "pt": "Mas quantas outras partes ainda há para descobrir?",
-                "en_pt": "But how many other parts are there still to discover?"
-            },
-            "ipa": {
-                "fr": "mɛ kɔ̃bjˈɛ̃ dotʁ paʁtˈi ʁˈɛsttil a dekuvʁˈiʁ",
-                "de": "[ˈaːbɐ viː ˈfiːlə ˈandəʁə ˈtaɪ̯lə ɡɪpt ɛs nɔx tsu ɛntˈdɛkn̩]",
-                "it": "[mˌa kwˈante ˈaltre pˈaːrtɪ rˈɛstano ankˈoːra dˌa skoprˈiːre]",
-                "es": "[ˈpeɾo ˈkwantas ˈpaɾtes ˈmas ˈkeðan poɾ ðeskuˈβɾiɾ]",
-                "nl": "[maːr huvˈeːl ˈɑndərə dˈeːlən zɛɪn ər nˈɔx tə ɔntdˈɛkən]",
-                "pt": "[mas kwˈɐ̃ŋtæz ˈowtræs pˈaɾətʃyz ˌaˈiŋdæ a pˌaɾæ dˌeskobrˈir]",
-                "en": "[bˌʌt hˌaʊ mˈɛni ˈʌðə pˈɑːts ɑː ðeə lˈɛft tə dɪskˈʌvə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-011",
-            "text": {
-                "fr": "Le soleil se lève enfin après cette longue nuit.",
-                "en": "The sun is finally rising after this long night.",
-                "de": "Die Sonne geht endlich nach dieser langen Nacht auf.",
-                "it": "Il sole finalmente sorge dopo questa lunga notte.",
-                "es": "El sol finalmente sale después de esta larga noche.",
-                "nl": "De zon komt eindelijk op na deze lange nacht.",
-                "pt": "O sol finalmente nasce depois desta longa noite.",
-                "en_pt": "The sun finally rises after this long night."
-            },
-            "ipa": {
-                "fr": "lə- sɔlˈɛj sə- lˈɛv ɑ̃fˌɛ̃ apʁˌɛ sɛt lˈɔ̃ɡ nyˈi",
-                "de": "[diː ˈzɔnə ɡeːt ˈɛntlɪç naːç ˈdiːzɐ ˈlaŋən naχt aʊ̯f]",
-                "it": "[ˌil sˈoːle fˌinalmˈente sˈoːrdʒe dˈoːpo kwˌɛsta lˈuŋɡa nˈɔtːe]",
-                "es": "[el sol fiˈnal.men.te ˈsale ðesˈpwes ðe ˈesta ˈlaɾɣa ˈnoʧe]",
-                "nl": "[də zˈɔn kˈɔmt ˈɛɪndələk ɔp naː dˌeːzə lˈɑŋə nˈɑxt]",
-                "pt": "[ʊ sˈɔl fˌinaʊmˈeɪŋtʃy nˈasy depˈoɪz dˈɛstæ lˈoŋɡæ nˈoɪtʃy]",
-                "en": "[ðə sˈʌn ɪz fˈaɪnəli ɹˈaɪzɪŋ ˈaftə ðɪs lˈɒŋ nˈaɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-012",
-            "text": {
-                "fr": "Il est temps que je descende chercher de l'aide.",
-                "en": "It's time for me to go look for help.",
-                "de": "Es ist Zeit, dass ich runtergehe und Hilfe suche.",
-                "it": "È ora che scenda a cercare aiuto.",
-                "es": "Es hora de que baje a buscar ayuda.",
-                "nl": "Het is tijd dat ik op zoek ga naar hulp.",
-                "pt": "É hora de descer para procurar ajuda.",
-                "en_pt": "It's time to go down and look for help."
-            },
-            "ipa": {
-                "fr": "il ɛ tˈɑ̃ kə ʒə- dɛsˈɑ̃d ʃɛʁʃˈe də- lˈɛd",
-                "de": "[ɛs ɪst t͡saɪ̯t das ɪç ˈʁʊntɐɡeːə ʊnt ˈhɪlfə ˈzʊxə]",
-                "it": "[ˌɛ ˈɔːra kˌe ʃˈɛnda ˌa tʃerkˈaːre ajˈuːto]",
-                "es": "[es ˈoɾa ðe ke ˈβaxe a busˈkaɾ aˈʝuða]",
-                "nl": "[hət ɪs tˈɛɪd dɑt ɪk ɔp zˈuk ɣˈaː naːr hˈɵlp]",
-                "pt": "[ɛ ˈɔɾæ dʒy desˈer pˌaɾæ prˌokuɾˈaɾ ˌaʒˈudæ]",
-                "en": "[ɪts tˈaɪm fɔː mˌiː tə ɡˌəʊ lˈʊk fɔː hˈɛlp]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-013",
-            "text": {
-                "fr": "Cette nuit m'a transformée",
-                "en": "This night has transformed me.",
-                "de": "Diese Nacht hat mich verändert.",
-                "it": "Questa notte mi ha trasformata.",
-                "es": "Esta noche me ha transformado.",
-                "nl": "Deze nacht heeft mij veranderd.",
-                "pt": "Esta noite me transformou."
-            },
-            "ipa": {
-                "fr": "sɛt nyˈi ma tʁɑ̃sfɔʁmˈe",
-                "de": "[ˈdiːzə naχt hat mɪç fɛɐˈʔɛndɐt]",
-                "it": "[kwˌɛsta nˈɔtːe mˌɪ ˌa trˌasformˈaːta]",
-                "es": "[ˈesta ˈnoʧe me a tɾansfoɾˈmaðo]",
-                "nl": "[dˌeːzə nˈɑxt heːft mˈɛɪ vərˈɑndərt]",
-                "pt": "[ˌɛstæ nˈoɪtʃy my trˌɐ̃ŋsfoɾəmˈow]",
-                "en": "[ðɪs nˈaɪt hɐz tɹansfˈɔːmd mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-014",
-            "text": {
-                "fr": "Mais toute transformation implique aussi une perte",
-                "en": "But every transformation also involves a loss.",
-                "de": "Aber jede Veränderung bedeutet auch einen Verlust.",
-                "it": "Ma ogni trasformazione implica anche una perdita.",
-                "es": "Pero toda transformación también implica una pérdida.",
-                "nl": "Maar elke transformatie betekent ook een verlies.",
-                "pt": "Mas toda transformação implica também uma perda—perdi minha inocência, minha ingenuidade.",
-                "en_pt": "But every transformation also implies a loss—I lost my innocence, my naivety."
-            },
-            "ipa": {
-                "fr": "mɛ tut tʁɑ̃sfɔʁmasjˈɔ̃ ɛ̃plˈik osˌi yn pˈɛʁt",
-                "de": "[ˈaːbɐ ˈjeːdə fɛɐˈʔɛndəʁʊŋ bəˈdɔɪ̯tət ˈaʊ̯x ˈaɪ̯nən fɛɐˈlʊst]",
-                "it": "[mˌa ˈoɲʲɪ trˌasformˌatsiˈɔːne ˈimplika ˈanke ˌʊna pˈɛrdita]",
-                "es": "[ˈpeɾo ˈtoða tɾansfoɾmaˈsjon tamˈbjen imˈplika ˈuna ˈpeɾðiða]",
-                "nl": "[maːr ˈɛlkə trˌɑnsfɔrmˈaːtsi bətˈeːkənt oːk ən vərlˈis]",
-                "pt": "[mas tˈodæ trˌɐ̃ŋsfoɾəmasˈɐ̃ʊ̃ ˌimplˈikæ tɐ̃mbˈeɪŋ ˌumæ pˈeɾədæ peɾədʒˈi mˌiɲæ ˌinosˈeɪŋsjæ\n mˌiɲæ ˌiŋʒenuɪdˈadʒy]",
-                "en": "[bˌʌt ˈɛvɹɪ tɹansfɔːmˈeɪʃən ˈɒlsəʊ ɪnvˈɒlvz ɐ lˈɒs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-015",
-            "text": {
-                "fr": "j'ai perdu mon innocence, ma naïveté",
-                "en": "I've lost my innocence, my naivety.",
-                "de": "Ich habe meine Unschuld, meine Naivität verloren.",
-                "it": "Ho perso la mia innocenza, la mia ingenuità.",
-                "es": "He perdido mi inocencia, mi ingenuidad.",
-                "nl": "Ik ben mijn onschuld, mijn naïviteit kwijtgeraakt."
-            },
-            "ipa": {
-                "fr": "ʒe pɛʁdˈy mɔ̃n inɔsˈɑ̃s ma- naivtˈe",
-                "de": "[ɪç haːbə ˈmaɪ̯nə ˈʊnʃʊlt ˈmaɪ̯nə naɪ̯iˈviːtɛːt fɛɐ̯ˈloːʁən]",
-                "it": "[ˌo pˈɛːrso lˌa mˌia ˌinnotʃˈɛntsa\n lˌa mˌia ˌindʒenˌʊitˈa]",
-                "es": "[e peɾˈðiðo mi inoˈθenθja mi iŋɡeˈnwiðað]",
-                "nl": "[ɪk bɛn mɛɪn ɔnsxˈɵlt\n mɛɪn nˌaːivitˈɛɪt kʋˈɛɪtɣɪːrˌaːkt]",
-                "en": "[aɪv lˈɒst maɪ ˈɪnəsəns maɪ naɪˈiːvɪti]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-016",
-            "text": {
-                "fr": "Je ne peux plus prétendre que la vie est simple.",
-                "en": "I can no longer pretend that life is simple.",
-                "de": "Ich kann nicht mehr vorgeben, dass das Leben einfach ist.",
-                "it": "Non posso più fingere che la vita sia semplice.",
-                "es": "Ya no puedo pretender que la vida es simple.",
-                "nl": "Ik kan niet meer doen alsof het leven simpel is.",
-                "pt": "Não posso mais fingir que a vida é simples."
-            },
-            "ipa": {
-                "fr": "ʒə- nə- pˈø ply pʁetˈɑ̃dʁ kə la- vˈi ɛ sˈɛ̃pl",
-                "de": "[ɪç kan nɪçt meːɐ fɔɐ̯ˈɡeːbn̩ das das ˈleːbn̩ ˈaɪ̯nfax ɪst]",
-                "it": "[nˌon pˈɔsso pjˌʊ fˈindʒere kˌe lˌa vˈiːta sˌia sˈemplitʃe]",
-                "es": "[ˈʝa no ˈpwedo pɾetenˈdeɾ ke la ˈβiða es ˈsimple]",
-                "nl": "[ɪk kɑn nˈit mˌeːr dˈun ˈɑlsɔf hət lˈeːvən sˈɪmpəl ɪs]",
-                "pt": "[nˌɐ̃ʊ̃ pˌɔsʊ mˈaɪs fiŋʒˈir ky a vˈidæ ɛ sˈimplys]",
-                "en": "[aɪ kan nˌəʊ lˈɒŋɡə pɹɪtˈɛnd ðat lˈaɪf ɪz sˈɪmpəl]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-017",
-            "text": {
-                "fr": "Cette cabane, cette montagne..",
-                "en": "This cabin, these mountains...",
-                "de": "Diese Hütte, diese Berge..",
-                "it": "Questa baita, queste montagne...",
-                "es": "Esa cabaña, esos Pirineos...",
-                "nl": "Die hut, die bergen...",
-                "pt": "Esta cabana, esta montanha...",
-                "en_pt": "This cabin, this mountain..."
-            },
-            "ipa": {
-                "fr": "sɛt kabˈan sɛt mɔ̃tˈaɲ",
-                "de": "[ˈdiːzə ˈhʏtə ˈdiːzə ˈbɛʁɡə]",
-                "it": "[kwˌɛsta bˈaɪːta\n kwˌɛste montˈaɲɲe]",
-                "es": "[ˈesa kaˈβaɲa ˈesos piɾiˈneos]",
-                "nl": "[di hˈɵt\n di bˈɛrɣən]",
-                "pt": "[ˌɛstæ kˌabˈɐ̃næ\n ˌɛstæ mˌoŋtˈɐ̃ɲæ]",
-                "en": "[ðɪs kˈabɪn ðiːz mˈaʊntɪnz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-018",
-            "text": {
-                "fr": "elles continueront d'exister après mon départ, indifférentes à mon histoire.",
-                "en": "they will continue to exist after I leave, indifferent to my story.",
-                "de": "sie werden weiterexistieren, nachdem ich gegangen bin, gleichgültig gegenüber meiner Geschichte.",
-                "it": "continueranno ad esistere dopo la mia partenza, indifferenti alla mia storia.",
-                "es": "Continuarán existiendo después de mi partida, indiferentes a mi historia.",
-                "nl": "ze zullen blijven bestaan na mijn vertrek, onverschillig voor mijn verhaal.",
-                "pt": "continuarão existindo depois da minha partida, indiferentes à minha história.",
-                "en_pt": "will continue to exist after my departure, indifferent to my story."
-            },
-            "ipa": {
-                "fr": "ɛl kɔ̃tinyʁˈɔ̃ dɛɡzistˈe apʁˌɛ mɔ̃ depˈaʁ ɛ̃difeʁˈɑ̃tz a mɔ̃n istwˈaʁ",
-                "de": "[ziː ˈvɛʁdn̩ ˈvaɪ̯tɐʔɛkzɪˈstɪʁən naχˈdeːm ɪç ɡəˈɡaŋən bɪn ˈɡlaɪçˌɡʏltɪç ɡəˈɡnʏːbɐ ˈmaɪ̯nɐ ɡəˈʃɪçtə]",
-                "it": "[kˌontinˌʊerˈanno ˌad ezˈistere dˈoːpo lˌa mˌia partˈɛntsa\n ˌindifferˈɛntɪ ˌalla mˌia stˈɔria]",
-                "es": "[kontinwaˈɾan eksisˈtjendo ðesˈpwes ðe mi paɾˈtiða inðiˈfeɾentes a mi isˈtoɾja]",
-                "nl": "[zə zˌɵlən blˈɛɪvən bəstˈaːn naː mɛɪn vərtrˈɛk\n ɔnvərsxˈɪləx vɔːr mɛɪn vərhˈaːl]",
-                "pt": "[kˌoŋtʃinˌuaɾˈɐ̃ʊ̃ ˌezistʃˈiŋdʊ depˈoɪz da mˌiɲæ pˌaɾətʃˈidæ\n ˌiŋdʒifeɾˈeɪŋtʃyz ˌaː mˌiɲæ ˌistˈɔɾjæ]",
-                "en": "[ðeɪ wɪl kəntˈɪnjuː tʊ ɛɡzˈɪst ˈaftəɹ aɪ lˈiːv ɪndˈɪfɹənt tə maɪ stˈɔːɹɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-019",
-            "text": {
-                "fr": "Sophie, novembre 2024. La montagne enseigne.",
-                "en": "Sophie, November 2024. The mountains teach.",
-                "de": "Sophie, November 2024. Die Berge lehren.",
-                "it": "Sophie, novembre 2024. La montagna insegna.",
-                "es": "Sophie, noviembre de 2024. La montaña enseña.",
-                "nl": "Sophie, november 2024. De bergen onderwijzen.",
-                "pt": "A montanha ensina.",
-                "en_pt": "The mountain teaches."
-            },
-            "ipa": {
-                "fr": "sɔfˈi nɔvˈɑ̃bʁ dø mil vɛ̃tkˈatʁ la- mɔ̃tˈaɲ ɑ̃sˈɛɲ",
-                "de": "[zɔˈfiː noˈvɛmbɐ ˌt͡svaɪ̯ˈtaʊ̯zənt͡sˈvaɪ̯nʊntˈfʏɐ̯t͡sɪç diː ˈbɛʁɡə ˈleːʁən]",
-                "it": "[sˈopje\n novˈɛmbre dˈue mˈila vˌentikwˈatːro\n lˌa montˈaɲɲa insˈeɲʲa]",
-                "es": "[ˈsofi noˈβjembɾe ðe 2024 la monˈtaɲa enˈseɲa]",
-                "nl": "[sɔphˈi\n noːvˈɛmbər tʋˈeː dˌœyzɛnt vˌirɛntʋˌɪntəx\n də bˈɛrɣən ˈɔndərʋˌɛɪzən]",
-                "pt": "[a mˌoŋtˈɐ̃ɲæ ˌeɪŋsˈinæ]",
-                "en": "[sˈəʊfi nəʊvˈɛmbə tˈuː θˈaʊzənd ən twˈɛntifˈɔː ðə mˈaʊntɪnz tˈiːtʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-020",
-            "text": {
-                "fr": "Au lever du jour, Sophie est toujours dans la cabane.",
-                "en": "At dawn, Sophie is still in the cabin.",
-                "de": "Beim Sonnenaufgang ist Sophie immer noch in der Hütte.",
-                "it": "All'alba, Sophie è ancora nella baita.",
-                "es": "Al amanecer, Sophie sigue en la cabaña.",
-                "nl": "Bij het aanbreken van de dag is Sophie nog steeds in de hut.",
-                "pt": "Ao amanhecer, Sophie ainda está na cabana."
-            },
-            "ipa": {
-                "fr": "o ləvˈe dy- ʒˈuʁ sɔfˈi ɛ tuʒˌuʁ dɑ̃ la- kabˈan",
-                "de": "[baɪ̯m ˈzɔnənˈaʊ̯fɡaŋ ɪst zɔˈfiː ˈɪmɐ nɔx ɪn deːɐ̯ ˈhʏtə]",
-                "it": "[allˈalba\n sˈopje ˌɛ ankˈoːra nˌɛlla bˈaɪːta]",
-                "es": "[al amaˈneθeɾ ˈsofi ˈsiɣe en la kaˈβaɲa]",
-                "nl": "[bɛɪ hət ˈaːnbrˌeːkən vɑn də dˈɑx ɪ sɔphˈi nˈɔx stˈeːts ɪn də hˈɵt]",
-                "pt": "[aʊ ˌæmɐ̃ɲesˈer\n sˌofˈij ˌaˈiŋdæ estˌa na kˌabˈɐ̃næ]",
-                "en": "[at dˈɔːn sˈəʊfi ɪz stˈɪl ɪnðə kˈabɪn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-021",
             "text": {
                 "fr": "Le feu brûle encore doucement.",
                 "en": "The fire is still burning softly.",
@@ -660,10 +91,10 @@
             }
         },
         {
-            "id": "scene-14-022",
+            "id": "scene-14-003",
             "text": {
                 "fr": "Elle sort et regarde le soleil qui se lève.",
-                "en": "She goes outside and watches the sunrise.",
+                "en": "She goes out and watches the rising sun.",
                 "de": "Sie geht hinaus und schaut auf den aufgehenden Sonnenaufgang.",
                 "it": "Esce e guarda il sole che sorge.",
                 "es": "Sale y observa el sol que se levanta.",
@@ -678,7 +109,7 @@
                 "es": "[ˈsale i oβˈseɾβa el sol ke se leˈβanta]",
                 "nl": "[zə ɣˈaːt naːr bˈœytən ɛn kˈɛɪkt naːr də ˈɔpkˌoːməndə zˈɔn]",
                 "pt": "[ˌɛlæ sˈaɪ i ˈɔljæ ʊ sˈɔl nˌasˈeɪŋdʊ]",
-                "en": "[ʃiː ɡəʊz aʊtsˈaɪd and wˈɒtʃɪz ðə sˈʌnɹaɪz]"
+                "en": "[ʃiː ɡəʊz ˈaʊt and wˈɒtʃɪz ðə ɹˈaɪzɪŋ sˈʌn]"
             },
             "provenance": {
                 "fr": "original",
@@ -691,10 +122,41 @@
             }
         },
         {
-            "id": "scene-14-023",
+            "id": "scene-14-004",
+            "text": {
+                "fr": "Cette épreuve m'a fait comprendre quelque chose sur moi-même.",
+                "en": "This ordeal made me understand something about myself.",
+                "de": "Diese Herausforderung hat mir etwas über mich selbst gezeigt.",
+                "it": "Questa prova mi ha fatto capire qualcosa su me stessa.",
+                "es": "Esta prueba me ha hecho entender algo sobre mí misma.",
+                "nl": "Die ervaring heeft me iets over mezelf laten inzien.",
+                "pt": "Esta prova me fez compreender algo sobre mim mesma.",
+                "en_pt": "This trial made me understand something about myself."
+            },
+            "ipa": {
+                "fr": "sɛt epʁˈøv ma fˈɛ kɔ̃pʁˈɑ̃dʁ kˌɛlkə ʃˈoz syʁ mwˌamˈɛm",
+                "de": "[ˈdiːzə hɛˈʁaʊ̯sˌfɔʁdəʁʊŋ hat miːɐ̯ ˈɛtvas ˈyːbɐ mɪç zɛlpst ɡəˈt͡saɪ̯kt]",
+                "it": "[kwˌɛsta prˈɔːva mˌɪ ˌa fˈatːo kapˈiːre kwalkˈɔːza sˌʊ mˌe stˈessa]",
+                "es": "[ˈesta ˈpɾweβa me a ˈeʃo en.tenˈdeɾ ˈalɣo soˈβɾe ˈmi ˈmiz.ma]",
+                "nl": "[di ɛrvˈaːrɪŋ heːft mə ˈits ˈoːvər məsˈɛlf lˈaːtən ˈɪnzˌin]",
+                "pt": "[ˌɛstæ prˈɔvæ my fˈes kˌompreeɪŋdˈeɾ ˈaʊɡʊ sˈobry mˈiŋ mˈezmæ]",
+                "en": "[ðɪs ɔːdˈiəl mˌeɪd mˌiː ˌʌndəstˈand sˈʌmθɪŋ ɐbˌaʊt maɪsˈɛlf]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-005",
             "text": {
                 "fr": "Elle pense à toutes les fois où elle avait peur, où elle doutait d'elle-même.",
-                "en": "She thinks about all the times she was scared, when she doubted herself.",
+                "en": "She thinks of all the times she was afraid, when she doubted herself.",
                 "de": "Sie denkt an all die Male, als sie Angst hatte und an sich selbst zweifelte.",
                 "it": "Pensa a tutte le volte che aveva paura, che dubitava di sé stessa.",
                 "es": "Piensa en todas las veces que tenía miedo, que dudaba de sí misma.",
@@ -709,7 +171,7 @@
                 "es": "[ˈpjensa en ˈtoðas las ˈβeθes ke ˈti.a ˈmjeðo ke ðuˈðaβa ðe si ˈmiz.ma]",
                 "nl": "[zə dˈɛŋkt aːn ˈɑlə kˈɪːrən dɑt zə bˈɑŋ ʋˈɑs\n dɑt zə aːn zɪxsˈɛlf tʋˈɛɪfəldə]",
                 "pt": "[ˌɛlæ pˈeɪŋsæ ˈeɪŋ tˈodæz az vˈezys ky tˌevy mˈedʊ\n ky dˌuvidˈow dʒy sˈi mˈezmæ]",
-                "en": "[ʃiː θˈɪŋks ɐbˌaʊt ˈɔːl ðə tˈaɪmz ʃiː wɒz skˈeəd wˌɛn ʃiː dˈaʊtɪd hɜːsˈɛlf]"
+                "en": "[ʃiː θˈɪŋks ɒv ˈɔːl ðə tˈaɪmz ʃiː wɒz ɐfɹˈeɪd wˌɛn ʃiː dˈaʊtɪd hɜːsˈɛlf]"
             },
             "provenance": {
                 "fr": "original",
@@ -722,15 +184,46 @@
             }
         },
         {
-            "id": "scene-14-024",
+            "id": "scene-14-006",
+            "text": {
+                "pt": "Nunca pensei ser capaz de sobreviver sozinha.",
+                "en": "I never thought I could survive alone."
+            },
+            "ipa": {
+                "pt": "[nˌũŋkæ peɪŋsˈeɪ ser kapˈaz dʒy sobɾevivˈer sˌozˈiɲæ]",
+                "en": "[aɪ nˈɛvə θˈɔːt aɪ kʊd səvˈaɪv ɐlˈəʊn]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-007",
+            "text": {
+                "pt": "Nunca.",
+                "en": "Never."
+            },
+            "ipa": {
+                "pt": "[nˈũŋkæ]",
+                "en": "[nˈɛvə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-008",
             "text": {
                 "fr": "Elle regarde les montagnes autour d'elle, magnifiques dans la lumière du matin.",
-                "en": "She looks at the mountains around her, beautiful in the morning light.",
+                "en": "She looks at the mountains around her, magnificent in the morning light.",
                 "de": "Sie sieht die Berge um sich herum, herrlich im Morgenlicht.",
                 "it": "Guarda le montagne intorno a sé, magnifiche nella luce del mattino.",
                 "es": "Observa las montañas a su alrededor, magníficas en la luz de la mañana.",
                 "nl": "Ze kijkt naar de bergen om haar heen, prachtig in het ochtendlicht.",
-                "pt": "Ela olha as montanhas ao redor, lindas na luz da manhã."
+                "pt": "Ela olha as montanhas ao redor, lindas na luz da manhã.",
+                "en_pt": "She looks at the mountains around her, beautiful in the morning light."
             },
             "ipa": {
                 "fr": "ɛl ʁəɡˈaʁd le- mɔ̃tˈanjz otˌuʁ dˈɛl maɲifˈik dɑ̃ la- lymjˈɛʁ dy- matˈɛ̃",
@@ -739,7 +232,7 @@
                 "es": "[oβˈseɾβa las monˈtaɲas a su alreˈðeðoɾ maɲiˈfiθas en la luθ ðe la maˈɲana]",
                 "nl": "[zə kˈɛɪkt naːr də bˈɛrɣən ɔm haːr hˈeːn\n prˈɑxtəx ɪn hət ˈɔxtəndlˌɪxt]",
                 "pt": "[ˌɛlæ ˈɔljæ az mˌoŋtˈɐ̃ɲæz aʊ xedˈɔr\n lˈiŋdæz na lˈuz da mɐ̃ɲˈɐ̃]",
-                "en": "[ʃiː lˈʊks at ðə mˈaʊntɪnz ɐɹˈaʊnd hɜː bjˈuːtɪfəl ɪnðə mˈɔːnɪŋ lˈaɪt]"
+                "en": "[ʃiː lˈʊks at ðə mˈaʊntɪnz ɐɹˈaʊnd hɜː maɡnˈɪfɪsənt ɪnðə mˈɔːnɪŋ lˈaɪt]"
             },
             "provenance": {
                 "fr": "original",
@@ -752,7 +245,7 @@
             }
         },
         {
-            "id": "scene-14-025",
+            "id": "scene-14-009",
             "text": {
                 "fr": "Mais maintenant, elle voit aussi leur indifférence.",
                 "en": "But now, she also sees their indifference.",
@@ -783,37 +276,10 @@
             }
         },
         {
-            "id": "scene-14-026",
-            "text": {
-                "fr": "La montagne ne l'a pas sauvée par bonté.",
-                "en": "The mountains have not saved her out of kindness.",
-                "de": "Der Berg hat sie nicht aus Güte gerettet.",
-                "it": "La montagna non l'ha salvata per bontà.",
-                "es": "La montaña no la salvó por bondad.",
-                "nl": "De bergen hebben haar niet uit goedheid gered."
-            },
-            "ipa": {
-                "fr": "la- mɔ̃tˈaɲ nə- la pa sovˈe paʁ bɔ̃tˈe",
-                "de": "[deːɐ̯ ˈbɛʁk hat ziː nɪçt aʊ̯s ˈɡyːtə ɡəˈʁɛtət]",
-                "it": "[lˌa montˈaɲɲa nˌon lˌa salvˈaːta pˌɛr bontˈa]",
-                "es": "[la monˈtaɲa no la salˈβo poɾ bonˈdað]",
-                "nl": "[də bˈɛrɣən hˌɛbən haːr nˌit œyt ɣˈudhɛɪt ɣərˈɛt]",
-                "en": "[ðə mˈaʊntɪnz hɐvnˌɒt sˈeɪvd hɜːɹ ˌaʊtəv kˈaɪndnəs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-14-027",
+            "id": "scene-14-010",
             "text": {
                 "fr": "elle a simplement existé, et Sophie a appris à lire ses signes.",
-                "en": "they just existed, and Sophie has learned to read their signs.",
+                "en": "It simply existed, and Sophie learned to read its signs.",
                 "de": "er hat einfach nur existiert, und Sophie hat gelernt, seine Zeichen zu lesen.",
                 "it": "ha semplicemente esistito, e Sophie ha imparato a leggere i suoi segni.",
                 "es": "Simplemente existió, y Sophie aprendió a interpretar sus señales.",
@@ -828,7 +294,7 @@
                 "es": "[sim.pleˈmente eksisˈtjo i ˈsofi a.pɾenˈðjo a in.teɾpɾeˈtaɾ sus ˈseɲales]",
                 "nl": "[zə hˌɛbən ɣəʋˈoːn bəstˈaːn\n ɛn sɔphˈi heːft ɣəlˈɪːrt hɵn tˈeːkəns tə lˈeːzən]",
                 "pt": "[a mˌoŋtˈɐ̃ɲæ nˌɐ̃ʊ̃ a saʊvˈow por bˌoŋdˈadʒy ˌɛlæ sˌimplezmˈeɪŋtʃj ˌezistʃˈiʊ\n i sˌofˈij ˌapreɪŋdˈeʊ a lˈer seʊs sinˈaɪs]",
-                "en": "[ðeɪ dʒˈʌst ɛɡzˈɪstɪd and sˈəʊfi hɐz lˈɜːnd tə ɹˈiːd ðeə sˈaɪnz]"
+                "en": "[ɪt sˈɪmpli ɛɡzˈɪstɪd and sˈəʊfi lˈɜːnd tə ɹˈiːd ɪts sˈaɪnz]"
             },
             "provenance": {
                 "fr": "original",
@@ -841,7 +307,268 @@
             }
         },
         {
-            "id": "scene-14-028",
+            "id": "scene-14-011",
+            "text": {
+                "fr": "Quoi que la vie me réserve, je saurai mieux y faire face",
+                "en": "Whatever life has in store for me, I will know better how to face it",
+                "de": "Was auch immer das Leben für mich bereithält, ich werde besser damit umgehen können.",
+                "it": "Qualunque cosa la vita mi riservi, saprò affrontarla meglio.",
+                "es": "Sea lo que sea que me depare la vida, sabré enfrentarlo mejor.",
+                "nl": "Wat het leven ook voor me in petto heeft, ik zal er beter mee kunnen omgaan.",
+                "pt": "Seja o que for que a vida me reserva, saberei lidar melhor.",
+                "en_pt": "Whatever life has in store for me, I'll know how to deal with it better."
+            },
+            "ipa": {
+                "fr": "kwˌa kə la- vˈi mə- ʁezˈɛʁv ʒə- soʁˈe mjˌø i fˈɛʁ fˈas",
+                "de": "[vas ˈaʊ̯x ˈɪmɐ das ˈleːbn̩ fʏʁ mɪç bəˈʁaɪ̯tˌhɛlt ɪç ˈvɛʁdə ˈbɛsɐ daˈmɪt ˈʊmˌɡeːən ˈkœnən]",
+                "it": "[kwalˈunkwe kˈɔːza lˌa vˈiːta mˌɪ rizˈɛːrvɪ\n saprˈɔ ˌaffrontˈaːrla mˈɛːʎo]",
+                "es": "[ˈsea lo ke ˈsea ke me ðeˈpaɾe la ˈβiða ˈsaβɾe en.fɾenˈtaɾ.lo meˈxoɾ]",
+                "nl": "[ʋɑt hət lˈeːvən oːk vɔːr mə ɪn pˈɛtoː heːft\n ɪk zɑl ər bˈeːtər mˈeː kˌɵnən ɔmɣˈaːn]",
+                "pt": "[sˈeʒæ ʊ ky fˈor ky a vˈidæ my xˌezˈɛɾəvæ\n sˌabeɾˈeɪ lidˈar meljˈɔr]",
+                "en": "[wɒtˈɛvə lˈaɪf hɐz ɪn stˈɔː fɔː mˌiː aɪ wɪl nˈəʊ bˈɛtə hˌaʊ tə fˈeɪs ɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-012",
+            "text": {
+                "fr": "Mais je ne serai jamais prête",
+                "en": "But I will never be ready",
+                "de": "Aber ich werde niemals bereit sein.",
+                "it": "Ma non sarò mai pronta.",
+                "es": "Pero nunca estaré completamente preparada.",
+                "nl": "Maar ik zal nooit helemaal klaar zijn.",
+                "pt": "Mas nunca estarei \"completamente\" pronta.",
+                "en_pt": "But I'll never be \"completely\" ready."
+            },
+            "ipa": {
+                "fr": "mɛ ʒə- nə- səʁˈe ʒamˈɛ pʁˈɛt",
+                "de": "[ˈaːbɐ ɪç ˈvɛʁdə ˈniːmals bəˈʁaɪ̯t zaɪ̯n]",
+                "it": "[mˌa nˌon sarˈɔ mˌaɪ prˈonta]",
+                "es": "[ˈpeɾo ˈnunka es.taˈɾe kom.ple.taˈmente pɾepaˈɾaða]",
+                "nl": "[maːr ɪk zɑl nˈoːjt hˌeːləmˈaːl klˈaːr zɛɪn]",
+                "pt": "[maz nˌũŋkæ ˌestaɾˌeɪ kˌompletæmˈeɪŋtʃy prˈoŋtæ]",
+                "en": "[bˌʌt aɪ wɪl nˈɛvə biː ɹˈɛdi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-013",
+            "text": {
+                "pt": "Ela pensa em Lucas, em seu relacionamento.",
+                "en": "She thinks about Lucas, about their relationship."
+            },
+            "ipa": {
+                "pt": "[ˌɛlæ pˈeɪŋsæ ˈeɪŋ lˈukæs\n ˈeɪŋ seʊ xˌelasˌionæmˈeɪŋtʊ]",
+                "en": "[ʃiː θˈɪŋks ɐbˌaʊt lˈuːkəz ɐbˌaʊt ðeə ɹɪlˈeɪʃənʃˌɪp]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-014",
+            "text": {
+                "fr": "Il n'est pas nécessaire d'avoir toujours quelqu'un à ses côtés.",
+                "en": "It is not necessary to always have someone by your side.",
+                "de": "Es ist nicht nötig, immer jemanden an seiner Seite zu haben.",
+                "it": "Non è necessario avere sempre qualcuno al proprio fianco.",
+                "es": "No es necesario tener siempre a alguien al lado.",
+                "nl": "Het is niet nodig om altijd iemand aan je zijde te hebben.",
+                "pt": "Não é necessário ter sempre alguém ao lado.",
+                "en_pt": "It's not necessary to always have someone by your side."
+            },
+            "ipa": {
+                "fr": "il nɛ pa nesɛsˈɛʁ davwˈaʁ tuʒˌuʁ kɛlkˌœ̃ a se- kotˈe",
+                "de": "[ɛs ɪst nɪçt ˈnøːtɪç ˈɪmɐ ˈjeːmandn̩ an ˈzaɪ̯nɐ ˈzaɪ̯tə tsu ˈhaːbn̩]",
+                "it": "[nˌon ˌɛ nˌetʃessˈario avˈeːre sˈɛmpre kwalkˈuːno ˌal prˈɔprio fjˈanko]",
+                "es": "[no es neseˈsaɾjo ˈteneɾ ˈsjem.pɾe a alˈɣjen al ˈlaðo]",
+                "nl": "[hət ɪs nˌit nˈoːdəx ɔm ˈɑltɛɪt ˈimɑnd aːn jə zˈɛɪdə tə hˌɛbən]",
+                "pt": "[nˌɐ̃ʊ̃ ɛ nˌesesˈaɾjʊ ter sˌeɪmpri aʊɡˈeɪŋ aʊ lˈadʊ]",
+                "en": "[ɪt ɪz nˌɒt nˈɛsəsəɹi tʊ ˈɔːlweɪz hav sˈʌmwɒn baɪ jɔː sˈaɪd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-015",
+            "text": {
+                "fr": "Bien que Lucas me manque terriblement, je me sens plus entière qu'avant",
+                "en": "Although I miss Lucas terribly, I feel more whole than before",
+                "de": "Obwohl ich Lucas schrecklich vermisse, fühle ich mich vollständiger als vorher.",
+                "it": "Anche se Lucas mi manca tantissimo, mi sento più completa di prima.",
+                "es": "Aunque echo mucho de menos a Lucas, me siento más completa que antes.",
+                "nl": "Hoewel ik Lucas vreselijk mis, voel ik me completer dan voorheen.",
+                "pt": "Embora Lucas me faça muita falta, me sinto mais completa do que antes.",
+                "en_pt": "Although I miss Lucas very much, I feel more complete than before."
+            },
+            "ipa": {
+                "fr": "bjˈɛ̃ kə lykˈa mə- mˈɑ̃k tɛʁibləmˈɑ̃ ʒə- mə- sˈɑ̃ plyz ɑ̃tjˈɛʁ kavˈɑ̃",
+                "de": "[ˈɔpvoːl ɪç ˈluːkas ˈʃʁɛklɪç fɛɐ̯ˈmɪsə fˈyːlə ɪç mɪç ˈfɔlˌʃtɛndɪɡɐ als ˈfoːɐ̯heːɐ]",
+                "it": "[ˈanke sˌe lˈuːkas mˌɪ mˈanka tantˈissimo\n mˌɪ sˈɛnto pjˌʊ komplˈɛːta dˌɪ prˈiːma]",
+                "es": "[aˈunke ˈeʧo ˈmuʧo ðe ˈmenos a ˈlukas me ˈsjento ˈmas komˈpleta ke anˈtes]",
+                "nl": "[huʋˈɛl ɪk lˈykɑs vrˈeːsələk mˈɪs\n vˈul ɪk mə kˈɔmplətər dˈɑn vˈɔːrhˌeːn]",
+                "pt": "[ˌeɪmbˈɔɾæ lˈukæz my fˈasæ mwˈiŋtæ fˈaʊtæ\n my sˈiŋtʊ mˈaɪs kˌomplˈɛtæ dʊ ky ˈɐ̃ŋtʃys]",
+                "en": "[ɒlðˈəʊ aɪ mˈɪs lˈuːkəz tˈɛɹəblɪ aɪ fˈiːl mˈɔː hˈəʊl ðɐn bɪfˈɔː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-016",
+            "text": {
+                "pt": "Mas \"completa\" não significa \"acabada\"—significa \"em devir\".",
+                "en": "But \"complete\" doesn't mean \"finished\"—it means \"becoming.\""
+            },
+            "ipa": {
+                "pt": "[mas kˌomplˈɛtæ nˌɐ̃ʊ̃ sˌiɡnifˈikæ ˌakabˈadæ sˌiɡnifˈikæ ˈeɪŋ devˈir]",
+                "en": "[bˌʌt kəmplˈiːt dˈʌzənt mˈiːn fˈɪnɪʃt ɪt mˈiːnz bɪkˈʌmɪŋ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-017",
+            "text": {
+                "fr": "C'est comme si j'avais retrouvé une partie de moi-même que j'avais perdue",
+                "en": "It's as if I had found a part of myself that I had lost",
+                "de": "Es ist, als hätte ich einen Teil von mir wiedergefunden, den ich verloren hatte.",
+                "it": "È come se avessi ritrovato una parte di me stessa che avevo perso.",
+                "es": "Es como si hubiera recuperado una parte de mí misma que había perdido.",
+                "nl": "Het is alsof ik een deel van mezelf heb teruggevonden dat ik kwijt was.",
+                "pt": "É como se tivesse encontrado uma parte de mim que tinha perdido.",
+                "en_pt": "It's as if I had found a part of myself that I had lost."
+            },
+            "ipa": {
+                "fr": "sɛ kɔm sˈi ʒavˈɛ ʁətʁuvˈe yn paʁtˈi də- mwˌamˈɛm kə ʒavˈɛ pɛʁdˈy",
+                "de": "[ɛs ɪst als ˈhɛtə ɪç ˈaɪ̯nən taɪ̯l fɔn miːɐ ˈviːdɐɡəˌfʊndn̩ den ɪç fɛɐ̯ˈloːʁən ˈhatə]",
+                "it": "[ˌɛ kˌome sˌe avˌɛssɪ rˌitrovˈaːto ˌʊna pˈaːrte dˌɪ mˌe stˈessa kˌe avˌɛvo pˈɛːrso]",
+                "es": "[es ˈkomo si uˈβjeɾa ɾekupeˈɾaðo ˈuna ˈpaɾte ðe ˈmi ˈmiz.ma ke aˈβi.a perˈðiðo]",
+                "nl": "[hət ɪs ˈɑlsɔf ɪk ən dˈeːl vɑn məsˈɛlf hɛp tərˈɵxəvˌɔndən dɑt ɪk kʋˈɛɪt ʋˈɑs]",
+                "pt": "[ɛ kˌomʊ sy tʃˌivˈɛsj ˌeɪŋkoŋtrˈadw ˌumæ pˈaɾətʃy dʒy mˈiŋ ky tʃˌiɲæ pˌeɾədʒˈidʊ]",
+                "en": "[ɪts az ɪf aɪ hɐd fˈaʊnd ɐ pˈɑːt ɒv maɪsˈɛlf ðat aɪ hɐd lˈɒst]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-018",
+            "text": {
+                "fr": "Mais combien d'autres parties reste-t-il à découvrir?",
+                "en": "But how many other parts remain to be discovered?",
+                "de": "Aber wie viele andere Teile gibt es noch zu entdecken?",
+                "it": "Ma quante altre parti restano ancora da scoprire?",
+                "es": "Pero, ¿cuántas partes más quedan por descubrir?",
+                "nl": "Maar hoeveel andere delen zijn er nog te ontdekken?",
+                "pt": "Mas quantas outras partes ainda há para descobrir?",
+                "en_pt": "But how many other parts are there still to discover?"
+            },
+            "ipa": {
+                "fr": "mɛ kɔ̃bjˈɛ̃ dotʁ paʁtˈi ʁˈɛsttil a dekuvʁˈiʁ",
+                "de": "[ˈaːbɐ viː ˈfiːlə ˈandəʁə ˈtaɪ̯lə ɡɪpt ɛs nɔx tsu ɛntˈdɛkn̩]",
+                "it": "[mˌa kwˈante ˈaltre pˈaːrtɪ rˈɛstano ankˈoːra dˌa skoprˈiːre]",
+                "es": "[ˈpeɾo ˈkwantas ˈpaɾtes ˈmas ˈkeðan poɾ ðeskuˈβɾiɾ]",
+                "nl": "[maːr huvˈeːl ˈɑndərə dˈeːlən zɛɪn ər nˈɔx tə ɔntdˈɛkən]",
+                "pt": "[mas kwˈɐ̃ŋtæz ˈowtræs pˈaɾətʃyz ˌaˈiŋdæ a pˌaɾæ dˌeskobrˈir]",
+                "en": "[bˌʌt hˌaʊ mˈɛni ˈʌðə pˈɑːts ɹɪmˈeɪn təbi dɪskˈʌvəd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-019",
+            "text": {
+                "pt": "O sol ilumina agora todo o vale.",
+                "en": "The sun now illuminates the entire valley."
+            },
+            "ipa": {
+                "pt": "[ʊ sˈɔl ˌilumˈinæ ˌaɡˈɔɾæ tˈodw ʊ vˈaly]",
+                "en": "[ðə sˈʌn nˈaʊ ɪlˈuːmɪnˌeɪts ðɪ ɛntˈaɪə vˈalɪ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-020",
+            "text": {
+                "fr": "Le soleil se lève enfin après cette longue nuit.",
+                "en": "The sun finally rises after this long night.",
+                "de": "Die Sonne geht endlich nach dieser langen Nacht auf.",
+                "it": "Il sole finalmente sorge dopo questa lunga notte.",
+                "es": "El sol finalmente sale después de esta larga noche.",
+                "nl": "De zon komt eindelijk op na deze lange nacht.",
+                "pt": "O sol finalmente nasce depois desta longa noite."
+            },
+            "ipa": {
+                "fr": "lə- sɔlˈɛj sə- lˈɛv ɑ̃fˌɛ̃ apʁˌɛ sɛt lˈɔ̃ɡ nyˈi",
+                "de": "[diː ˈzɔnə ɡeːt ˈɛntlɪç naːç ˈdiːzɐ ˈlaŋən naχt aʊ̯f]",
+                "it": "[ˌil sˈoːle fˌinalmˈente sˈoːrdʒe dˈoːpo kwˌɛsta lˈuŋɡa nˈɔtːe]",
+                "es": "[el sol fiˈnal.men.te ˈsale ðesˈpwes ðe ˈesta ˈlaɾɣa ˈnoʧe]",
+                "nl": "[də zˈɔn kˈɔmt ˈɛɪndələk ɔp naː dˌeːzə lˈɑŋə nˈɑxt]",
+                "pt": "[ʊ sˈɔl fˌinaʊmˈeɪŋtʃy nˈasy depˈoɪz dˈɛstæ lˈoŋɡæ nˈoɪtʃy]",
+                "en": "[ðə sˈʌn fˈaɪnəli ɹˈaɪzɪz ˈaftə ðɪs lˈɒŋ nˈaɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-021",
             "text": {
                 "fr": "Elle prend sa décision.",
                 "en": "She makes her decision.",
@@ -871,25 +598,25 @@
             }
         },
         {
-            "id": "scene-14-029",
+            "id": "scene-14-022",
             "text": {
-                "fr": "Elle touche le mur de la cabane avec gratitude et une étrange mélancolie.",
-                "en": "She touches the wall of the cabin with gratitude and a strange melancholy.",
-                "de": "Sie berührt die Wand der Hütte mit Dankbarkeit und einer seltsamen Melancholie.",
-                "it": "Tocca il muro della baita con gratitudine e una strana malinconia.",
-                "es": "Toca la pared de la cabaña con gratitud y una extraña melancolía.",
-                "nl": "Ze raakt de muur van de hut aan met dankbaarheid en een vreemde weemoed.",
-                "pt": "Ela toca a parede da cabana com gratidão e uma estranha melancolia.",
-                "en_pt": "She touches the cabin wall with gratitude and a strange melancholy."
+                "fr": "Il est temps que je descende chercher de l'aide.",
+                "en": "It's time for me to go down and seek help.",
+                "de": "Es ist Zeit, dass ich runtergehe und Hilfe suche.",
+                "it": "È ora che scenda a cercare aiuto.",
+                "es": "Es hora de que baje a buscar ayuda.",
+                "nl": "Het is tijd dat ik op zoek ga naar hulp.",
+                "pt": "É hora de descer para procurar ajuda.",
+                "en_pt": "It's time to go down and look for help."
             },
             "ipa": {
-                "fr": "ɛl tˈuʃ lə- mˈyʁ də- la- kabˈan avˌɛk ɡʁatitˈyd e yn etʁˈɑ̃ʒ melɑ̃kɔlˈi",
-                "de": "[ziː bəˈʁyːɐ̯t diː vant deːɐ̯ ˈhʏtə mɪt ˈdaŋkbaːʁkaɪ̯t ʊnt ˈaɪ̯nɐ ˈzɛltzamən mɛˈlɑŋkoˈliː]",
-                "it": "[tˈokːa ˌil mˈuːro dˌɛlla bˈaɪːta kˌon ɡrˌatitˈudine ˌe ˌʊna strˈaːna mˌalinkonˈiːa]",
-                "es": "[ˈtoka la paˈɾeð ðe la kaˈβaɲa kon ɡɾaˈtiðuð i ˈuna eksˈtɾaɲa melankoˈli.a]",
-                "nl": "[zə rˈaːk tə mˈyr vɑn də hˈɵt aːn mɛ tˈɑŋkbaːrhˌɛɪt ɛn ən vrˈeːmdə ʋeːmˈut]",
-                "pt": "[ˌɛlæ tˈɔkæ a pˌaɾˈedʒy da kˌabˈɐ̃næ koŋ ɡrˌatʃidˈɐ̃ʊ̃ i ˌumæ ˌestrˈɐ̃ɲæ mˌelɐ̃ŋkolˈiæ]",
-                "en": "[ʃiː tˈʌtʃɪz ðə wˈɔːl ɒvðə kˈabɪn wɪð ɡɹˈatɪtjˌuːd and ɐ stɹˈeɪndʒ mˈɛlənkˌɒli]"
+                "fr": "il ɛ tˈɑ̃ kə ʒə- dɛsˈɑ̃d ʃɛʁʃˈe də- lˈɛd",
+                "de": "[ɛs ɪst t͡saɪ̯t das ɪç ˈʁʊntɐɡeːə ʊnt ˈhɪlfə ˈzʊxə]",
+                "it": "[ˌɛ ˈɔːra kˌe ʃˈɛnda ˌa tʃerkˈaːre ajˈuːto]",
+                "es": "[es ˈoɾa ðe ke ˈβaxe a busˈkaɾ aˈʝuða]",
+                "nl": "[hət ɪs tˈɛɪd dɑt ɪk ɔp zˈuk ɣˈaː naːr hˈɵlp]",
+                "pt": "[ɛ ˈɔɾæ dʒy desˈer pˌaɾæ prˌokuɾˈaɾ ˌaʒˈudæ]",
+                "en": "[ɪts tˈaɪm fɔː mˌiː tə ɡˌəʊ dˌaʊn and sˈiːk hˈɛlp]"
             },
             "provenance": {
                 "fr": "original",
@@ -902,82 +629,191 @@
             }
         },
         {
-            "id": "scene-14-030",
+            "id": "scene-14-023",
             "text": {
-                "pt": "Nunca pensei ser capaz de sobreviver sozinha.",
-                "en": "I never thought I could survive alone."
+                "fr": "Cette nuit m'a transformée",
+                "en": "This night has transformed me",
+                "de": "Diese Nacht hat mich verändert.",
+                "it": "Questa notte mi ha trasformata.",
+                "es": "Esta noche me ha transformado.",
+                "nl": "Deze nacht heeft mij veranderd.",
+                "pt": "Esta noite me transformou.",
+                "en_pt": "This night has transformed me."
             },
             "ipa": {
-                "pt": "[nˌũŋkæ peɪŋsˈeɪ ser kapˈaz dʒy sobɾevivˈer sˌozˈiɲæ]",
-                "en": "[aɪ nˈɛvə θˈɔːt aɪ kʊd səvˈaɪv ɐlˈəʊn]"
+                "fr": "sɛt nyˈi ma tʁɑ̃sfɔʁmˈe",
+                "de": "[ˈdiːzə naχt hat mɪç fɛɐˈʔɛndɐt]",
+                "it": "[kwˌɛsta nˈɔtːe mˌɪ ˌa trˌasformˈaːta]",
+                "es": "[ˈesta ˈnoʧe me a tɾansfoɾˈmaðo]",
+                "nl": "[dˌeːzə nˈɑxt heːft mˈɛɪ vərˈɑndərt]",
+                "pt": "[ˌɛstæ nˈoɪtʃy my trˌɐ̃ŋsfoɾəmˈow]",
+                "en": "[ðɪs nˈaɪt hɐz tɹansfˈɔːmd mˌiː]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-14-031",
+            "id": "scene-14-024",
             "text": {
-                "pt": "Nunca.",
-                "en": "Never."
+                "fr": "Mais toute transformation implique aussi une perte",
+                "en": "But every transformation also involves a loss",
+                "de": "Aber jede Veränderung bedeutet auch einen Verlust.",
+                "it": "Ma ogni trasformazione implica anche una perdita.",
+                "es": "Pero toda transformación también implica una pérdida.",
+                "nl": "Maar elke transformatie betekent ook een verlies.",
+                "pt": "Mas toda transformação implica também uma perda—perdi minha inocência, minha ingenuidade.",
+                "en_pt": "But every transformation also implies a loss—I lost my innocence, my naivety."
             },
             "ipa": {
-                "pt": "[nˈũŋkæ]",
-                "en": "[nˈɛvə]"
+                "fr": "mɛ tut tʁɑ̃sfɔʁmasjˈɔ̃ ɛ̃plˈik osˌi yn pˈɛʁt",
+                "de": "[ˈaːbɐ ˈjeːdə fɛɐˈʔɛndəʁʊŋ bəˈdɔɪ̯tət ˈaʊ̯x ˈaɪ̯nən fɛɐˈlʊst]",
+                "it": "[mˌa ˈoɲʲɪ trˌasformˌatsiˈɔːne ˈimplika ˈanke ˌʊna pˈɛrdita]",
+                "es": "[ˈpeɾo ˈtoða tɾansfoɾmaˈsjon tamˈbjen imˈplika ˈuna ˈpeɾðiða]",
+                "nl": "[maːr ˈɛlkə trˌɑnsfɔrmˈaːtsi bətˈeːkənt oːk ən vərlˈis]",
+                "pt": "[mas tˈodæ trˌɐ̃ŋsfoɾəmasˈɐ̃ʊ̃ ˌimplˈikæ tɐ̃mbˈeɪŋ ˌumæ pˈeɾədæ peɾədʒˈi mˌiɲæ ˌinosˈeɪŋsjæ\n mˌiɲæ ˌiŋʒenuɪdˈadʒy]",
+                "en": "[bˌʌt ˈɛvɹɪ tɹansfɔːmˈeɪʃən ˈɒlsəʊ ɪnvˈɒlvz ɐ lˈɒs]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-14-032",
+            "id": "scene-14-025",
             "text": {
-                "pt": "Ela pensa em Lucas, em seu relacionamento.",
-                "en": "She thinks about Lucas, about their relationship."
+                "fr": "Je ne peux plus prétendre que la vie est simple.",
+                "en": "I can no longer pretend that life is simple.",
+                "de": "Ich kann nicht mehr vorgeben, dass das Leben einfach ist.",
+                "it": "Non posso più fingere che la vita sia semplice.",
+                "es": "Ya no puedo pretender que la vida es simple.",
+                "nl": "Ik kan niet meer doen alsof het leven simpel is.",
+                "pt": "Não posso mais fingir que a vida é simples."
             },
             "ipa": {
-                "pt": "[ˌɛlæ pˈeɪŋsæ ˈeɪŋ lˈukæs\n ˈeɪŋ seʊ xˌelasˌionæmˈeɪŋtʊ]",
-                "en": "[ʃiː θˈɪŋks ɐbˌaʊt lˈuːkəz ɐbˌaʊt ðeə ɹɪlˈeɪʃənʃˌɪp]"
+                "fr": "ʒə- nə- pˈø ply pʁetˈɑ̃dʁ kə la- vˈi ɛ sˈɛ̃pl",
+                "de": "[ɪç kan nɪçt meːɐ fɔɐ̯ˈɡeːbn̩ das das ˈleːbn̩ ˈaɪ̯nfax ɪst]",
+                "it": "[nˌon pˈɔsso pjˌʊ fˈindʒere kˌe lˌa vˈiːta sˌia sˈemplitʃe]",
+                "es": "[ˈʝa no ˈpwedo pɾetenˈdeɾ ke la ˈβiða es ˈsimple]",
+                "nl": "[ɪk kɑn nˈit mˌeːr dˈun ˈɑlsɔf hət lˈeːvən sˈɪmpəl ɪs]",
+                "pt": "[nˌɐ̃ʊ̃ pˌɔsʊ mˈaɪs fiŋʒˈir ky a vˈidæ ɛ sˈimplys]",
+                "en": "[aɪ kan nˌəʊ lˈɒŋɡə pɹɪtˈɛnd ðat lˈaɪf ɪz sˈɪmpəl]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-14-033",
+            "id": "scene-14-026",
             "text": {
-                "pt": "Mas \"completa\" não significa \"acabada\"—significa \"em devir\".",
-                "en": "But \"complete\" doesn't mean \"finished\"—it means \"becoming.\""
+                "fr": "Elle touche le mur de la cabane avec gratitude et une étrange mélancolie.",
+                "en": "She touches the cabin wall with gratitude and a strange melancholy.",
+                "de": "Sie berührt die Wand der Hütte mit Dankbarkeit und einer seltsamen Melancholie.",
+                "it": "Tocca il muro della baita con gratitudine e una strana malinconia.",
+                "es": "Toca la pared de la cabaña con gratitud y una extraña melancolía.",
+                "nl": "Ze raakt de muur van de hut aan met dankbaarheid en een vreemde weemoed.",
+                "pt": "Ela toca a parede da cabana com gratidão e uma estranha melancolia."
             },
             "ipa": {
-                "pt": "[mas kˌomplˈɛtæ nˌɐ̃ʊ̃ sˌiɡnifˈikæ ˌakabˈadæ sˌiɡnifˈikæ ˈeɪŋ devˈir]",
-                "en": "[bˌʌt kəmplˈiːt dˈʌzənt mˈiːn fˈɪnɪʃt ɪt mˈiːnz bɪkˈʌmɪŋ]"
+                "fr": "ɛl tˈuʃ lə- mˈyʁ də- la- kabˈan avˌɛk ɡʁatitˈyd e yn etʁˈɑ̃ʒ melɑ̃kɔlˈi",
+                "de": "[ziː bəˈʁyːɐ̯t diː vant deːɐ̯ ˈhʏtə mɪt ˈdaŋkbaːʁkaɪ̯t ʊnt ˈaɪ̯nɐ ˈzɛltzamən mɛˈlɑŋkoˈliː]",
+                "it": "[tˈokːa ˌil mˈuːro dˌɛlla bˈaɪːta kˌon ɡrˌatitˈudine ˌe ˌʊna strˈaːna mˌalinkonˈiːa]",
+                "es": "[ˈtoka la paˈɾeð ðe la kaˈβaɲa kon ɡɾaˈtiðuð i ˈuna eksˈtɾaɲa melankoˈli.a]",
+                "nl": "[zə rˈaːk tə mˈyr vɑn də hˈɵt aːn mɛ tˈɑŋkbaːrhˌɛɪt ɛn ən vrˈeːmdə ʋeːmˈut]",
+                "pt": "[ˌɛlæ tˈɔkæ a pˌaɾˈedʒy da kˌabˈɐ̃næ koŋ ɡrˌatʃidˈɐ̃ʊ̃ i ˌumæ ˌestrˈɐ̃ɲæ mˌelɐ̃ŋkolˈiæ]",
+                "en": "[ʃiː tˈʌtʃɪz ðə kˈabɪn wˈɔːl wɪð ɡɹˈatɪtjˌuːd and ɐ stɹˈeɪndʒ mˈɛlənkˌɒli]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-14-034",
+            "id": "scene-14-027",
             "text": {
-                "pt": "O sol ilumina agora todo o vale.",
-                "en": "The sun now illuminates the entire valley."
+                "fr": "Cette cabane, cette montagne..",
+                "en": "This cabin, this mountain..",
+                "de": "Diese Hütte, diese Berge..",
+                "it": "Questa baita, queste montagne...",
+                "es": "Esa cabaña, esos Pirineos...",
+                "nl": "Die hut, die bergen...",
+                "pt": "Esta cabana, esta montanha...",
+                "en_pt": "This cabin, this mountain..."
             },
             "ipa": {
-                "pt": "[ʊ sˈɔl ˌilumˈinæ ˌaɡˈɔɾæ tˈodw ʊ vˈaly]",
-                "en": "[ðə sˈʌn nˈaʊ ɪlˈuːmɪnˌeɪts ðɪ ɛntˈaɪə vˈalɪ]"
+                "fr": "sɛt kabˈan sɛt mɔ̃tˈaɲ",
+                "de": "[ˈdiːzə ˈhʏtə ˈdiːzə ˈbɛʁɡə]",
+                "it": "[kwˌɛsta bˈaɪːta\n kwˌɛste montˈaɲɲe]",
+                "es": "[ˈesa kaˈβaɲa ˈesos piɾiˈneos]",
+                "nl": "[di hˈɵt\n di bˈɛrɣən]",
+                "pt": "[ˌɛstæ kˌabˈɐ̃næ\n ˌɛstæ mˌoŋtˈɐ̃ɲæ]",
+                "en": "[ðɪs kˈabɪn ðɪs mˈaʊntɪn]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
         },
         {
-            "id": "scene-14-035",
+            "id": "scene-14-028",
+            "text": {
+                "fr": "elles continueront d'exister après mon départ, indifférentes à mon histoire.",
+                "en": "they will continue to exist after my departure, indifferent to my story.",
+                "de": "sie werden weiterexistieren, nachdem ich gegangen bin, gleichgültig gegenüber meiner Geschichte.",
+                "it": "continueranno ad esistere dopo la mia partenza, indifferenti alla mia storia.",
+                "es": "Continuarán existiendo después de mi partida, indiferentes a mi historia.",
+                "nl": "ze zullen blijven bestaan na mijn vertrek, onverschillig voor mijn verhaal.",
+                "pt": "continuarão existindo depois da minha partida, indiferentes à minha história.",
+                "en_pt": "will continue to exist after my departure, indifferent to my story."
+            },
+            "ipa": {
+                "fr": "ɛl kɔ̃tinyʁˈɔ̃ dɛɡzistˈe apʁˌɛ mɔ̃ depˈaʁ ɛ̃difeʁˈɑ̃tz a mɔ̃n istwˈaʁ",
+                "de": "[ziː ˈvɛʁdn̩ ˈvaɪ̯tɐʔɛkzɪˈstɪʁən naχˈdeːm ɪç ɡəˈɡaŋən bɪn ˈɡlaɪçˌɡʏltɪç ɡəˈɡnʏːbɐ ˈmaɪ̯nɐ ɡəˈʃɪçtə]",
+                "it": "[kˌontinˌʊerˈanno ˌad ezˈistere dˈoːpo lˌa mˌia partˈɛntsa\n ˌindifferˈɛntɪ ˌalla mˌia stˈɔria]",
+                "es": "[kontinwaˈɾan eksisˈtjendo ðesˈpwes ðe mi paɾˈtiða inðiˈfeɾentes a mi isˈtoɾja]",
+                "nl": "[zə zˌɵlən blˈɛɪvən bəstˈaːn naː mɛɪn vərtrˈɛk\n ɔnvərsxˈɪləx vɔːr mɛɪn vərhˈaːl]",
+                "pt": "[kˌoŋtʃinˌuaɾˈɐ̃ʊ̃ ˌezistʃˈiŋdʊ depˈoɪz da mˌiɲæ pˌaɾətʃˈidæ\n ˌiŋdʒifeɾˈeɪŋtʃyz ˌaː mˌiɲæ ˌistˈɔɾjæ]",
+                "en": "[ðeɪ wɪl kəntˈɪnjuː tʊ ɛɡzˈɪst ˈaftə maɪ dɪpˈɑːtʃə ɪndˈɪfɹənt tə maɪ stˈɔːɹɪ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-029",
             "text": {
                 "pt": "Antes de partir, ela grava algumas palavras na parede, logo abaixo da inscrição misteriosa: Sophie, novembro 2024.",
                 "en": "Before leaving, she carves some words on the wall, just below the mysterious inscription: Sophie, November 2024."
@@ -988,6 +824,172 @@
             },
             "provenance": {
                 "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-030",
+            "text": {
+                "fr": "Sophie, novembre 2024. La montagne enseigne.",
+                "en": "Sophie, November 2024. The mountain teaches.",
+                "de": "Sophie, November 2024. Die Berge lehren.",
+                "it": "Sophie, novembre 2024. La montagna insegna.",
+                "es": "Sophie, noviembre de 2024. La montaña enseña.",
+                "nl": "Sophie, november 2024. De bergen onderwijzen.",
+                "pt": "A montanha ensina.",
+                "en_pt": "The mountain teaches."
+            },
+            "ipa": {
+                "fr": "sɔfˈi nɔvˈɑ̃bʁ dø mil vɛ̃tkˈatʁ la- mɔ̃tˈaɲ ɑ̃sˈɛɲ",
+                "de": "[zɔˈfiː noˈvɛmbɐ ˌt͡svaɪ̯ˈtaʊ̯zənt͡sˈvaɪ̯nʊntˈfʏɐ̯t͡sɪç diː ˈbɛʁɡə ˈleːʁən]",
+                "it": "[sˈopje\n novˈɛmbre dˈue mˈila vˌentikwˈatːro\n lˌa montˈaɲɲa insˈeɲʲa]",
+                "es": "[ˈsofi noˈβjembɾe ðe 2024 la monˈtaɲa enˈseɲa]",
+                "nl": "[sɔphˈi\n noːvˈɛmbər tʋˈeː dˌœyzɛnt vˌirɛntʋˌɪntəx\n də bˈɛrɣən ˈɔndərʋˌɛɪzən]",
+                "pt": "[a mˌoŋtˈɐ̃ɲæ ˌeɪŋsˈinæ]",
+                "en": "[sˈəʊfi nəʊvˈɛmbə tˈuː θˈaʊzənd ən twˈɛntifˈɔː ðə mˈaʊntɪn tˈiːtʃɪz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-031",
+            "text": {
+                "fr": "Je n'aurais jamais cru être capable de survivre seule",
+                "en": "I never would have believed I was capable of surviving alone",
+                "de": "Ich hätte nie gedacht, dass ich alleine überleben könnte.",
+                "it": "Non avrei mai creduto di essere capace di sopravvivere da sola.",
+                "es": "Nunca habría creído ser capaz de sobrevivir sola.",
+                "nl": "Ik had nooit gedacht dat ik alleen zou kunnen overleven."
+            },
+            "ipa": {
+                "fr": "ʒə- noʁˈɛ ʒamˌɛ kʁˈy ˈɛtʁ kapˈabl də- syʁvˈivʁ sˈœl",
+                "de": "[ɪç ˈhɛtə niː ɡəˈdaxt das ɪç aˈlaɪ̯nə ˈyːbɐˌleːbn̩ ˈkøntə]",
+                "it": "[nˌon avrˈeːɪ mˌaɪ kredˈuːto dˌɪ ˈɛssere kapˈaːtʃe dˌɪ sˌɔpravvˈivere dˌa sˈoːla]",
+                "es": "[ˈnunka aˈβɾi.a kɾeˈiðo seɾ kaˈpaθ ðe soβɾeˈβiβiɾ ˈsola]",
+                "nl": "[ɪk hˈɑt nˈoːjt ɣədˈɑxt dɑt ɪk ɑlˈeːn zʌʊ kˌɵnən ˌoːvərlˈeːvən]",
+                "en": "[aɪ nˈɛvə wʊdhɐv bɪlˈiːvd aɪ wɒz kˈeɪpəbəl ɒv səvˈaɪvɪŋ ɐlˈəʊn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-032",
+            "text": {
+                "fr": "Mais ne signifie pas",
+                "en": "But it does not mean",
+                "de": "Aber das bedeutet nicht",
+                "it": "Ma non significa...",
+                "es": "Pero no significa",
+                "nl": "Maar dat betekent niet"
+            },
+            "ipa": {
+                "fr": "mˈɛ nə- siɲifˈi pˈa",
+                "de": "[ˈaːbɐ das bəˈdɔɪ̯tət nɪçt]",
+                "it": "[mˌa nˌon siɲˈifika]",
+                "es": "[ˈpeɾo no siɣniˈfika]",
+                "nl": "[maːr dɑt bətˈeːkənt nˈit]",
+                "en": "[bˌʌt ɪt dʌznˌɒt mˈiːn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-033",
+            "text": {
+                "fr": "—cela signifie",
+                "en": "—that means",
+                "de": "—das bedeutet",
+                "it": "—significa",
+                "es": "—eso significa",
+                "nl": "—dat betekent"
+            },
+            "ipa": {
+                "fr": "səlˌa siɲifˈi",
+                "de": "[—das bəˈdɔɪ̯tət]",
+                "it": "[siɲˈifika]",
+                "es": "[—ˈeso siɣniˈfika]",
+                "nl": "[dɑt bətˈeːkənt]",
+                "en": "[ðat mˈiːnz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-034",
+            "text": {
+                "fr": "j'ai perdu mon innocence, ma naïveté",
+                "en": "I have lost my innocence, my naivety",
+                "de": "Ich habe meine Unschuld, meine Naivität verloren.",
+                "it": "Ho perso la mia innocenza, la mia ingenuità.",
+                "es": "He perdido mi inocencia, mi ingenuidad.",
+                "nl": "Ik ben mijn onschuld, mijn naïviteit kwijtgeraakt."
+            },
+            "ipa": {
+                "fr": "ʒe pɛʁdˈy mɔ̃n inɔsˈɑ̃s ma- naivtˈe",
+                "de": "[ɪç haːbə ˈmaɪ̯nə ˈʊnʃʊlt ˈmaɪ̯nə naɪ̯iˈviːtɛːt fɛɐ̯ˈloːʁən]",
+                "it": "[ˌo pˈɛːrso lˌa mˌia ˌinnotʃˈɛntsa\n lˌa mˌia ˌindʒenˌʊitˈa]",
+                "es": "[e peɾˈðiðo mi inoˈθenθja mi iŋɡeˈnwiðað]",
+                "nl": "[ɪk bɛn mɛɪn ɔnsxˈɵlt\n mɛɪn nˌaːivitˈɛɪt kʋˈɛɪtɣɪːrˌaːkt]",
+                "en": "[aɪ hav lˈɒst maɪ ˈɪnəsəns maɪ naɪˈiːvɪti]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-14-035",
+            "text": {
+                "fr": "La montagne ne l'a pas sauvée par bonté.",
+                "en": "The mountain did not save her out of kindness.",
+                "de": "Der Berg hat sie nicht aus Güte gerettet.",
+                "it": "La montagna non l'ha salvata per bontà.",
+                "es": "La montaña no la salvó por bondad.",
+                "nl": "De bergen hebben haar niet uit goedheid gered."
+            },
+            "ipa": {
+                "fr": "la- mɔ̃tˈaɲ nə- la pa sovˈe paʁ bɔ̃tˈe",
+                "de": "[deːɐ̯ ˈbɛʁk hat ziː nɪçt aʊ̯s ˈɡyːtə ɡəˈʁɛtət]",
+                "it": "[lˌa montˈaɲɲa nˌon lˌa salvˈaːta pˌɛr bontˈa]",
+                "es": "[la monˈtaɲa no la salˈβo poɾ bonˈdað]",
+                "nl": "[də bˈɛrɣən hˌɛbən haːr nˌit œyt ɣˈudhɛɪt ɣərˈɛt]",
+                "en": "[ðə mˈaʊntɪn dɪdnˌɒt sˈeɪv hɜːɹ ˌaʊtəv kˈaɪndnəs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-15.json
+++ b/language_materials/unified/stories/scene-15.json
@@ -24,253 +24,15 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-15-001",
             "text": {
-                "fr": "J'entends un bruit de moteur au-dessus de moi.",
-                "en": "I hear an engine noise above me.",
-                "de": "Ich höre ein Motorengeräusch über mir.",
-                "it": "Sento un rumore di motore sopra di me.",
-                "es": "Oigo un ruido de motor encima de mí.",
-                "nl": "Ik hoor een motorgeluid boven me.",
-                "pt": "Ouço um barulho de motor acima de mim."
-            },
-            "ipa": {
-                "fr": "ʒɑ̃tˈɑ̃z œ̃ bʁyˈi də- mɔtˈœʁ odəsˈy də- mwˈa",
-                "de": "[ɪ� hoːrə ʔaɪn ˈmoːtoːɐ̯ɡəˌʁɔʏ̯ʃ ˈyːbɐ miːɐ̯]",
-                "it": "[sˈɛnto ˌʊn rʊmˈoːre dˌɪ motˈoːre sˈɔːpra dˌɪ mˈe]",
-                "es": "[ˈoiɣo un ˈrwiðo ðe ˈmotoɾ enˈθima ðe ˈmi]",
-                "nl": "[ɪk hˈoːr ən mˈoːtɔrɣˌeːlœyt bˈoːvən mə]",
-                "pt": "[ˈowsw ũŋ bˌaɾˈuljʊ dʒy motˈoɾ ˌasˈimæ dʒy mˈiŋ]",
-                "en": "[aɪ hˈiəɹ ɐn ˈɛndʒɪn nˈɔɪz əbˈʌv mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-002",
-            "text": {
-                "fr": "C'est un hélicoptère de secours!",
-                "en": "It's a rescue helicopter!",
-                "de": "Das ist ein Rettungshubschrauber!",
-                "it": "È un elicottero di soccorso!",
-                "es": "¡Es un helicóptero de rescate!",
-                "nl": "Het is een reddingshelikopter!",
-                "pt": "É um helicóptero de resgate!"
-            },
-            "ipa": {
-                "fr": "sɛt œ̃n elikɔptˈɛʁ də- səkˈuʁ",
-                "de": "[das ɪst ʔaɪn ˈʁɛtʊŋsˌhʊpʃʁaʊ̯bɐ]",
-                "it": "[ˌɛ ˌʊn ˌɛlikˈɔtːero dˌɪ sokːˈoːrso]",
-                "es": "[es un eliˈkopteɾo ðe resˈkate]",
-                "nl": "[hət ɪs ən rˈɛdɪŋshˌeːlikˌɔptər]",
-                "pt": "[ɛ ũŋ ˌelikˈɔpteɾʊ dʒy xˌezɡˈatʃy]",
-                "en": "[ɪts ɐ ɹˈɛskjuː hˈɛlɪkˌɒptə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-003",
-            "text": {
-                "fr": "Ils me cherchent, il faut que je leur fasse signe!",
-                "en": "They are looking for me, I need to wave!",
-                "de": "Sie suchen mich, ich muss ihnen Zeichen geben!",
-                "it": "Mi stanno cercando, devo far loro un segnale!",
-                "es": "¡Me están buscando, tengo que hacerles señas!",
-                "nl": "Ze zijn me aan het zoeken, ik moet zwaaien!",
-                "pt": "Eles estão me procurando, preciso fazer sinal!",
-                "en_pt": "They're looking for me, I need to signal!"
-            },
-            "ipa": {
-                "fr": "il mə- ʃˈɛʁʃ il fo kə ʒə- lœʁ fˈas sˈiɲ",
-                "de": "[ziː ˈzuːxən mɪ� ɪ� mʊs ˈiːnən ˈt͡saɪ̯çən ˈɡeːbən]",
-                "it": "[mˌɪ stˈanno tʃerkˈando\n dˈɛːvo fˈar lˌɔro ˌʊn seɲˈaːle]",
-                "es": "[me esˈtan busˈkando ˈteŋɣo ke aˈθeɾles ˈseɲas]",
-                "nl": "[zə zɛɪn mə aːn hət zˈukən\n ɪk mˈut zʋˈaːjən]",
-                "pt": "[ˌelyz estˌɐ̃ʊ̃ my prˌokuɾˈɐ̃ŋdʊ\n prˌesˈizʊ fazˌer sinˈaʊ]",
-                "en": "[ðeɪ ɑː lˈʊkɪŋ fɔː mˌiː aɪ nˈiːd tə wˈeɪv]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-004",
-            "text": {
-                "fr": "Là-haut! Je suis ici! Ici!",
-                "en": "Up there! I am here! Here!",
-                "de": "Da oben! Ich bin hier! Hier!",
-                "it": "Lassù! Sono qui! Qui!",
-                "es": "¡Allá arriba! ¡Estoy aquí! ¡Aquí!",
-                "nl": "Daarboven! Ik ben hier! Hier!"
-            },
-            "ipa": {
-                "fr": "lˈaˈo ʒə- syˌiz isˈi isˈi",
-                "de": "[da ˈoːbən ɪ� bɪn hiːɐ̯ hiːɐ̯]",
-                "it": "[lassˈu\n sˌono kwˈi\n kwˈi]",
-                "es": "[ˈaʎa aˈriβa | esˈtoj aˈki | aˈki]",
-                "nl": "[daːrbˈoːvən\n ɪk bɛn hˈir\n hˈir]",
-                "en": "[ˌʌp ðˈeə aɪɐm hˈiə hˈiə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-005",
-            "text": {
-                "fr": "Ils m'ont vue, ils descendent!",
-                "en": "They have seen me, they are coming down!",
-                "de": "Sie haben mich gesehen, sie kommen runter!",
-                "it": "Mi hanno vista, stanno scendendo!",
-                "es": "¡Me han visto, están bajando!",
-                "nl": "Ze hebben me gezien, ze komen naar beneden!",
-                "pt": "Eles me viram, estão descendo!",
-                "en_pt": "They saw me, they're coming down!"
-            },
-            "ipa": {
-                "fr": "il mɔ̃ vˈy il dɛsˈɑ̃d",
-                "de": "[ziː ˈhaːbən mɪ� ɡəˈzeːən ziː ˈkɔmən ˈʁʊntɐ]",
-                "it": "[mˌɪ ˌanno vˈista\n stˈanno ʃendˈɛndo]",
-                "es": "[me an ˈbisto | esˈtan baˈxando]",
-                "nl": "[zə hˌɛbən mə ɣəzˈin\n zə kˈoːmən naːr bənˈeːdən]",
-                "pt": "[ˌelyz my vˈiɾɐ̃ʊ̃\n estˌɐ̃ʊ̃ dˌesˈeɪŋdʊ]",
-                "en": "[ðeɪ hav sˈiːn mˌiː ðeɪ ɑː kˈʌmɪŋ dˈaʊn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-006",
-            "text": {
-                "fr": "Que je suis soulagée!",
-                "en": "What a relief!",
-                "de": "Wie erleichtert ich bin!",
-                "it": "Che sollievo!",
-                "es": "¡Qué aliviada me siento!",
-                "nl": "Wat een opluchting!"
-            },
-            "ipa": {
-                "fr": "kə ʒə- syˌi sulaʒˈe",
-                "de": "[viː ɛɐ̯ˈlaɪ̯�ɐ̯t ɪ� bɪn]",
-                "it": "[kˌe sˌolliˈɛːvo]",
-                "es": "[ke aliˈβjaða me ˈsjento]",
-                "nl": "[ʋɑt ən ˈɔplˌɵxtɪŋ]",
-                "en": "[wˌɒt ɐ ɹɪlˈiːf]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-007",
-            "text": {
-                "fr": "Lucas doit être fou d'inquiétude.",
-                "en": "Lucas must be terribly worried.",
-                "de": "Lucas muss sich wahnsinnig Sorgen machen.",
-                "it": "Lucas deve essere impazzito dall'ansia.",
-                "es": "Lucas debe estar loco de preocupación.",
-                "nl": "Lucas moet zich rot zorgen maken.",
-                "pt": "Lucas deve estar louco de preocupação.",
-                "en_pt": "Lucas must be crazy with worry."
-            },
-            "ipa": {
-                "fr": "lykˈa dwˈa ˈɛtʁ fˈu dɛ̃kjetˈyd",
-                "de": "[ˈluːkas mʊs zɪ� ˈvaːnˈzɪnɪ� ˈzɔʁɡən ˈmaxən]",
-                "it": "[lˈuːkas dˈeːve ˈɛssere ˌimpatsːˈiːto dallˈansia]",
-                "es": "[ˈlukas ˈðeβe esˈtar ˈloko ðe pɾeokuˈpaθjon]",
-                "nl": "[lˈykɑs mˈut zɪx rˈɔt zˈɔrɣən mˈaːkən]",
-                "pt": "[lˈukæz dˈɛvj estˌar lˈowkʊ dʒy prˌeokˌupasˈɐ̃ʊ̃]",
-                "en": "[lˈuːkəz mˈʌst biː tˈɛɹəblɪ wˈʌɹɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-008",
-            "text": {
-                "fr": "Bientôt, nous serons réunis.",
-                "en": "Soon, we will be reunited.",
-                "de": "Bald sind wir wieder zusammen.",
-                "it": "Presto saremo di nuovo insieme.",
-                "es": "Pronto, estaremos juntos.",
-                "nl": "Binnenkort zijn we weer samen.",
-                "pt": "Logo estaremos reunidos.",
-                "en_pt": "Soon we'll be reunited."
-            },
-            "ipa": {
-                "fr": "bjɛ̃tˈo nu səʁˈɔ̃ ʁeynˈi",
-                "de": "[balt zɪnt viːɐ̯ ˈviːdɐ t͡suˈzamən]",
-                "it": "[prˈɛsto sarˌɛmo dˌɪ nʊˈɔːvo insjˈɛːme]",
-                "es": "[ˈpɾonto | estaˈɾemos ˈxuntos]",
-                "nl": "[bˈɪnənkˌɔrt zɛɪn ʋə ʋˈɪːr sˈaːmən]",
-                "pt": "[lˈɔɡw ˌestaɾˌemʊz xˌeunˈidʊs]",
-                "en": "[sˈuːn wiː wɪl biː ɹˌiːjuːnˈaɪtɪd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-15-009",
-            "text": {
                 "fr": "Sophie commence à descendre prudemment.",
-                "en": "Sophie starts to descend cautiously.",
+                "en": "Sophie begins to descend cautiously.",
                 "de": "Sophie beginnt vorsichtig abzusteigen.",
                 "it": "Sophie inizia a scendere con cautela.",
                 "es": "Sophie empieza a bajar con cuidado.",
@@ -285,7 +47,7 @@
                 "es": "[ˈsofi emˈpjeθa a baˈxaɾ kon kwiˈðaðo]",
                 "nl": "[sɔphˈi bəɣˈɪnt vˌɔːrzˈɪxtəx ˈɑf tə dˈaːlən]",
                 "pt": "[sˌofˈiy kˌomˈɛsæ a desˈer koŋ kˌuɪdˈadʊ]",
-                "en": "[sˈəʊfi stˈɑːts tə dɪsˈɛnd kˈɔːʃəsli]"
+                "en": "[sˈəʊfi bɪɡˈɪnz tə dɪsˈɛnd kˈɔːʃəsli]"
             },
             "provenance": {
                 "fr": "original",
@@ -298,7 +60,7 @@
             }
         },
         {
-            "id": "scene-15-010",
+            "id": "scene-15-002",
             "text": {
                 "fr": "Le brouillard s'est levé, le ciel est clair.",
                 "en": "The fog has lifted, the sky is clear.",
@@ -328,7 +90,7 @@
             }
         },
         {
-            "id": "scene-15-011",
+            "id": "scene-15-003",
             "text": {
                 "fr": "Soudain, elle entend un bruit inhabituel.",
                 "en": "Suddenly, she hears an unusual noise.",
@@ -359,16 +121,46 @@
             }
         },
         {
-            "id": "scene-15-012",
+            "id": "scene-15-004",
+            "text": {
+                "fr": "J'entends un bruit de moteur au-dessus de moi.",
+                "en": "I hear a sound of a motor above me.",
+                "de": "Ich höre ein Motorengeräusch über mir.",
+                "it": "Sento un rumore di motore sopra di me.",
+                "es": "Oigo un ruido de motor encima de mí.",
+                "nl": "Ik hoor een motorgeluid boven me.",
+                "pt": "Ouço um barulho de motor acima de mim.",
+                "en_pt": "I hear an engine noise above me."
+            },
+            "ipa": {
+                "fr": "ʒɑ̃tˈɑ̃z œ̃ bʁyˈi də- mɔtˈœʁ odəsˈy də- mwˈa",
+                "de": "[ɪ� hoːrə ʔaɪn ˈmoːtoːɐ̯ɡəˌʁɔʏ̯ʃ ˈyːbɐ miːɐ̯]",
+                "it": "[sˈɛnto ˌʊn rʊmˈoːre dˌɪ motˈoːre sˈɔːpra dˌɪ mˈe]",
+                "es": "[ˈoiɣo un ˈrwiðo ðe ˈmotoɾ enˈθima ðe ˈmi]",
+                "nl": "[ɪk hˈoːr ən mˈoːtɔrɣˌeːlœyt bˈoːvən mə]",
+                "pt": "[ˈowsw ũŋ bˌaɾˈuljʊ dʒy motˈoɾ ˌasˈimæ dʒy mˈiŋ]",
+                "en": "[aɪ hˈiəɹ ɐ sˈaʊnd əvə mˈəʊtəɹ əbˈʌv mˌiː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-005",
             "text": {
                 "fr": "Elle lève les yeux et voit quelque chose dans le ciel.",
-                "en": "She looks up and sees something in the sky.",
+                "en": "She raises her eyes and sees something in the sky.",
                 "de": "Sie blickt hoch und sieht etwas am Himmel.",
                 "it": "Alza gli occhi e vede qualcosa nel cielo.",
                 "es": "Levanta la vista y ve algo en el cielo.",
                 "nl": "Ze kijkt omhoog en ziet iets in de lucht.",
-                "pt": "Ela levanta os olhos e vê algo no céu.",
-                "en_pt": "She raises her eyes and sees something in the sky."
+                "pt": "Ela levanta os olhos e vê algo no céu."
             },
             "ipa": {
                 "fr": "ɛl lˈɛv le-z jˈøz e vwˈa kˌɛlkə ʃˈoz dɑ̃ lə- sjˈɛl",
@@ -377,7 +169,7 @@
                 "es": "[leˈβanta la ˈβista i βe ˈalɣo en el ˈθjelo]",
                 "nl": "[zə kˈɛɪkt ɔmhˈoːx ɛn zˈit ˈits ɪn də lˈɵxt]",
                 "pt": "[ˌɛlæ lˌevˈɐ̃ŋtæ ʊz ˈɔljʊz i vˈe ˈaʊɡʊ nʊ sˈɛʊ]",
-                "en": "[ʃiː lˈʊks ˌʌp and sˈiːz sˈʌmθɪŋ ɪnðə skˈaɪ]"
+                "en": "[ʃiː ɹˈeɪzɪz hɜːɹ ˈaɪz and sˈiːz sˈʌmθɪŋ ɪnðə skˈaɪ]"
             },
             "provenance": {
                 "fr": "original",
@@ -390,15 +182,77 @@
             }
         },
         {
-            "id": "scene-15-013",
+            "id": "scene-15-006",
+            "text": {
+                "fr": "C'est un hélicoptère de secours!",
+                "en": "It's a rescue helicopter!",
+                "de": "Das ist ein Rettungshubschrauber!",
+                "it": "È un elicottero di soccorso!",
+                "es": "¡Es un helicóptero de rescate!",
+                "nl": "Het is een reddingshelikopter!",
+                "pt": "É um helicóptero de resgate!"
+            },
+            "ipa": {
+                "fr": "sɛt œ̃n elikɔptˈɛʁ də- səkˈuʁ",
+                "de": "[das ɪst ʔaɪn ˈʁɛtʊŋsˌhʊpʃʁaʊ̯bɐ]",
+                "it": "[ˌɛ ˌʊn ˌɛlikˈɔtːero dˌɪ sokːˈoːrso]",
+                "es": "[es un eliˈkopteɾo ðe resˈkate]",
+                "nl": "[hət ɪs ən rˈɛdɪŋshˌeːlikˌɔptər]",
+                "pt": "[ɛ ũŋ ˌelikˈɔpteɾʊ dʒy xˌezɡˈatʃy]",
+                "en": "[ɪts ɐ ɹˈɛskjuː hˈɛlɪkˌɒptə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-007",
+            "text": {
+                "fr": "Ils me cherchent, il faut que je leur fasse signe!",
+                "en": "They are looking for me, I have to signal them!",
+                "de": "Sie suchen mich, ich muss ihnen Zeichen geben!",
+                "it": "Mi stanno cercando, devo far loro un segnale!",
+                "es": "¡Me están buscando, tengo que hacerles señas!",
+                "nl": "Ze zijn me aan het zoeken, ik moet zwaaien!",
+                "pt": "Eles estão me procurando, preciso fazer sinal!",
+                "en_pt": "They're looking for me, I need to signal!"
+            },
+            "ipa": {
+                "fr": "il mə- ʃˈɛʁʃ il fo kə ʒə- lœʁ fˈas sˈiɲ",
+                "de": "[ziː ˈzuːxən mɪ� ɪ� mʊs ˈiːnən ˈt͡saɪ̯çən ˈɡeːbən]",
+                "it": "[mˌɪ stˈanno tʃerkˈando\n dˈɛːvo fˈar lˌɔro ˌʊn seɲˈaːle]",
+                "es": "[me esˈtan busˈkando ˈteŋɣo ke aˈθeɾles ˈseɲas]",
+                "nl": "[zə zɛɪn mə aːn hət zˈukən\n ɪk mˈut zʋˈaːjən]",
+                "pt": "[ˌelyz estˌɐ̃ʊ̃ my prˌokuɾˈɐ̃ŋdʊ\n prˌesˈizʊ fazˌer sinˈaʊ]",
+                "en": "[ðeɪ ɑː lˈʊkɪŋ fɔː mˌiː aɪ hav tə sˈɪɡnəl ðˌɛm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-008",
             "text": {
                 "fr": "Elle enlève sa veste rouge et la secoue frénétiquement au-dessus de sa tête.",
-                "en": "She takes off her red jacket and waves it frantically above her head.",
+                "en": "She takes off her red jacket and shakes it frantically above her head.",
                 "de": "Sie zieht ihre rote Jacke aus und schüttelt sie verzweifelt über ihrem Kopf.",
                 "it": "Toglie la sua giacca rossa e la agita freneticamente sopra la testa.",
                 "es": "Se quita la chaqueta roja y la agita frenéticamente sobre su cabeza.",
                 "nl": "Ze trekt haar rode jas uit en zwaait er heftig mee boven haar hoofd.",
-                "pt": "Ela tira sua jaqueta vermelha e a balança freneticamente acima da cabeça."
+                "pt": "Ela tira sua jaqueta vermelha e a balança freneticamente acima da cabeça.",
+                "en_pt": "She takes off her red jacket and waves it frantically above her head."
             },
             "ipa": {
                 "fr": "ɛl ɑ̃lˈɛv sa- vˈɛst ʁˈuʒ e la- səkˈu fʁenetikmˈɑ̃ odəsˈy də- sa- tˈɛt",
@@ -407,7 +261,7 @@
                 "es": "[se ˈkita la tʃaˈketa ˈroxa i la aˈxita fɾeneˈtikamente ˈsoβɾe su kaˈβeθa]",
                 "nl": "[zə trˈɛkt haːr rˈoːdə jˈɑs œyt ɛn zʋˈaːjt ər hˈɛftəx mˈeː bˈoːvən haːr hˈoːft]",
                 "pt": "[ˌɛlæ tʃˈiɾæ sˌuæ ʒˌakˈetæ vˌeɾəmˈeljæ i a bˌalˈɐ̃ŋsæ frˌenetʃˌikæmˈeɪŋtʃj ˌasˈimæ da kˌabˈesæ]",
-                "en": "[ʃiː tˈeɪks ˈɒf hɜː ɹˈɛd dʒˈakɪt and wˈeɪvz ɪt fɹˈantɪkli əbˌʌv hɜː hˈɛd]"
+                "en": "[ʃiː tˈeɪks ˈɒf hɜː ɹˈɛd dʒˈakɪt and ʃˈeɪks ɪt fɹˈantɪkli əbˌʌv hɜː hˈɛd]"
             },
             "provenance": {
                 "fr": "original",
@@ -420,10 +274,55 @@
             }
         },
         {
-            "id": "scene-15-014",
+            "id": "scene-15-009",
+            "text": {
+                "pt": "Aqui em cima!",
+                "en": "Up here!"
+            },
+            "ipa": {
+                "pt": "[akˈi ˈeɪŋ sˈimæ]",
+                "en": "[ˌʌp hˈiə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-010",
+            "text": {
+                "pt": "Estou aqui!",
+                "en": "I'm here!"
+            },
+            "ipa": {
+                "pt": "[estˌow akˈi]",
+                "en": "[aɪm hˈiə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-011",
+            "text": {
+                "pt": "Aqui!",
+                "en": "Here!"
+            },
+            "ipa": {
+                "pt": "[akˈi]",
+                "en": "[hˈiə]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-012",
             "text": {
                 "fr": "L'hélicoptère fait un cercle, puis se rapproche.",
-                "en": "The helicopter circles around and comes closer.",
+                "en": "The helicopter makes a circle, then comes closer.",
                 "de": "Der Hubschrauber macht einen Kreis, dann nähert er sich.",
                 "it": "L'elicottero fa un giro e poi si avvicina.",
                 "es": "El helicóptero hace un círculo, luego se acerca.",
@@ -438,7 +337,68 @@
                 "es": "[el eliˈkopteɾo ˈaθe un ˈθiɾkulo | ˈlweɣo se aˈθeɾka]",
                 "nl": "[də hˈeːlikˌɔptər mˈaːkt ən rˈɔntjə ɛn kˈɔm tˌɪxtərbˈɛɪ]",
                 "pt": "[ʊ ˌelikˈɔpteɾʊ faz ũŋ sˈiɾəkulʊ\n depˈoɪs sj ˌaprosˈimæ]",
-                "en": "[ðə hˈɛlɪkˌɒptə sˈɜːkəlz ɐɹˈaʊnd and kˈʌmz klˈəʊsə]"
+                "en": "[ðə hˈɛlɪkˌɒptə mˌeɪks ɐ sˈɜːkəl ðˈɛn kˈʌmz klˈəʊsə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-013",
+            "text": {
+                "fr": "Ils m'ont vue, ils descendent!",
+                "en": "They saw me, they are coming down!",
+                "de": "Sie haben mich gesehen, sie kommen runter!",
+                "it": "Mi hanno vista, stanno scendendo!",
+                "es": "¡Me han visto, están bajando!",
+                "nl": "Ze hebben me gezien, ze komen naar beneden!",
+                "pt": "Eles me viram, estão descendo!",
+                "en_pt": "They saw me, they're coming down!"
+            },
+            "ipa": {
+                "fr": "il mɔ̃ vˈy il dɛsˈɑ̃d",
+                "de": "[ziː ˈhaːbən mɪ� ɡəˈzeːən ziː ˈkɔmən ˈʁʊntɐ]",
+                "it": "[mˌɪ ˌanno vˈista\n stˈanno ʃendˈɛndo]",
+                "es": "[me an ˈbisto | esˈtan baˈxando]",
+                "nl": "[zə hˌɛbən mə ɣəzˈin\n zə kˈoːmən naːr bənˈeːdən]",
+                "pt": "[ˌelyz my vˈiɾɐ̃ʊ̃\n estˌɐ̃ʊ̃ dˌesˈeɪŋdʊ]",
+                "en": "[ðeɪ sˈɔː mˌiː ðeɪ ɑː kˈʌmɪŋ dˈaʊn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-014",
+            "text": {
+                "fr": "L'émotion la submerge.",
+                "en": "Emotion overwhelms her.",
+                "de": "Die Emotion überwältigt sie.",
+                "it": "L'emozione la travolge.",
+                "es": "La emoción la embarga.",
+                "nl": "De emotie overweldigt haar.",
+                "pt": "A emoção a domina."
+            },
+            "ipa": {
+                "fr": "lemɔsjˈɔ̃ la- sybmˈɛʁʒ",
+                "de": "[diː ʔemoˈt͡si̯oːn ˈyːbɐˌvɛltɪkt ziː]",
+                "it": "[lˌemotsiˈɔːne lˌa travˈoldʒe]",
+                "es": "[la emoˈθjon la emˈβarɣa]",
+                "nl": "[də eːmˈoːtsi ˌoːvərʋˈɛldɪxt haːr]",
+                "pt": "[a ˌemosˈɐ̃ʊ̃ a dˌomˈinæ]",
+                "en": "[ɪmˈəʊʃən ˌəʊvəwˈɛlmz hɜː]"
             },
             "provenance": {
                 "fr": "original",
@@ -453,30 +413,14 @@
         {
             "id": "scene-15-015",
             "text": {
-                "fr": "L'émotion la submerge.",
-                "en": "The emotion overwhelms her.",
-                "de": "Die Emotion überwältigt sie.",
-                "it": "L'emozione la travolge.",
-                "es": "La emoción la embarga.",
-                "nl": "De emotie overweldigt haar.",
-                "pt": "A emoção a domina.",
-                "en_pt": "Emotion overwhelms her."
+                "pt": "Que alívio!",
+                "en": "What a relief!"
             },
             "ipa": {
-                "fr": "lemɔsjˈɔ̃ la- sybmˈɛʁʒ",
-                "de": "[diː ʔemoˈt͡si̯oːn ˈyːbɐˌvɛltɪkt ziː]",
-                "it": "[lˌemotsiˈɔːne lˌa travˈoldʒe]",
-                "es": "[la emoˈθjon la emˈβarɣa]",
-                "nl": "[də eːmˈoːtsi ˌoːvərʋˈɛldɪxt haːr]",
-                "pt": "[a ˌemosˈɐ̃ʊ̃ a dˌomˈinæ]",
-                "en": "[ðɪ ɪmˈəʊʃən ˌəʊvəwˈɛlmz hɜː]"
+                "pt": "[ky ˌalˈivjʊ]",
+                "en": "[wˌɒt ɐ ɹɪlˈiːf]"
             },
             "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -485,12 +429,13 @@
             "id": "scene-15-016",
             "text": {
                 "fr": "Pendant que l'hélicoptère se pose dans une petite clairière, elle pense à Lucas.",
-                "en": "As the helicopter lands in a small clearing, she thinks of Lucas.",
+                "en": "While the helicopter lands in a small clearing, she thinks of Lucas.",
                 "de": "Während der Hubschrauber auf einer kleinen Lichtung landet, denkt sie an Lucas.",
                 "it": "Mentre l'elicottero atterra in una piccola radura, pensa a Lucas.",
                 "es": "Mientras el helicóptero aterriza en un pequeño claro, piensa en Lucas.",
                 "nl": "Terwijl de helikopter landt in een kleine open plek, denkt ze aan Lucas.",
-                "pt": "Enquanto o helicóptero pousa em uma pequena clareira, ela pensa em Lucas."
+                "pt": "Enquanto o helicóptero pousa em uma pequena clareira, ela pensa em Lucas.",
+                "en_pt": "As the helicopter lands in a small clearing, she thinks of Lucas."
             },
             "ipa": {
                 "fr": "pɑ̃dˈɑ̃ kə lelikɔptˈɛʁ sə- pˈoz dɑ̃z yn pətˈit klɛʁjˈɛʁ ɛl pˈɑ̃s a lykˈa",
@@ -499,7 +444,7 @@
                 "es": "[mjẽnˈtɾas el eliˈkopteɾo ateˈriθa en un peˈkeɲo ˈklaɾo | ˈpjẽnsa en ˈlukas]",
                 "nl": "[tˈɛrʋɛɪl də hˈeːlikˌɔptər lˈɑnt ɪn ən klˈɛɪnə ˈoːpən plˈɛk\n dˈɛŋkt zə aːn lˈykɑs]",
                 "pt": "[ˌeɪŋkwˈɐ̃ŋtw ʊ ˌelikˈɔpteɾʊ pˈowzæ ˈeɪŋ ˌumæ pˌekˈenæ klˌaɾˈeɪɾæ\n ˌɛlæ pˈeɪŋsæ ˈeɪŋ lˈukæs]",
-                "en": "[az ðə hˈɛlɪkˌɒptə lˈandz ɪn ɐ smˈɔːl klˈiəɹɪŋ ʃiː θˈɪŋks ɒv lˈuːkəz]"
+                "en": "[wˌaɪl ðə hˈɛlɪkˌɒptə lˈandz ɪn ɐ smˈɔːl klˈiəɹɪŋ ʃiː θˈɪŋks ɒv lˈuːkəz]"
             },
             "provenance": {
                 "fr": "original",
@@ -513,6 +458,37 @@
         },
         {
             "id": "scene-15-017",
+            "text": {
+                "fr": "Lucas doit être fou d'inquiétude.",
+                "en": "Lucas must be frantic with worry.",
+                "de": "Lucas muss sich wahnsinnig Sorgen machen.",
+                "it": "Lucas deve essere impazzito dall'ansia.",
+                "es": "Lucas debe estar loco de preocupación.",
+                "nl": "Lucas moet zich rot zorgen maken.",
+                "pt": "Lucas deve estar louco de preocupação.",
+                "en_pt": "Lucas must be crazy with worry."
+            },
+            "ipa": {
+                "fr": "lykˈa dwˈa ˈɛtʁ fˈu dɛ̃kjetˈyd",
+                "de": "[ˈluːkas mʊs zɪ� ˈvaːnˈzɪnɪ� ˈzɔʁɡən ˈmaxən]",
+                "it": "[lˈuːkas dˈeːve ˈɛssere ˌimpatsːˈiːto dallˈansia]",
+                "es": "[ˈlukas ˈðeβe esˈtar ˈloko ðe pɾeokuˈpaθjon]",
+                "nl": "[lˈykɑs mˈut zɪx rˈɔt zˈɔrɣən mˈaːkən]",
+                "pt": "[lˈukæz dˈɛvj estˌar lˈowkʊ dʒy prˌeokˌupasˈɐ̃ʊ̃]",
+                "en": "[lˈuːkəz mˈʌst biː fɹˈantɪk wɪð wˈʌɹi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-15-018",
             "text": {
                 "fr": "Les secouristes courent vers elle avec une couverture.",
                 "en": "The rescuers run towards her with a blanket.",
@@ -543,31 +519,32 @@
             }
         },
         {
-            "id": "scene-15-018",
-            "text": {
-                "pt": "Aqui em cima!",
-                "en": "Up here!"
-            },
-            "ipa": {
-                "pt": "[akˈi ˈeɪŋ sˈimæ]",
-                "en": "[ˌʌp hˈiə]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
             "id": "scene-15-019",
             "text": {
-                "pt": "Estou aqui!",
-                "en": "I'm here!"
+                "fr": "Bientôt, nous serons réunis.",
+                "en": "Soon, we will be reunited.",
+                "de": "Bald sind wir wieder zusammen.",
+                "it": "Presto saremo di nuovo insieme.",
+                "es": "Pronto, estaremos juntos.",
+                "nl": "Binnenkort zijn we weer samen.",
+                "pt": "Logo estaremos reunidos.",
+                "en_pt": "Soon we'll be reunited."
             },
             "ipa": {
-                "pt": "[estˌow akˈi]",
-                "en": "[aɪm hˈiə]"
+                "fr": "bjɛ̃tˈo nu səʁˈɔ̃ ʁeynˈi",
+                "de": "[balt zɪnt viːɐ̯ ˈviːdɐ t͡suˈzamən]",
+                "it": "[prˈɛsto sarˌɛmo dˌɪ nʊˈɔːvo insjˈɛːme]",
+                "es": "[ˈpɾonto | estaˈɾemos ˈxuntos]",
+                "nl": "[bˈɪnənkˌɔrt zɛɪn ʋə ʋˈɪːr sˈaːmən]",
+                "pt": "[lˈɔɡw ˌestaɾˌemʊz xˌeunˈidʊs]",
+                "en": "[sˈuːn wiː wɪl biː ɹˌiːjuːnˈaɪtɪd]"
             },
             "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "pt": "original",
                 "en": "original"
             }
@@ -575,30 +552,54 @@
         {
             "id": "scene-15-020",
             "text": {
-                "pt": "Aqui!",
-                "en": "Here!"
+                "fr": "Là-haut! Je suis ici! Ici!",
+                "en": "Up there! I'm here! Here!",
+                "de": "Da oben! Ich bin hier! Hier!",
+                "it": "Lassù! Sono qui! Qui!",
+                "es": "¡Allá arriba! ¡Estoy aquí! ¡Aquí!",
+                "nl": "Daarboven! Ik ben hier! Hier!"
             },
             "ipa": {
-                "pt": "[akˈi]",
-                "en": "[hˈiə]"
+                "fr": "lˈaˈo ʒə- syˌiz isˈi isˈi",
+                "de": "[da ˈoːbən ɪ� bɪn hiːɐ̯ hiːɐ̯]",
+                "it": "[lassˈu\n sˌono kwˈi\n kwˈi]",
+                "es": "[ˈaʎa aˈriβa | esˈtoj aˈki | aˈki]",
+                "nl": "[daːrbˈoːvən\n ɪk bɛn hˈir\n hˈir]",
+                "en": "[ˌʌp ðˈeə aɪm hˈiə hˈiə]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         },
         {
             "id": "scene-15-021",
             "text": {
-                "pt": "Que alívio!",
-                "en": "What a relief!"
+                "fr": "Que je suis soulagée!",
+                "en": "How relieved I am!",
+                "de": "Wie erleichtert ich bin!",
+                "it": "Che sollievo!",
+                "es": "¡Qué aliviada me siento!",
+                "nl": "Wat een opluchting!"
             },
             "ipa": {
-                "pt": "[ky ˌalˈivjʊ]",
-                "en": "[wˌɒt ɐ ɹɪlˈiːf]"
+                "fr": "kə ʒə- syˌi sulaʒˈe",
+                "de": "[viː ɛɐ̯ˈlaɪ̯�ɐ̯t ɪ� bɪn]",
+                "it": "[kˌe sˌolliˈɛːvo]",
+                "es": "[ke aliˈβjaða me ˈsjento]",
+                "nl": "[ʋɑt ən ˈɔplˌɵxtɪŋ]",
+                "en": "[hˌaʊ ɹɪlˈiːvd aɪˈam]"
             },
             "provenance": {
-                "pt": "original",
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
                 "en": "original"
             }
         }

--- a/language_materials/unified/stories/scene-16.json
+++ b/language_materials/unified/stories/scene-16.json
@@ -24,1177 +24,12 @@
             "nl",
             "pt"
         ],
-        "generated": "2026-04-09",
+        "generated": "2026-04-14",
         "generator": "merge_materials.py"
     },
     "phrases": [
         {
             "id": "scene-16-001",
-            "text": {
-                "fr": "Sophie! Dieu merci, tu es vivante!",
-                "en": "Sophie! Thank God, you're alive!",
-                "de": "Sophie! Gott sei Dank, du lebst noch!",
-                "it": "Sophie! Grazie a Dio, sei viva!",
-                "es": "¡Sophie! Menos mal que estás viva.",
-                "nl": "Sophie! Godzijdank, je leeft nog!",
-                "pt": "Graças a Deus você está viva!",
-                "en_pt": "Thank God you're alive!"
-            },
-            "ipa": {
-                "fr": "sɔfˈi djˈø mɛʁsˈi ty ɛ vivˈɑ̃t",
-                "de": "[zoːfˈiː\n ɡˈɔt zˈaɪ dˈaŋk\n duː lˈeːpst nˈɔx]",
-                "it": "[sˈopje\n ɡrˈatsje ˌa dˈiːo\n sˌɛj vˈiːva]",
-                "es": "[ˈso.fi | ˈme.nos mal ke esˈtas ˈβi.βa]",
-                "nl": "[sɔphˈi\n ɣˈɔdzɛɪdˌɑŋk\n jə lˈeːft nˈɔx]",
-                "pt": "[ɡrˈasæz a dˈeʊz vosˌe estˌa vˈivæ]",
-                "en": "[sˈəʊfi θˈaŋk ɡˈɒd jɔːɹ ɐlˈaɪv]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-002",
-            "text": {
-                "fr": "Lucas! J'avais tellement peur pour toi!",
-                "en": "Lucas! I was so scared for you!",
-                "de": "Lucas! Ich hatte solche Angst um dich!",
-                "it": "Lucas! Avevo così paura per te!",
-                "es": "¡Lucas! ¡Tenía tanto miedo por ti!",
-                "nl": "Lucas! Ik was zo bang voor je!",
-                "pt": "Estava com tanto medo por você!",
-                "en_pt": "I was so afraid for you!"
-            },
-            "ipa": {
-                "fr": "lykˈa ʒavˈɛ tɛlmˈɑ̃ pˈœʁ puʁ twˈa",
-                "de": "[lˈuːkɑːs\n ɪç hˌatə zˈɔlçə ˈaŋst ʊm dˈɪç]",
-                "it": "[lˈuːkas\n avˌɛvo kozˈi paˈuːra pˌɛr tˈe]",
-                "es": "[ˈlu.kas | ˈte.nja ˈtan.to ˈmje.ðo por ti]",
-                "nl": "[lˈykɑs\n ɪk ʋˈɑ soː bˈɑŋ vɔːr jə]",
-                "pt": "[estˌavæ koŋ tˈɐ̃ŋtʊ mˈedʊ por vosˈe]",
-                "en": "[lˈuːkəz aɪ wɒz sˌəʊ skˈeəd fɔː juː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-003",
-            "text": {
-                "fr": "Pardonne-moi de t'avoir laissée partir seule",
-                "en": "Forgive me for letting you go alone",
-                "de": "Verzeih mir, dass ich dich alleine gehen ließ",
-                "it": "Perdonami per averti lasciata andare da sola",
-                "es": "Perdóname por haberte dejado ir sola.",
-                "nl": "Sorry dat ik je alleen heb laten gaan",
-                "pt": "Me perdoa por ter deixado você ir sozinha.",
-                "en_pt": "Forgive me for letting you go alone."
-            },
-            "ipa": {
-                "fr": "paʁdˈɔnmwˌa də- tavwˈaʁ lɛsˈe paʁtˈiʁ sˈœl",
-                "de": "[fɛɾtsˈaɪ mˈiːɾ\n das ɪç dɪç alˈaɪnə ɡˈeːən lˈiːs]",
-                "it": "[perdˈonamɪ pˌɛr avˈɛːrtɪ laʃˈaːta andˈaːre dˌa sˈoːla]",
-                "es": "[perˈðo.na.me por aˈβer.te deˈxa.ðo ir ˈso.la]",
-                "nl": "[sˈɔɾri dɑt ɪk jə ɑlˈeːn hɛp lˈaːtən ɣˈaːn]",
-                "pt": "[my pˌeɾədˈoæ por ter dˌeɪʃˈadʊ vosˌe ˈir sˌozˈiɲæ]",
-                "en": "[fəɡˈɪv mˌiː fɔː lˈɛtɪŋ juː ɡˌəʊ ɐlˈəʊn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-004",
-            "text": {
-                "fr": "Je suis tellement désolé.",
-                "en": "I'm so sorry.",
-                "de": "Es tut mir so leid.",
-                "it": "Sono davvero dispiaciuto.",
-                "es": "Lo siento muchísimo.",
-                "nl": "Het spijt me zo.",
-                "pt": "Sinto muito."
-            },
-            "ipa": {
-                "fr": "ʒə- syˌi tɛlmˈɑ̃ dezɔlˈe",
-                "de": "[ɛs tˈuːt miːɾ zoː lˈaɪt]",
-                "it": "[sˌono davvˈeːro dˌispjatʃˈuːto]",
-                "es": "[lo ˈsjen.to muˈtʃi.si.mo]",
-                "nl": "[hət spˈɛɪt mə zˈoː]",
-                "pt": "[sˈiŋtʊ mwˈiŋtʊ]",
-                "en": "[aɪm sˌəʊ sˈɒɹi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-005",
-            "text": {
-                "fr": "Non, c'est moi qui aurais dû t'écouter",
-                "en": "No, I should have listened to you",
-                "de": "Nein, ich hätte auf dich hören sollen",
-                "it": "No, sono io che avrei dovuto ascoltarti",
-                "es": "No, debería haber sido yo quien te escuchara.",
-                "nl": "Nee, ik had naar je moeten luisteren",
-                "pt": "Não, fui eu quem deveria ter te escutado.",
-                "en_pt": "No, I'm the one who should have listened to you."
-            },
-            "ipa": {
-                "fr": "nˈɔ̃ sɛ mwˌa ki oʁˈɛ dˈyː tekutˈe",
-                "de": "[nˈaɪn\n ɪç hˌɛtə aʊf dɪç hˈøːrən zˌɔlən]",
-                "it": "[nˈɔ\n sˌono ˌio kˌe avrˈeːɪ dovˈuːto ˌaskoltˈaːrtɪ]",
-                "es": "[no | deˈβe.ɾja aˈβer siˈðo jo kjen te eskuˈtʃa.ɾa]",
-                "nl": "[nˈeː\n ɪk hˈɑt naːr jə mˈutən lˈœystərən]",
-                "pt": "[nˈɐ̃ʊ̃\n fuɪ eʊ kˈeɪŋ dˌeveɾˈiæ ter tʃj ˌeskutˈadʊ]",
-                "en": "[nˈəʊ aɪ ʃˌʊdəv lˈɪsənd tə juː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-006",
-            "text": {
-                "fr": "Tu voulais faire demi-tour.",
-                "en": "You wanted to turn back.",
-                "de": "Du wolltest umkehren.",
-                "it": "Volevi tornare indietro.",
-                "es": "Tú querías volver atrás.",
-                "nl": "Je wilde omdraaien.",
-                "pt": "Você queria voltar."
-            },
-            "ipa": {
-                "fr": "ty vulˈɛ fˈɛʁ dəmˈitˈuʁ",
-                "de": "[duː vɔltəst ʊmkˈeːrən]",
-                "it": "[volˈɛːvɪ tornˈaːre indjˈɛːtro]",
-                "es": "[tu keˈɾjas ˈbol.βer aˈtras]",
-                "nl": "[jə ʋˌɪldə ˈɔmdraːjən]",
-                "pt": "[vosˌe kˌeɾˈiæ vowtˈar]",
-                "en": "[juː wˈɒntɪd tə tˈɜːn bˈak]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-007",
-            "text": {
-                "fr": "L'important, c'est que nous soyons tous les deux sains et saufs.",
-                "en": "The important thing is that we are both safe.",
-                "de": "Das Wichtigste ist, dass wir beide heil sind.",
-                "it": "L'importante è che siamo entrambi sani e salvi.",
-                "es": "Lo importante es que ambos estamos bien.",
-                "nl": "Het belangrijkste is dat we allebei veilig zijn.",
-                "pt": "O importante é que estamos os dois bem.",
-                "en_pt": "The important thing is that we're both okay."
-            },
-            "ipa": {
-                "fr": "lɛ̃pɔʁtˈɑ̃ sɛ kə nu swajˈɔ̃ tu le- dˈø sˈɛ̃z e sˈof",
-                "de": "[das vˈɪçtɪçstə ɪst\n das viːɾ bˈaɪdə hˈaɪl zɪnt]",
-                "it": "[lˌimportˈante ˌɛ kˌe sjˌamo entrˈambɪ sˈaːnɪ ˌe sˈalvɪ]",
-                "es": "[lo imporˈtan.te es ke ˈam.bos esˈta.mos ˈβjen]",
-                "nl": "[hət bəlˈɑŋrɛɪkstə ɪs dɑt ʋə ˈɑləbˌɛɪ vˈɛɪləx zɛɪn]",
-                "pt": "[u ˌimpoɾətˈɐ̃ŋtʃj ɛ ky estˌɐ̃mʊz ʊz dˈoɪz bˈeɪŋ]",
-                "en": "[ðɪ ɪmpˈɔːtənt θˈɪŋ ɪz ðat wiː ɑː bˈəʊθ sˈeɪf]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-008",
-            "text": {
-                "fr": "Cette expérience nous a changés,",
-                "en": "This experience has changed us,",
-                "de": "Diese Erfahrung hat uns verändert,",
-                "it": "Questa esperienza ci ha cambiati,",
-                "es": "Esta experiencia nos ha cambiado,",
-                "nl": "Deze ervaring heeft ons veranderd,",
-                "pt": "Esta experiência nos mudou, diz Sophie suavemente.",
-                "en_pt": "This experience changed us, Sophie says softly."
-            },
-            "ipa": {
-                "fr": "sɛt ɛkspeʁjˈɑ̃s nuz a ʃɑ̃ʒˈe",
-                "de": "[dˌiːzə ɛɾfˈɑːrʊŋ hat ʊns fɛɾˈɛndɜt]",
-                "it": "[kwˌɛsta ˌesperiˈɛntsa tʃˌɪ ˌa kambjˈaːtɪ]",
-                "es": "[ˈes.ta ekspeˈɾjen.θja nos a kamˈβja.ðo]",
-                "nl": "[dˌeːzə ɛrvˈaːrɪŋ heːft ɔns vərˈɑndərt]",
-                "pt": "[ˌɛstæ ˌespeɾjˈeɪŋsjæ nʊz mudˈow\n dʒˈis sˌofˈiy sˌuavemˈeɪŋtʃy]",
-                "en": "[ðɪs ɛkspˈiəɹɪəns hɐz tʃˈeɪndʒd ˌʌs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-009",
-            "text": {
-                "fr": "Mais elle nous a aussi coûté quelque chose.",
-                "en": "But it has also cost us something.",
-                "de": "Aber sie hat uns auch etwas gekostet.",
-                "it": "Ma ci ha anche costato qualcosa.",
-                "es": "pero también nos ha costado algo.",
-                "nl": "Maar het heeft ons ook iets gekost.",
-                "pt": "Mas também nos custou algo.",
-                "en_pt": "But it also cost us something."
-            },
-            "ipa": {
-                "fr": "mɛz ɛl nuz a osˌi kutˈe kˌɛlkə ʃˈoz",
-                "de": "[ˌɑːbɜ ziː hat ʊns ˌaʊx ˈɛtvɑːs ɡəkˈɔstət]",
-                "it": "[mˌa tʃˌɪ ˌa ˈanke kostˈaːto kwalkˈɔːza]",
-                "es": "[ˈpe.ro tamˈbjen nos a kosˈta.ðo ˈal.ɣo]",
-                "nl": "[maːr hət heːft ɔns oːk ˈits ɣəkˈɔst]",
-                "pt": "[mas tɐ̃mbˈeɪŋ nʊs kustˈow ˈaʊɡʊ]",
-                "en": "[bˌʌt ɪt hɐz ˈɒlsəʊ kˈɒst ˌʌs sˈʌmθɪŋ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-010",
-            "text": {
-                "fr": "Qu'est-ce qu'elle nous a coûté?",
-                "en": "What did it cost us?",
-                "de": "Was hat sie uns gekostet?",
-                "it": "Cosa ci ha costato?",
-                "es": "¿Qué nos ha costado?",
-                "nl": "Wat heeft het ons gekost?",
-                "pt": "O que nos custou?"
-            },
-            "ipa": {
-                "fr": "kɛs kɛl nuz a kutˈe",
-                "de": "[vˈas hat ziː ʊns ɡəkˈɔstət]",
-                "it": "[kˈɔːza tʃˌɪ ˌa kostˈaːto]",
-                "es": "[ke nos a kosˈta.ðo]",
-                "nl": "[ʋɑt heːft hət ɔns ɣəkˈɔst]",
-                "pt": "[ʊ ky nʊs kustˈow]",
-                "en": "[wˌɒt dˈɪd ɪt kˈɒst ˌʌs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-011",
-            "text": {
-                "fr": "Notre innocence, peut-être",
-                "en": "Our innocence, perhaps",
-                "de": "Vielleicht unsere Unschuld",
-                "it": "Forse la nostra innocenza",
-                "es": "Quizás nuestra inocencia.",
-                "nl": "Onze onschuld, misschien",
-                "pt": "Nossa inocência, talvez.",
-                "en_pt": "Our innocence, perhaps."
-            },
-            "ipa": {
-                "fr": "nɔtʁ inɔsˈɑ̃s pˈøtˈɛtʁ",
-                "de": "[fiːllˈaɪçt ˌʊnzrə ˈʊnʃˌʊlt]",
-                "it": "[fˈoːrse lˌa nˌɔstra ˌinnotʃˈɛntsa]",
-                "es": "[kiˈθas nweˈstra i.noˈθen.θja]",
-                "nl": "[ɔnzˌə ɔnsxˈɵlt\n mɪsxˈin]",
-                "pt": "[nˌɔsæ ˌinosˈeɪŋsjæ taʊvˈes]",
-                "en": "[aʊəɹ ˈɪnəsəns pəhˈaps]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-012",
-            "text": {
-                "fr": "L'illusion que nous pouvions contrôler nos vies",
-                "en": "The illusion that we could control our lives",
-                "de": "Die Illusion, dass wir unser Leben kontrollieren können",
-                "it": "L'illusione che potessimo controllare le nostre vite",
-                "es": "La ilusión de que podíamos controlar nuestras vidas",
-                "nl": "De illusie dat we ons leven konden beheersen",
-                "pt": "A ilusão de que podíamos controlar nossas vidas.",
-                "en_pt": "The illusion that we could control our lives."
-            },
-            "ipa": {
-                "fr": "lilyzjˈɔ̃ kə nu puvjˈɔ̃ kɔ̃tʁolˈe no vˈi",
-                "de": "[diː ɪluːzjˈoːn\n das viːɾ ˌʊnzɜ lˈeːbən kɔntɾɔlˈiːrən kˈœnən]",
-                "it": "[lˌillʊziˈoːne kˌe potˈessimo kˌontrollˈaːre lˌe nˌɔstre vˈiːte]",
-                "es": "[la i.luˈsjon de ke poˈði.a.mos kon.tɾoˈlaɾ nweˈstɾas ˈβi.ðas]",
-                "nl": "[də ɪlˈyzˌi dɑt ʋə ɔns lˈeːvən kˌɔndən bəhˈɪːrsən]",
-                "pt": "[a ˌiluzˈɐ̃ʊ̃ dʒy ky podʒˌiæmʊs kˌoŋtrolˈar nˌɔsæz vˈidæs]",
-                "en": "[ðɪ ɪlˈuːʒən ðat wiː kʊd kəntɹˈəʊl aʊə lˈaɪvz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-013",
-            "text": {
-                "fr": "Le bonheur facile.",
-                "en": "The easy happiness.",
-                "de": "Das unbeschwerte Glück.",
-                "it": "La felicità facile.",
-                "es": "La felicidad fácil.",
-                "nl": "Het gemakkelijke geluk.",
-                "pt": "A felicidade fácil.",
-                "en_pt": "Easy happiness."
-            },
-            "ipa": {
-                "fr": "lə- bɔnˈœʁ fasˈil",
-                "de": "[das ˈʊnbəʃvˌeːɾtə ɡlˈʏk]",
-                "it": "[lˌa fˌɛlitʃitˈa fˈatʃile]",
-                "es": "[la fe.liθiˈðað ˈfa.θil]",
-                "nl": "[hət ɣəmˈɑkələkə ɣəlˈɵk]",
-                "pt": "[a fˌelisidˈadʒy fˈasiʊ]",
-                "en": "[ðɪ ˈiːzi hˈapɪnəs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-014",
-            "text": {
-                "fr": "Je ne suis plus la même personne qu'avant",
-                "en": "I am not the same person as before",
-                "de": "Ich bin nicht mehr dieselbe Person wie früher",
-                "it": "Non sono più la stessa persona di prima",
-                "es": "Ya no soy la misma persona que antes.",
-                "nl": "Ik ben niet meer dezelfde persoon als voorheen",
-                "pt": "Não sou mais a mesma pessoa de antes.",
-                "en_pt": "I'm not the same person I was before."
-            },
-            "ipa": {
-                "fr": "ʒə- nə- syˌi ply la- mˈɛm pɛʁsˈɔn kavˈɑ̃",
-                "de": "[ɪç bɪn nˈɪçt mˌeːɾ diːzˈɛlbə pɛɾzˈoːn viː frˈyːɜ]",
-                "it": "[nˌon sˌono pjˌʊ lˌa stˈessa persˈoːna dˌɪ prˈiːma]",
-                "es": "[ʝa no soi la ˈmis.ma perˈso.na ke ˈan.tes]",
-                "nl": "[ɪk bɛn nˈit mˌeːr dəzˈɛlvdə pɛrsˈoːn ɑls vˈɔːrhˌeːn]",
-                "pt": "[nˌɐ̃ʊ̃ sow mˈaɪz a mˈezmæ pˌesˈoæ dʒj ˈɐ̃ŋtʃys]",
-                "en": "[aɪɐm nˌɒt ðə sˈeɪm pˈɜːsən az bɪfˈɔː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-015",
-            "text": {
-                "fr": "Cette nuit dans la montagne.",
-                "en": "That night in the Ardennes.",
-                "de": "Diese Nacht in den Alpen.",
-                "it": "Quella notte sulla montagna.",
-                "es": "Esa noche en los Pirineos.",
-                "nl": "Die nacht in de Ardennen.",
-                "pt": "Esta noite na montanha...",
-                "en_pt": "This night on the mountain..."
-            },
-            "ipa": {
-                "fr": "sɛt nyˈi dɑ̃ la- mɔ̃tˈaɲ",
-                "de": "[dˌiːzə nˈaxt ɪn deːn ˈalpən]",
-                "it": "[kwˌɛlla nˈɔtːe sˌʊlla montˈaɲɲa]",
-                "es": "[ˈe.sa ˈno.tʃe en los piɾiˈne.os]",
-                "nl": "[di nˈɑxt ɪn də ˈɑrdɛnən]",
-                "pt": "[ˌɛstæ nˈoɪtʃy na mˌoŋtˈɐ̃ɲæ]",
-                "en": "[ðat nˈaɪt ɪnðɪ ˈɑːdənz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-016",
-            "text": {
-                "fr": "Moi non plus, j'ai appris tellement de choses",
-                "en": "Me neither, I've learned so much",
-                "de": "Ich auch, ich habe so viel gelernt",
-                "it": "Nemmeno io, ho imparato tantissimo",
-                "es": "Yo también, he aprendido tantas cosas.",
-                "nl": "Ik ook niet, ik heb zoveel geleerd",
-                "pt": "Eu também, aprendi tantas coisas.",
-                "en_pt": "Me too, I learned so many things."
-            },
-            "ipa": {
-                "fr": "mwˌa nɔ̃ plˈy ʒe apʁˈi tɛlmˈɑ̃ də- ʃˈoz",
-                "de": "[ɪç ˈaʊx\n ɪç hɑːbə zoː fˈiːl ɡəlˈɛɾnt]",
-                "it": "[nemmˈeːno ˈio\n ˌo ˌimparˈaːto tantˈissimo]",
-                "es": "[ʝo tamˈbjen | e a.prenˈdi.ðo ˈtan.tas ˈko.sas]",
-                "nl": "[ɪk oːk nˈit\n ɪk hɛp zoːvˈeːl ɣəlˈɪːrt]",
-                "pt": "[eʊ tɐ̃mbˈeɪŋ\n ˌapreɪŋdʒˈi tˈɐ̃ŋtæs kˈoɪzæs]",
-                "en": "[mˌiː nˈaɪðə aɪv lˈɜːnd sˈəʊ mˌʌtʃ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-017",
-            "text": {
-                "fr": "La chèvre qui m'a guidé, les gens qui m'ont aidé.",
-                "en": "The goat that guided me, the people who helped me.",
-                "de": "Die Ziege, die mich geführt hat, die Menschen, die mir geholfen haben.",
-                "it": "La capra che mi ha guidato, le persone che mi hanno aiutato.",
-                "es": "La cabra que me guió, las personas que me ayudaron.",
-                "nl": "De geit die me leidde, de mensen die me hielpen.",
-                "pt": "A cabra que me guiou, as pessoas que me ajudaram...",
-                "en_pt": "The goat that guided me, the people who helped me..."
-            },
-            "ipa": {
-                "fr": "la- ʃˈɛvʁ ki ma ɡidˈe le- ʒˈɑ̃ ki mɔ̃t ɛdˈe",
-                "de": "[diː tsˈiːɡə\n diː mɪç ɡəfˈyːɾt hat\n diː mˈɛnʃən\n diː miːɾ ɡəhˈɔlfən hˈɑːbən]",
-                "it": "[lˌa kˈaːpra kˌe mˌɪ ˌa ɡwidˈaːto\n lˌe persˈoːne kˌe mˌɪ ˌanno ˌajʊtˈaːto]",
-                "es": "[la ˈka.βɾa ke me ɣiˈo | las perˈso.nas ke me aʝuˈða.ɾon]",
-                "nl": "[də ɣˈɛɪt di mə lˈɛɪdə\n də mˈɛnsən di mə hˈilpən]",
-                "pt": "[a kˈabræ ky my ɡiˈow\n as pˌesˈoæs ky mj ˌaʒudˈaɾɐ̃ʊ̃]",
-                "en": "[ðə ɡˈəʊt ðat ɡˈaɪdɪd mˌiː ðə pˈiːpəl hˌuː hˈɛlpt mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-018",
-            "text": {
-                "fr": "Était-ce vraiment une chèvre guide, ou juste une chèvre ordinaire? Nous projetons tant de signification sur ce qui nous arrive.",
-                "en": "Was it really a guide goat, or just an ordinary goat? We project so much meaning onto what happens to us.",
-                "de": "War es wirklich eine Führungsziege, oder nur eine gewöhnliche Ziege? Wir legen so viel Bedeutung in das, was uns passiert.",
-                "it": "Era davvero una capra guida, o solo una capra normale? Proiettiamo così tanto significato su ciò che ci accade.",
-                "es": "¿Era realmente una cabra guía, o solo una cabra común? Proyectamos mucho significado en lo que nos pasa.",
-                "nl": "Was het echt een gidsgeit, of gewoon een gewone geit? We leggen zoveel betekenis in wat ons overkomt.",
-                "pt": "Era realmente uma cabra guia, ou apenas uma cabra comum?",
-                "en_pt": "Was it really a guide goat, or just an ordinary goat?"
-            },
-            "ipa": {
-                "fr": "etˈɛs vʁɛmˈɑ̃ yn ʃˈɛvʁ ɡˈid u ʒˈyst yn ʃˈɛvʁ ɔʁdinˈɛʁ nu pʁɔʒtˈɔ̃ tɑ̃ də- siɲifikasjˈɔ̃ syʁ sə- ki nuz aʁˈiv",
-                "de": "[vɑːɾ ɛs vˈɪɾklɪç ˌaɪnə fˈyːrʊŋstsˌiːɡə\n ˌoːdɜ nˈuːɾ ˌaɪnə ɡəvˈøːnlɪçə tsˈiːɡə\n viːɾ lˈeːɡən zoː fˈiːl bədˈɔøtʊŋ ɪn das\n vˈas ʊns pasˈiːɾt]",
-                "it": "[ˌɛra davvˈeːro ˌʊna kˈaːpra ɡwˈiːda\n ˌo sˈoːlo ˌʊna kˈaːpra normˈaːle\n prˌɔɪetːjˈaːmo kozˈi tˌanto sˌiɲifikˈaːto sˌʊ tʃˈɔ kˌe tʃˌɪ akːˈaːde]",
-                "es": "[ˈe.ɾa re.alˈmen.te uˈna ˈka.βɾa ˈɣi.a | o ˈso.lo uˈna ˈka.βɾa koˈmun | pɾo.jekˈta.mos ˈmu.tʃo siɣ.ni.fiˈka.ðo en lo ke nos ˈpa.sa]",
-                "nl": "[ʋˈɑs hət ˈɛxt ən ɣˈɪdsxɛɪt\n ɔf ɣəʋˈoːn ən ɣəʋˈoːnə ɣˈɛɪt\n ʋə lˈɛɣən zoːvˈeːl bətˈeːkənˌɪs ɪn ʋɑt ɔns ˌoːvərkˈɔmt]",
-                "pt": "[ˌɛɾæ xˌeaʊmˈeɪŋtʃj ˌumæ kˈabræ ɡˈiæ\n ow ˌapˈenæz ˌumæ kˈabræ komˈũŋ]",
-                "en": "[wɒz ɪt ɹˈiəlɪ ɐ ɡˈaɪd ɡˈəʊt ɔː dʒˈʌst ɐn ˈɔːdɪnəɹi ɡˈəʊt wiː pɹədʒˈɛkt sˈəʊ mˌʌtʃ mˈiːnɪŋ ˌɒntʊ wɒt hˈapənz tʊ ˌʌs]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-019",
-            "text": {
-                "fr": "Peut-être que cela n'a pas d'importance",
-                "en": "Maybe it doesn't matter",
-                "de": "Vielleicht macht das keinen Unterschied",
-                "it": "Forse non ha importanza",
-                "es": "Quizás eso no importa",
-                "nl": "Misschien maakt het niet uit",
-                "pt": "Talvez não importe.",
-                "en_pt": "Maybe it doesn't matter."
-            },
-            "ipa": {
-                "fr": "pˈøtˈɛtʁ kə səlˌa na pa dɛ̃pɔʁtˈɑ̃s",
-                "de": "[fiːllˈaɪçt mˈaxt das kˈaɪnən ˌʊntɜʃˈiːt]",
-                "it": "[fˈoːrse nˌon ˌa ˌimportˈantsa]",
-                "es": "[kiˈθas ˈe.so no imˈpor.ta]",
-                "nl": "[mɪsxˈin mˈaːkt hət nˌit ˈœyt]",
-                "pt": "[taʊvˈez nˌɐ̃ʊ̃ ˌimpˈɔɾətʃy]",
-                "en": "[mˈeɪbiː ɪt dˈʌzənt mˈatə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-020",
-            "text": {
-                "fr": "J'ai choisi de lui faire confiance, et cela m'a sauvé.",
-                "en": "I chose to trust him, and it saved me.",
-                "de": "Ich habe mich entschieden, ihr zu vertrauen, und das hat mich gerettet.",
-                "it": "Ho scelto di fidarmi di lei, e questo mi ha salvato.",
-                "es": "Elegí confiar en ella, y eso me salvó.",
-                "nl": "Ik koos ervoor om hem te vertrouwen, en dat heeft me gered.",
-                "pt": "Escolhi confiar nela, e isso me salvou.",
-                "en_pt": "I chose to trust her, and that saved me."
-            },
-            "ipa": {
-                "fr": "ʒe ʃwazˈi də- lyˌi fˈɛʁ kɔ̃fjˈɑ̃s e səlˌa ma sovˈe",
-                "de": "[ɪç hɑːbə mɪç ɛntʃˈiːdən\n iːɾ tsuː fɛɾtɾˈaʊən\n ʊnt das hat mɪç ɡərˈɛtət]",
-                "it": "[ˌo ʃˈelto dˌɪ fidˈaːrmɪ dˌɪ lˈɛj\n ˌe kwˌɛsto mˌɪ ˌa salvˈaːto]",
-                "es": "[eˈle.xi konˈfjar en ˈe.ʎa | i ˈe.so me salˈβo]",
-                "nl": "[ɪk kˈoːs ɛrvˈɔːr ɔm hˈɛm tə vərtrˈʌʊən\n ɛn dɑt heːft mə ɣərˈɛt]",
-                "pt": "[ˌeskoljˈi kˌoŋfiˈar nˈɛlæ\n i ˈisʊ my saʊvˈow]",
-                "en": "[aɪ tʃˈəʊz tə tɹˈʌst hˌɪm and ɪt sˈeɪvd mˌiː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-021",
-            "text": {
-                "fr": "Quand on est séparés, on réalise ce qui compte vraiment.",
-                "en": "When we are apart, we realize what really matters.",
-                "de": "Wenn wir getrennt sind, wird uns klar, was wirklich zählt.",
-                "it": "Quando siamo separati, ci rendiamo conto di ciò che conta davvero.",
-                "es": "Cuando estamos separados, nos damos cuenta de lo que realmente importa.",
-                "nl": "Als we apart zijn, realiseren we ons wat echt belangrijk is.",
-                "pt": "Quando estamos separados, percebemos o que realmente importa.",
-                "en_pt": "When we're separated, we realize what really matters."
-            },
-            "ipa": {
-                "fr": "kɑ̃t ɔ̃n ɛ sepaʁˈe ɔ̃ ʁealˈiz sə- ki kˈɔ̃t vʁɛmˈɑ̃",
-                "de": "[vˌɛn viːɾ ɡətɾˈɛnt zɪnt\n vˌɪɾt ʊns klˈɑːɾ\n vˈas vˈɪɾklɪç tsˈɛːlt]",
-                "it": "[kwˈando sjˌamo sˌeparˈaːtɪ\n tʃˌɪ rendjˈaːmo kˈonto dˌɪ tʃˈɔ kˌe kˈonta davvˈeːro]",
-                "es": "[ˈkwan.do esˈta.mos sepaˈɾa.ðos | nos ˈða.mos ˈkwenta de lo ke re.alˈmen.te imˈpor.ta]",
-                "nl": "[ɑls ʋə ˈaːpɑrt zɛɪn\n rˌeːaːlizˈɪːrən ʋə ɔns ʋɑt ˈɛxt bəlˈɑŋrɛɪk ɪs]",
-                "pt": "[kwˈɐ̃ŋdw estˌɐ̃mʊs sˌepaɾˈadʊs\n pˌeɾəsebˈemʊz ʊ ky xˌeaʊmˈeɪŋtʃj ˌimpˈɔɾətæ]",
-                "en": "[wˌɛn wiː ɑːɹ ɐpˈɑːt wiː ɹˈiəlaɪz wɒt ɹˈiəlɪ mˈatəz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-022",
-            "text": {
-                "fr": "Je ne veux plus jamais te perdre.",
-                "en": "I never want to lose you again.",
-                "de": "Ich will dich nie wieder verlieren.",
-                "it": "Non voglio mai più perderti.",
-                "es": "No quiero perderte nunca más.",
-                "nl": "Ik wil je nooit meer kwijt.",
-                "pt": "Não quero nunca mais te perder."
-            },
-            "ipa": {
-                "fr": "ʒə- nə- vˈø ply ʒamˌɛ tə- pˈɛʁdʁ",
-                "de": "[ɪç vɪl dɪç nˈiː vˈiːdɜ fɛɾlˈiːrən]",
-                "it": "[nˌon vˈoːʎo mˌaɪ pjˌʊ pˈɛrdertɪ]",
-                "es": "[no ˈkje.ro perˈðer.te ˈnun.ka ˈmas]",
-                "nl": "[ɪk ʋɪl jə nˈoːjt mˈɪːr kʋˈɛɪt]",
-                "pt": "[nˌɐ̃ʊ̃ kˈɛɾʊ nˌũŋkæ mˈaɪs tʃy peɾədˈer]",
-                "en": "[aɪ nˈɛvə wˈɒnt tə lˈuːz juː ɐɡˈɛn]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-023",
-            "text": {
-                "fr": "Mais maintenant, je sais que je peux me débrouiller seule si nécessaire",
-                "en": "But now I know that I can manage alone if necessary",
-                "de": "Aber jetzt weiß ich, dass ich alleine zurechtkommen kann, wenn es sein muss",
-                "it": "Ma ora so che posso cavarmela da sola se necessario",
-                "es": "Pero ahora sé que puedo arreglármelas sola si es necesario",
-                "nl": "Maar nu weet ik dat ik alleen kan redden als het moet",
-                "pt": "Mas agora sei que posso me virar sozinha se necessário.",
-                "en_pt": "But now I know I can manage alone if necessary."
-            },
-            "ipa": {
-                "fr": "mɛ mɛ̃tnˈɑ̃ ʒə- sˈɛ kə ʒə- pˈø mə- debʁujˈe sˈœl sˈi nesɛsˈɛʁ",
-                "de": "[ˌɑːbɜ jˌɛtst vˈaɪs ɪç\n das ɪç alˈaɪnə tsuːrˈɛçtkɔmən kˌan\n vˌɛn ɛs zaɪn mˈʊs]",
-                "it": "[mˌa ˈɔːra sˈo kˌe pˈɔsso kavˈarmela dˌa sˈoːla sˌe nˌetʃessˈario]",
-                "es": "[ˈpe.ro aˈo.ɾa se ke ˈpwe.ðo a.reˈɣlar.me.las ˈso.la si es ne.seˈsa.ɾjo]",
-                "nl": "[maːr nˈy ʋˈeːt ɪk dɑt ɪk ɑlˈeːn kɑn rˈɛdən ɑls hət mˈut]",
-                "pt": "[maz ˌaɡˈɔɾæ sˈeɪ ky pˌɔsʊ my viɾˈar sˌozˈiɲæ sy nˌesesˈaɾjʊ]",
-                "en": "[bˌʌt nˈaʊ aɪ nˈəʊ ðat aɪ kan mˈanɪdʒ ɐlˈəʊn ɪf nˈɛsəsəɹi]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-024",
-            "text": {
-                "fr": "J'ai fait du feu, j'ai trouvé de l'eau, j'ai fait une soupe avec des orties.",
-                "en": "I made fire, found water, and made a soup with nettles.",
-                "de": "Ich habe Feuer gemacht, Wasser gefunden, eine Suppe mit Brennnesseln gekocht.",
-                "it": "Ho fatto fuoco, ho trovato acqua, ho fatto una zuppa con le ortiche.",
-                "es": "Hice fuego, encontré agua, hice una sopa con ortigas.",
-                "nl": "Ik maakte vuur, vond water, en maakte een soep van brandnetels.",
-                "pt": "Acendi fogo, encontrei água, fiz sopa com urtigas.",
-                "en_pt": "I lit a fire, found water, made soup with nettles."
-            },
-            "ipa": {
-                "fr": "ʒe fˈɛ dy- fˈø ʒe tʁuvˈe də- lˈo ʒe fˈɛt yn sˈup avˌɛk de-z ɔʁtˈi",
-                "de": "[ɪç hɑːbə fˈɔøɜ ɡəmˈaxt\n vˈasɜ ɡəfˈʊndən\n ˌaɪnə zˈʊpə mɪt brˈɛnɛsəln ɡəkˈɔxt]",
-                "it": "[ˌo fˈatːo fʊˈɔːko\n ˌo trovˈaːto ˈakːwa\n ˌo fˈatːo ˌʊna dzˈupːa kˌon lˌe ˈɔrtike]",
-                "es": "[ˈi.θe ˈfwe.ɣo | en.konˈtɾe ˈa.ɣwa | ˈi.θe uˈna ˈso.pa kon orˈti.ɣas]",
-                "nl": "[ɪk mˈaːktə vˈyr\n vˈɔnt ʋˈaːtər\n ɛn mˈaːktə ən sˈup vɑn brˈɑndnətˌɛls]",
-                "pt": "[ˌaseɪŋdʒˈi fˈoɡʊ\n ˌeɪŋkoŋtrˈeɪ ˈaɡwæ\n fˈis sˈopæ koŋ ˌuɾətʃˈiɡæs]",
-                "en": "[aɪ mˌeɪd fˈaɪə fˈaʊnd wˈɔːtə and mˌeɪd ɐ sˈuːp wɪð nˈɛtəlz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-025",
-            "text": {
-                "fr": "Et c'est exactement ce qui rend notre relation plus forte",
-                "en": "And that's exactly what makes our relationship stronger",
-                "de": "Und genau das macht unsere Beziehung stärker",
-                "it": "Ed è esattamente questo che rende la nostra relazione più forte",
-                "es": "Y eso es precisamente lo que hace nuestra relación más fuerte.",
-                "nl": "En dat is precies wat onze relatie sterker maakt",
-                "pt": "E é exatamente isso que torna nossa relação mais forte.",
-                "en_pt": "And that's exactly what makes our relationship stronger."
-            },
-            "ipa": {
-                "fr": "e sɛt ɛɡzaktəmˈɑ̃ sə- ki ʁˈɑ̃ nɔtʁ ʁəlasjˈɔ̃ ply fˈɔʁt",
-                "de": "[ʊnt ɡənˈaʊ das mˈaxt ˌʊnzrə bətsˈiːʊŋ ʃtˈɛɾkɜ]",
-                "it": "[ˌɛd ˌɛ ˌezatːamˈente kwˌɛsto kˌe rˈɛnde lˌa nˌɔstra rˌɛlatsiˈɔːne pjˌʊ fˈɔːrte]",
-                "es": "[i ˈe.so es preθiˈsa.mente lo ke aˈθe nweˈstɾa re.laˈθjon ˈmas ˈfwer.te]",
-                "nl": "[ɛn dɑt ɪs preːsˈis ʋɑt ɔnzˌə reːlˈaːtsi stˈɛrkər mˈaːkt]",
-                "pt": "[i ɛ ˌezatæmˈeɪŋtʃj ˈisʊ ky tˈɔɾənæ nˌɔsæ xˌelasˈɐ̃ʊ̃ mˈaɪs fˈɔɾətʃy]",
-                "en": "[and ðats ɛɡzˈaktli wɒt mˌeɪks aʊə ɹɪlˈeɪʃənʃˌɪp stɹˈɒŋɡə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-026",
-            "text": {
-                "fr": "Nous sommes deux personnes qui choisissent d'être ensemble.",
-                "en": "We are two people who choose to be together.",
-                "de": "Wir sind zwei Personen, die sich entscheiden, zusammen zu sein.",
-                "it": "Siamo due persone che scelgono di stare insieme.",
-                "es": "Somos dos personas que eligen estar juntas.",
-                "nl": "Wij zijn twee mensen die ervoor kiezen samen te zijn.",
-                "pt": "Somos duas pessoas que escolhem estar juntas—não por necessidade, mas por desejo.",
-                "en_pt": "We're two people who choose to be together—not out of necessity, but out of desire."
-            },
-            "ipa": {
-                "fr": "nu sɔm dˈø pɛʁsˈɔn ki ʃwazˈis dˈɛtʁ ɑ̃sˈɑ̃bl",
-                "de": "[viːɾ zɪnt tsvˈaɪ pɛɾzˈoːnən\n diː zɪç ɛntʃˈaɪdən\n tsuːzˈamən tsuː zaɪn]",
-                "it": "[sjˌamo dˈuːe persˈoːne kˌe ʃˈɛlɡono dˌɪ stˈaːre insjˈɛːme]",
-                "es": "[ˈso.mos dos perˈso.nas ke eˈli.xen esˈtar ˈxun.tas]",
-                "nl": "[ʋɛɪ zɛɪn tʋˈeː mˈɛnsən di ɛrvˈɔːr kˈizən sˈaːmən tə zɛɪn]",
-                "pt": "[sˌomʊz dˈuæs pˌesˈoæs ky ˌeskˈɔljeɪŋ estˌar ʒˈũŋtæs nˌɐ̃ʊ̃ por nˌesesidˈadʒy\n mas por dˌezˈeʒʊ]",
-                "en": "[wiː ɑː tˈuː pˈiːpəl hˌuː tʃˈuːz təbi təɡˈɛðə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-027",
-            "text": {
-                "fr": "pas par besoin, mais par désir.",
-                "en": "not out of necessity, but out of desire.",
-                "de": "Nicht aus Notwendigkeit, sondern aus Wunsch.",
-                "it": "non per necessità, ma per desiderio.",
-                "es": "no por necesidad, sino por deseo.",
-                "nl": "niet uit noodzaak, maar uit verlangen."
-            },
-            "ipa": {
-                "fr": "pa paʁ bəzwˈɛ̃ mɛ paʁ dezˈiʁ",
-                "de": "[nˈɪçt ˌaʊs nˈɔtvəndˌɪçkaɪt\n zˈɔndɜn ˌaʊs vˈʊnʃ]",
-                "it": "[nˌon pˌɛr nˌetʃessitˈa\n mˌa pˌɛr dˌezidˈɛrio]",
-                "es": "[no por neθeˈsi.ðað | si.no por deˈse.o]",
-                "nl": "[nˌit œyt noːdzˈaːk\n maːr œyt vərlˈɑŋən]",
-                "en": "[nˌɒt ˌaʊtəv nəsˈɛsɪti bˌʌt ˌaʊtəv dɪzˈaɪə]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-028",
-            "text": {
-                "fr": "Mais nous ne serons jamais, Lucas",
-                "en": "But we will never, Lucas",
-                "de": "Aber wir werden nie, Lucas",
-                "it": "Ma noi non saremo mai, Lucas",
-                "es": "Pero nunca seremos los mismos, Lucas",
-                "nl": "Maar wij zullen nooit, Lucas",
-                "pt": "Mas nunca seremos \"completos\", Lucas.",
-                "en_pt": "But we'll never be \"complete,\" Lucas."
-            },
-            "ipa": {
-                "fr": "mɛ nu nə- səʁˈɔ̃ ʒamˈɛ lykˈa",
-                "de": "[ˌɑːbɜ viːɾ vˌɛɾdən nˈiː\n lˈuːkɑːs]",
-                "it": "[mˌa nˌɔɪ nˌon sarˌɛmo mˈaɪ\n lˈuːkas]",
-                "es": "[ˈpe.ro ˈnun.ka seˈɾe.mos los ˈmis.mos | ˈlu.kas]",
-                "nl": "[maːr ʋɛɪ zˌɵlən nˈoːjt\n lˈykɑs]",
-                "pt": "[maz nˌũŋkæ seɾˌemʊs kˌomplˈɛtʊs\n lˈukæs]",
-                "en": "[bˌʌt wiː wɪl nˈɛvə lˈuːkəz]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-029",
-            "text": {
-                "fr": "Nous continuerons toujours de changer, de devenir",
-                "en": "We will always continue to change, to become",
-                "de": "Wir werden immer weiterhin uns verändern, wachsen",
-                "it": "Continueremo sempre a cambiare, a diventare",
-                "es": "Siempre seguiremos cambiando, evolucionando.",
-                "nl": "We blijven altijd veranderen, worden",
-                "pt": "Continuaremos sempre mudando, nos tornando.",
-                "en_pt": "We'll always keep changing, becoming."
-            },
-            "ipa": {
-                "fr": "nu kɔ̃tinyʁˈɔ̃ tuʒˌuʁ də- ʃɑ̃ʒˈe də- dəvnˈiʁ",
-                "de": "[viːɾ vˌɛɾdən ˈɪmɜ vˈaɪtɜhˌɪn ʊns fɛɾˈɛndɜn\n vˈaxzən]",
-                "it": "[kˌontinˌʊerˈɛːmo sˈɛmpre ˌa kambjˈaːre\n ˌa dˌiventˈaːre]",
-                "es": "[ˈsjem.pɾe seɣiˈɾe.mos kamˈβjan.do | eβoluθjoˈnan.do]",
-                "nl": "[ʋə blˈɛɪvən ˈɑltɛɪt vərˈɑndərən\n ʋˈɔrdən]",
-                "pt": "[kˌoŋtʃinˌuaɾˈemʊs sˌeɪmpry mˌudˈɐ̃ŋdʊ\n nʊs tˌoɾənˈɐ̃ŋdʊ]",
-                "en": "[wiː wɪl ˈɔːlweɪz kəntˈɪnjuː tə tʃˈeɪndʒ tə bɪkˈʌm]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-030",
-            "text": {
-                "fr": "Et c'est bien comme ça.",
-                "en": "And that's okay.",
-                "de": "Und das ist gut so.",
-                "it": "Ed è bene così.",
-                "es": "Y eso está bien así.",
-                "nl": "En dat is goed zo."
-            },
-            "ipa": {
-                "fr": "e sɛ bjˈɛ̃ kɔm sˈa",
-                "de": "[ʊnt das ɪst ɡˈuːt zˈoː]",
-                "it": "[ˌɛd ˌɛ bˈɛːne kozˈi]",
-                "es": "[i ˈe.so esˈta ˈβjen aˈsi]",
-                "nl": "[ɛn dɑt ɪs ɣˈut zˈoː]",
-                "en": "[and ðats əʊkˈeɪ]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-031",
-            "text": {
-                "fr": "Nous ne sommes pas venus ici pour fuir Paris,",
-                "en": "We didn't come here to escape Amsterdam,",
-                "de": "Wir sind nicht hierher gekommen, um Berlin zu verlassen,",
-                "it": "Non siamo venuti qui per scappare da Roma,",
-                "es": "No vinimos aquí para huir de Madrid,",
-                "nl": "We zijn hier niet gekomen om Amsterdam te ontvluchten,",
-                "pt": "Não viemos aqui para fugir de São Paulo, diz Sophie.",
-                "en_pt": "We didn't come here to escape from São Paulo, Sophie says."
-            },
-            "ipa": {
-                "fr": "nu nə- sɔm pa vənˈy isˈi puʁ fyˈiʁ paʁˈi",
-                "de": "[viːɾ zɪnt nˈɪçt hˈiːɾhɜ ɡəkˈɔmən\n ʊm bɛɾlˈiːn tsuː fɛɾlˈasən]",
-                "it": "[nˌon sjˌamo venˈuːtɪ kwˈi pˌɛr skapːˈaːre dˌa rˈɔːma]",
-                "es": "[no βiˈni.mos aˈki paɾa ˈwiɾ de maˈðɾið]",
-                "nl": "[ʋə zɛɪn hˈir nˌit ɣəkˈoːmən ɔm ˈɑmstərdˌɑm tə ɔntvlˈɵxtən]",
-                "pt": "[nˌɐ̃ʊ̃ vˌiˈemʊz akˈi pˌaɾæ fuʒˈir dʒy sɐ̃ʊ̃ pˈaʊlʊ\n dʒˈis sˌofˈiy]",
-                "en": "[wiː dˈɪdnt kˈʌm hˈiə tʊ ɛskˈeɪp ˈamstədˌam]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-032",
-            "text": {
-                "fr": "Nous sommes venus pour découvrir quelque chose",
-                "en": "we came to discover something new",
-                "de": "wir sind gekommen, um etwas zu entdecken",
-                "it": "siamo venuti per scoprire qualcosa",
-                "es": "vinimos para descubrir algo.",
-                "nl": "we kwamen om iets nieuws te ontdekken",
-                "pt": "Viemos para descobrir algo.",
-                "en_pt": "We came to discover something."
-            },
-            "ipa": {
-                "fr": "nu sɔm vənˈy puʁ dekuvʁˈiʁ kˌɛlkə ʃˈoz",
-                "de": "[viːɾ zɪnt ɡəkˈɔmən\n ʊm ˈɛtvɑːs tsuː ɛntdˈɛkən]",
-                "it": "[sjˌamo venˈuːtɪ pˌɛr skoprˈiːre kwalkˈɔːza]",
-                "es": "[biˈni.mos paɾa deskuˈβɾir ˈal.ɣo]",
-                "nl": "[ʋə kʋˈaːmən ɔm ˈits nˈiws tə ɔntdˈɛkən]",
-                "pt": "[vˌiˈemʊs pˌaɾæ dˌeskobrˈiɾ ˈaʊɡʊ]",
-                "en": "[wiː kˈeɪm tə dɪskˈʌvə sˈʌmθɪŋ njˈuː]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-033",
-            "text": {
-                "fr": "Et nous l'avons trouvé.",
-                "en": "and we found it.",
-                "de": "Und wir haben es gefunden.",
-                "it": "E l'abbiamo trovato.",
-                "es": "Y lo hemos encontrado.",
-                "nl": "en dat hebben we gevonden.",
-                "pt": "E encontramos.",
-                "en_pt": "And we found it."
-            },
-            "ipa": {
-                "fr": "e nu lavˈɔ̃ tʁuvˈe",
-                "de": "[ʊnt viːɾ hˌɑːbən ɛs ɡəfˈʊndən]",
-                "it": "[ˌe labːjˌamo trovˈaːto]",
-                "es": "[i lo ˈe.mos en.konˈtɾa.ðo]",
-                "nl": "[ɛn dɑt hˌɛbən ʋə ɣəvˈɔndən]",
-                "pt": "[i ˌeɪŋkoŋtrˈɐ̃mʊs]",
-                "en": "[and wiː fˈaʊnd ɪt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-034",
-            "text": {
-                "fr": "Qu'avons-nous trouvé exactement?",
-                "en": "What exactly did we find?",
-                "de": "Was haben wir genau gefunden?",
-                "it": "Cosa abbiamo trovato esattamente?",
-                "es": "¿Qué hemos encontrado exactamente?",
-                "nl": "Wat hebben we precies gevonden?",
-                "pt": "O que encontramos exatamente?"
-            },
-            "ipa": {
-                "fr": "kavˈɔ̃nu tʁuvˈe ɛɡzaktəmˈɑ̃",
-                "de": "[vˈas hˌɑːbən viːɾ ɡənˈaʊ ɡəfˈʊndən]",
-                "it": "[kˈɔːza abːjˌamo trovˈaːto ˌezatːamˈente]",
-                "es": "[ke ˈe.mos en.konˈtɾa.ðo eksakˈta.mente]",
-                "nl": "[ʋɑt hˌɛbən ʋə preːsˈis ɣəvˈɔndən]",
-                "pt": "[ʊ ky ˌeɪŋkoŋtrˈɐ̃mʊz ˌezatæmˈeɪŋtʃy]",
-                "en": "[wˌɒt ɛɡzˈaktli dˈɪd wiː fˈaɪnd]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-035",
-            "text": {
-                "fr": "Peut-être simplement que nous sommes capables d'affronter l'incertitude",
-                "en": "Maybe just that we are capable of facing uncertainty",
-                "de": "Vielleicht einfach, dass wir fähig sind, der Ungewissheit zu begegnen",
-                "it": "Forse solo che siamo capaci di affrontare l'incertezza",
-                "es": "Quizás simplemente que somos capaces de enfrentar la incertidumbre",
-                "nl": "Misschien gewoon dat we in staat zijn om onzekerheid het hoofd te bieden",
-                "pt": "Talvez simplesmente que somos capazes de enfrentar a incerteza.",
-                "en_pt": "Perhaps simply that we're capable of facing uncertainty."
-            },
-            "ipa": {
-                "fr": "pˈøtˈɛtʁ sɛ̃pləmˈɑ̃ kə nu sɔm kapˈabl dafʁɔ̃tˈe lɛ̃sɛʁtitˈyd",
-                "de": "[fiːllˈaɪçt ˈaɪnfˌax\n das viːɾ fˈɛːɪç zɪnt\n dɛɾ ˈʊnɡəvˌɪshaɪt tsuː bəɡˈeːɡnən]",
-                "it": "[fˈoːrse sˈoːlo kˌe sjˌamo kapˈaːtʃɪ dˌɪ ˌaffrontˈaːre lˌintʃertˈetsːa]",
-                "es": "[kiˈθas sim.pleˈmen.te ke ˈso.mos kaˈpa.θes de en.fɾenˈtaɾ la inθerˈti.ðum.bɾe]",
-                "nl": "[mɪsxˈin ɣəʋˈoːn dɑt ʋə ɪn stˈaːt zɛɪn ɔm ɔnzˈeːkərhˌɛɪt hət hˈoːvd tə bˈidən]",
-                "pt": "[taʊvˈes sˌimplezmˈeɪŋtʃy ky sˌomʊs kˌapˈazyz dʒj ˌeɪŋfreɪŋtˈaɾ a ˌiŋseɾətˈezæ]",
-                "en": "[mˈeɪbiː dʒˈʌst ðat wiː ɑː kˈeɪpəbəl ɒv fˈeɪsɪŋ ʌnsˈɜːtənti]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-036",
-            "text": {
-                "fr": "Et que notre amour peut exister même dans cette incertitude.",
-                "en": "and that our love can exist even in that uncertainty.",
-                "de": "Und dass unsere Liebe auch in dieser Ungewissheit bestehen kann.",
-                "it": "E che il nostro amore può esistere anche in questa incertezza.",
-                "es": "y que nuestro amor puede existir incluso en esa incertidumbre.",
-                "nl": "en dat onze liefde zelfs in die onzekerheid kan bestaan.",
-                "pt": "E que nosso amor pode existir mesmo nesta incerteza.",
-                "en_pt": "And that our love can exist even in this uncertainty."
-            },
-            "ipa": {
-                "fr": "e kə nɔtʁ amˈuʁ pˈøt ɛɡzistˈe mˈɛm dɑ̃ sɛt ɛ̃sɛʁtitˈyd",
-                "de": "[ʊnt das ˌʊnzrə lˈiːbə ˌaʊx ɪn dˌiːzɜ ˈʊnɡəvˌɪshaɪt bəʃtˈeːən kˌan]",
-                "it": "[ˌe kˌe ˌil nˌɔstro amˈoːre pʊˈɔ ezˈistere ˈanke ˌin kwˌɛsta ˌintʃertˈetsːa]",
-                "es": "[i ke nweˈstɾo aˈmoɾ ˈpwe.ðe eksisˈtiɾ inˈklu.so en ˈe.sa inθerˈti.ðum.bɾe]",
-                "nl": "[ɛn dɑt ɔnzˌə lˈivdə zˈɛlfs ɪn di ɔnzˈeːkərhˌɛɪt kɑn bəstˈaːn]",
-                "pt": "[i ky nˌɔsʊ æmˈor pˌɔdʒj ˌezistʃˈir mˈezmʊ nˌɛstæ ˌiŋseɾətˈezæ]",
-                "en": "[and ðat aʊə lˈʌv kan ɛɡzˈɪst ˈiːvən ɪn ðat ʌnsˈɜːtənti]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-037",
-            "text": {
-                "fr": "C'est déjà beaucoup,",
-                "en": "That's already a lot,",
-                "de": "Das ist schon viel,",
-                "it": "È già tanto,",
-                "es": "Eso ya es mucho,",
-                "nl": "Dat is al heel wat,",
-                "pt": "Já é muito.",
-                "en_pt": "It's already a lot."
-            },
-            "ipa": {
-                "fr": "sɛ deʒˈa bokˈu",
-                "de": "[das ɪst ʃˌoːn fˈiːl]",
-                "it": "[ˌɛ dʒˈa tˈanto]",
-                "es": "[ˈe.so ʝa es ˈmu.tʃo]",
-                "nl": "[dɑt ɪs ˈɑl hˈeːl ʋɑt]",
-                "pt": "[ʒˈa ɛ mwˈiŋtʊ]",
-                "en": "[ðats ɔːlɹˌɛdi ɐ lˈɒt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-038",
-            "text": {
-                "fr": "Oui. C'est déjà beaucoup.",
-                "en": "Yes. That's already a lot.",
-                "de": "Ja. Das ist schon viel.",
-                "it": "Sì. È già tanto.",
-                "es": "Sí. Ya es mucho.",
-                "nl": "Ja. Dat is al heel wat.",
-                "pt": "Já é muito, diz Lucas.",
-                "en_pt": "That's already a lot, Lucas says."
-            },
-            "ipa": {
-                "fr": "wˈi sɛ deʒˈa bokˈu",
-                "de": "[jˈɑː\n das ɪst ʃˌoːn fˈiːl]",
-                "it": "[sˈi\n ˌɛ dʒˈa tˈanto]",
-                "es": "[si | ʝa es ˈmu.tʃo]",
-                "nl": "[jˈaː\n dɑt ɪs ˈɑl hˈeːl ʋɑt]",
-                "pt": "[ʒˈa ɛ mwˈiŋtʊ\n dʒˈiz lˈukæs]",
-                "en": "[jˈɛs ðats ɔːlɹˌɛdi ɐ lˈɒt]"
-            },
-            "provenance": {
-                "fr": "original",
-                "de": "original",
-                "it": "original",
-                "es": "original",
-                "nl": "original",
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-039",
             "text": {
                 "fr": "L'hélicoptère atterrit au poste de secours.",
                 "en": "The helicopter lands at the rescue station.",
@@ -1225,10 +60,10 @@
             }
         },
         {
-            "id": "scene-16-040",
+            "id": "scene-16-002",
             "text": {
                 "fr": "Lucas attend dehors, fou d'angoisse.",
-                "en": "Lucas waits outside, mad with anxiety.",
+                "en": "Lucas waits outside, frantic with anxiety.",
                 "de": "Lucas wartet draußen, völlig ängstlich.",
                 "it": "Lucas aspetta fuori, impazzito d'ansia.",
                 "es": "Lucas espera afuera, loco de angustia.",
@@ -1243,7 +78,7 @@
                 "es": "[ˈlu.kas esˈpe.ɾa aˈfwera | ˈlo.ko de anˈɣus.tja]",
                 "nl": "[lˈykɑs ʋˈɑxt bˈœytən\n ɣˈɛk vɑn ˈɑŋst]",
                 "pt": "[lˈukæz ˌespˈɛɾæ dʊ lˈadʊ dʒy fˈɔɾæ\n lˈowkʊ dʒj ˌɐ̃ŋɡˈustʃjæ]",
-                "en": "[lˈuːkəz wˈeɪts aʊtsˈaɪd mˈad wɪð aŋzˈaɪəti]"
+                "en": "[lˈuːkəz wˈeɪts aʊtsˈaɪd fɹˈantɪk wɪð aŋzˈaɪəti]"
             },
             "provenance": {
                 "fr": "original",
@@ -1256,10 +91,10 @@
             }
         },
         {
-            "id": "scene-16-041",
+            "id": "scene-16-003",
             "text": {
                 "fr": "Quand Sophie descend, il court vers elle.",
-                "en": "When Sophie gets out, he runs towards her.",
+                "en": "When Sophie comes down, he runs towards her.",
                 "de": "Als Sophie aussteigt, läuft er auf sie zu.",
                 "it": "Quando Sophie scende, lui corre verso di lei.",
                 "es": "Cuando Sophie baja, él corre hacia ella.",
@@ -1274,7 +109,7 @@
                 "es": "[ˈkwan.do ˈso.fi ˈba.xa | el ˈko.re ˈa.θja ˈe.ʎa]",
                 "nl": "[ɑl sɔphˈi ˈœytstˌɑpt\n rˈɛnt hɛɪ naːr haːr tˈu]",
                 "pt": "[kwˈɐ̃ŋdʊ sˌofˈiy dˈɛsy\n ˌely kˈɔxi ˈeɪŋ dʒˌiɾesˈɐ̃ʊ̃ a ˈɛlæ]",
-                "en": "[wˌɛn sˈəʊfi ɡˈɛts ˈaʊt hiː ɹˈʌnz tʊwˈɔːdz hɜː]"
+                "en": "[wˌɛn sˈəʊfi kˈʌmz dˈaʊn hiː ɹˈʌnz tʊwˈɔːdz hɜː]"
             },
             "provenance": {
                 "fr": "original",
@@ -1287,10 +122,56 @@
             }
         },
         {
-            "id": "scene-16-042",
+            "id": "scene-16-004",
+            "text": {
+                "pt": "Sophie!",
+                "en": "Sophie!"
+            },
+            "ipa": {
+                "pt": "[sˌofˈiy]",
+                "en": "[sˈəʊfi]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-005",
+            "text": {
+                "fr": "Sophie! Dieu merci, tu es vivante!",
+                "en": "Sophie! Thank God, you are alive!",
+                "de": "Sophie! Gott sei Dank, du lebst noch!",
+                "it": "Sophie! Grazie a Dio, sei viva!",
+                "es": "¡Sophie! Menos mal que estás viva.",
+                "nl": "Sophie! Godzijdank, je leeft nog!",
+                "pt": "Graças a Deus você está viva!",
+                "en_pt": "Thank God you're alive!"
+            },
+            "ipa": {
+                "fr": "sɔfˈi djˈø mɛʁsˈi ty ɛ vivˈɑ̃t",
+                "de": "[zoːfˈiː\n ɡˈɔt zˈaɪ dˈaŋk\n duː lˈeːpst nˈɔx]",
+                "it": "[sˈopje\n ɡrˈatsje ˌa dˈiːo\n sˌɛj vˈiːva]",
+                "es": "[ˈso.fi | ˈme.nos mal ke esˈtas ˈβi.βa]",
+                "nl": "[sɔphˈi\n ɣˈɔdzɛɪdˌɑŋk\n jə lˈeːft nˈɔx]",
+                "pt": "[ɡrˈasæz a dˈeʊz vosˌe estˌa vˈivæ]",
+                "en": "[sˈəʊfi θˈaŋk ɡˈɒd juː ɑːɹ ɐlˈaɪv]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-006",
             "text": {
                 "fr": "Ils s'embrassent, pleurant tous les deux.",
-                "en": "They embrace each other, both crying.",
+                "en": "They kiss, both crying.",
                 "de": "Sie umarmen sich, beide weinend.",
                 "it": "Si abbracciano, piangendo entrambi.",
                 "es": "Se abrazan, llorando ambos.",
@@ -1305,7 +186,7 @@
                 "es": "[se aˈβɾa.θan | ʎoˈɾan.do ˈam.bos]",
                 "nl": "[zə ˈɔmhɛlzən ˈɛlkaːr\n bˈɛɪdən hˈœylənt]",
                 "pt": "[ˌelys sj ˌabrˈasɐ̃ʊ̃\n ʃˌoɾˈɐ̃ŋdw ʊz dˈoɪs]",
-                "en": "[ðeɪ ɛmbɹˈeɪs ˈiːtʃ ˈʌðə bˈəʊθ kɹˈaɪɪŋ]"
+                "en": "[ðeɪ kˈɪs bˈəʊθ kɹˈaɪɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1318,10 +199,180 @@
             }
         },
         {
-            "id": "scene-16-043",
+            "id": "scene-16-007",
+            "text": {
+                "pt": "Lucas!",
+                "en": "Lucas!"
+            },
+            "ipa": {
+                "pt": "[lˈukæs]",
+                "en": "[lˈuːkəz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-008",
+            "text": {
+                "fr": "Lucas! J'avais tellement peur pour toi!",
+                "en": "Lucas! I was so scared for you!",
+                "de": "Lucas! Ich hatte solche Angst um dich!",
+                "it": "Lucas! Avevo così paura per te!",
+                "es": "¡Lucas! ¡Tenía tanto miedo por ti!",
+                "nl": "Lucas! Ik was zo bang voor je!",
+                "pt": "Estava com tanto medo por você!",
+                "en_pt": "I was so afraid for you!"
+            },
+            "ipa": {
+                "fr": "lykˈa ʒavˈɛ tɛlmˈɑ̃ pˈœʁ puʁ twˈa",
+                "de": "[lˈuːkɑːs\n ɪç hˌatə zˈɔlçə ˈaŋst ʊm dˈɪç]",
+                "it": "[lˈuːkas\n avˌɛvo kozˈi paˈuːra pˌɛr tˈe]",
+                "es": "[ˈlu.kas | ˈte.nja ˈtan.to ˈmje.ðo por ti]",
+                "nl": "[lˈykɑs\n ɪk ʋˈɑ soː bˈɑŋ vɔːr jə]",
+                "pt": "[estˌavæ koŋ tˈɐ̃ŋtʊ mˈedʊ por vosˈe]",
+                "en": "[lˈuːkəz aɪ wɒz sˌəʊ skˈeəd fɔː juː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-009",
+            "text": {
+                "fr": "Pardonne-moi de t'avoir laissée partir seule",
+                "en": "Forgive me for letting you leave alone",
+                "de": "Verzeih mir, dass ich dich alleine gehen ließ",
+                "it": "Perdonami per averti lasciata andare da sola",
+                "es": "Perdóname por haberte dejado ir sola.",
+                "nl": "Sorry dat ik je alleen heb laten gaan",
+                "pt": "Me perdoa por ter deixado você ir sozinha.",
+                "en_pt": "Forgive me for letting you go alone."
+            },
+            "ipa": {
+                "fr": "paʁdˈɔnmwˌa də- tavwˈaʁ lɛsˈe paʁtˈiʁ sˈœl",
+                "de": "[fɛɾtsˈaɪ mˈiːɾ\n das ɪç dɪç alˈaɪnə ɡˈeːən lˈiːs]",
+                "it": "[perdˈonamɪ pˌɛr avˈɛːrtɪ laʃˈaːta andˈaːre dˌa sˈoːla]",
+                "es": "[perˈðo.na.me por aˈβer.te deˈxa.ðo ir ˈso.la]",
+                "nl": "[sˈɔɾri dɑt ɪk jə ɑlˈeːn hɛp lˈaːtən ɣˈaːn]",
+                "pt": "[my pˌeɾədˈoæ por ter dˌeɪʃˈadʊ vosˌe ˈir sˌozˈiɲæ]",
+                "en": "[fəɡˈɪv mˌiː fɔː lˈɛtɪŋ juː lˈiːv ɐlˈəʊn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-010",
+            "text": {
+                "fr": "Je suis tellement désolé.",
+                "en": "I am so sorry.",
+                "de": "Es tut mir so leid.",
+                "it": "Sono davvero dispiaciuto.",
+                "es": "Lo siento muchísimo.",
+                "nl": "Het spijt me zo.",
+                "pt": "Sinto muito.",
+                "en_pt": "I'm so sorry."
+            },
+            "ipa": {
+                "fr": "ʒə- syˌi tɛlmˈɑ̃ dezɔlˈe",
+                "de": "[ɛs tˈuːt miːɾ zoː lˈaɪt]",
+                "it": "[sˌono davvˈeːro dˌispjatʃˈuːto]",
+                "es": "[lo ˈsjen.to muˈtʃi.si.mo]",
+                "nl": "[hət spˈɛɪt mə zˈoː]",
+                "pt": "[sˈiŋtʊ mwˈiŋtʊ]",
+                "en": "[aɪɐm sˌəʊ sˈɒɹi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-011",
+            "text": {
+                "fr": "Non, c'est moi qui aurais dû t'écouter",
+                "en": "No, it is I who should have listened to you",
+                "de": "Nein, ich hätte auf dich hören sollen",
+                "it": "No, sono io che avrei dovuto ascoltarti",
+                "es": "No, debería haber sido yo quien te escuchara.",
+                "nl": "Nee, ik had naar je moeten luisteren",
+                "pt": "Não, fui eu quem deveria ter te escutado.",
+                "en_pt": "No, I'm the one who should have listened to you."
+            },
+            "ipa": {
+                "fr": "nˈɔ̃ sɛ mwˌa ki oʁˈɛ dˈyː tekutˈe",
+                "de": "[nˈaɪn\n ɪç hˌɛtə aʊf dɪç hˈøːrən zˌɔlən]",
+                "it": "[nˈɔ\n sˌono ˌio kˌe avrˈeːɪ dovˈuːto ˌaskoltˈaːrtɪ]",
+                "es": "[no | deˈβe.ɾja aˈβer siˈðo jo kjen te eskuˈtʃa.ɾa]",
+                "nl": "[nˈeː\n ɪk hˈɑt naːr jə mˈutən lˈœystərən]",
+                "pt": "[nˈɐ̃ʊ̃\n fuɪ eʊ kˈeɪŋ dˌeveɾˈiæ ter tʃj ˌeskutˈadʊ]",
+                "en": "[nˈəʊ ɪt ɪz aɪ hˌuː ʃˌʊdəv lˈɪsənd tə juː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-012",
+            "text": {
+                "fr": "Tu voulais faire demi-tour.",
+                "en": "You wanted to turn back",
+                "de": "Du wolltest umkehren.",
+                "it": "Volevi tornare indietro.",
+                "es": "Tú querías volver atrás.",
+                "nl": "Je wilde omdraaien.",
+                "pt": "Você queria voltar.",
+                "en_pt": "You wanted to turn back."
+            },
+            "ipa": {
+                "fr": "ty vulˈɛ fˈɛʁ dəmˈitˈuʁ",
+                "de": "[duː vɔltəst ʊmkˈeːrən]",
+                "it": "[volˈɛːvɪ tornˈaːre indjˈɛːtro]",
+                "es": "[tu keˈɾjas ˈbol.βer aˈtras]",
+                "nl": "[jə ʋˌɪldə ˈɔmdraːjən]",
+                "pt": "[vosˌe kˌeɾˈiæ vowtˈar]",
+                "en": "[juː wˈɒntɪd tə tˈɜːn bˈak]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-013",
             "text": {
                 "fr": "Ils restent enlacés un long moment.",
-                "en": "They remain embraced for a long time.",
+                "en": "They remain embraced for a long moment.",
                 "de": "Sie bleiben lange Zeit umschlungen.",
                 "it": "Restano abbracciati per un lungo momento.",
                 "es": "Permanecen abrazados un largo tiempo.",
@@ -1336,7 +387,7 @@
                 "es": "[per.maˈne.θen aˈβɾa.θa.ðos un ˈlar.ɣo ˈtjem.po]",
                 "nl": "[zə blˈɛɪvən lˈɑŋ ˈoːmɑrmt]",
                 "pt": "[ˌelys fˈikɐ̃ʊ̃ ˌabrasˈadʊs poɾ ũŋ lˈoŋɡʊ mˌomˈeɪŋtʊ]",
-                "en": "[ðeɪ ɹɪmˈeɪn ɛmbɹˈeɪst fəɹə lˈɒŋ tˈaɪm]"
+                "en": "[ðeɪ ɹɪmˈeɪn ɛmbɹˈeɪst fəɹə lˈɒŋ mˈəʊmənt]"
             },
             "provenance": {
                 "fr": "original",
@@ -1349,16 +400,46 @@
             }
         },
         {
-            "id": "scene-16-044",
+            "id": "scene-16-014",
+            "text": {
+                "fr": "L'important, c'est que nous soyons tous les deux sains et saufs.",
+                "en": "The important thing is that we are both safe and sound.",
+                "de": "Das Wichtigste ist, dass wir beide heil sind.",
+                "it": "L'importante è che siamo entrambi sani e salvi.",
+                "es": "Lo importante es que ambos estamos bien.",
+                "nl": "Het belangrijkste is dat we allebei veilig zijn.",
+                "pt": "O importante é que estamos os dois bem.",
+                "en_pt": "The important thing is that we're both okay."
+            },
+            "ipa": {
+                "fr": "lɛ̃pɔʁtˈɑ̃ sɛ kə nu swajˈɔ̃ tu le- dˈø sˈɛ̃z e sˈof",
+                "de": "[das vˈɪçtɪçstə ɪst\n das viːɾ bˈaɪdə hˈaɪl zɪnt]",
+                "it": "[lˌimportˈante ˌɛ kˌe sjˌamo entrˈambɪ sˈaːnɪ ˌe sˈalvɪ]",
+                "es": "[lo imporˈtan.te es ke ˈam.bos esˈta.mos ˈβjen]",
+                "nl": "[hət bəlˈɑŋrɛɪkstə ɪs dɑt ʋə ˈɑləbˌɛɪ vˈɛɪləx zɛɪn]",
+                "pt": "[u ˌimpoɾətˈɐ̃ŋtʃj ɛ ky estˌɐ̃mʊz ʊz dˈoɪz bˈeɪŋ]",
+                "en": "[ðɪ ɪmpˈɔːtənt θˈɪŋ ɪz ðat wiː ɑː bˈəʊθ sˈeɪf and sˈaʊnd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-015",
             "text": {
                 "fr": "Un secouriste leur apporte du thé chaud.",
-                "en": "A rescuer brings them warm tea.",
+                "en": "A rescuer brings them hot tea.",
                 "de": "Ein Sanitäter bringt ihnen heißen Tee.",
                 "it": "Un soccorritore porta loro del tè caldo.",
                 "es": "Un socorrista les trae té caliente.",
                 "nl": "Een reddingswerker brengt hen warme thee.",
-                "pt": "Um socorrista lhes traz chá quente.",
-                "en_pt": "A rescuer brings them hot tea."
+                "pt": "Um socorrista lhes traz chá quente."
             },
             "ipa": {
                 "fr": "œ̃ səkuʁˈist lœʁ apˈɔʁt dy- tˈe ʃˈo",
@@ -1367,7 +448,7 @@
                 "es": "[un so.koˈris.ta les ˈtɾae te kaˈljen.te]",
                 "nl": "[ən rˈɛdɪŋsʋˌɛrkər brˈɛŋt hɛn ʋˈɑrmə tˈeː]",
                 "pt": "[ũŋ sˌokoxˈistæ ʎˈys trˈas ʃˈa kˈeɪŋtʃy]",
-                "en": "[ɐ ɹˈɛskjuːə bɹˈɪŋz ðˌɛm wˈɔːm tˈiː]"
+                "en": "[ɐ ɹˈɛskjuːə bɹˈɪŋz ðˌɛm hˈɒt tˈiː]"
             },
             "provenance": {
                 "fr": "original",
@@ -1380,16 +461,15 @@
             }
         },
         {
-            "id": "scene-16-045",
+            "id": "scene-16-016",
             "text": {
                 "fr": "Ils s'assoient ensemble, encore tremblants.",
-                "en": "They sit down together, still trembling.",
+                "en": "They sit together, still trembling.",
                 "de": "Sie sitzen zusammen, immer noch zitternd.",
                 "it": "Si siedono insieme, ancora tremanti.",
                 "es": "Se sientan juntos, todavía temblando.",
                 "nl": "Ze gaan samen zitten, nog steeds trillend.",
-                "pt": "Eles sentam juntos, ainda tremendo.",
-                "en_pt": "They sit together, still trembling."
+                "pt": "Eles sentam juntos, ainda tremendo."
             },
             "ipa": {
                 "fr": "il saswˈat ɑ̃sˈɑ̃bl ɑ̃kˌɔʁ tʁɑ̃blˈɑ̃",
@@ -1398,7 +478,7 @@
                 "es": "[se ˈsjen.tan ˈxun.tos | to.ðaˈβja temˈblan.do]",
                 "nl": "[zə ɣˈaːn sˈaːmən zˈɪtən\n nˈɔx stˈeːts trˈɪlənt]",
                 "pt": "[ˌelys sˈeɪŋtɐ̃ʊ̃ ʒˈũŋtʊs\n ˌaˈiŋdæ trˌemˈeɪŋdʊ]",
-                "en": "[ðeɪ sˈɪt dˌaʊn təɡˈɛðə stˈɪl tɹˈɛmblɪŋ]"
+                "en": "[ðeɪ sˈɪt təɡˈɛðə stˈɪl tɹˈɛmblɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1411,16 +491,337 @@
             }
         },
         {
-            "id": "scene-16-046",
+            "id": "scene-16-017",
+            "text": {
+                "fr": "Cette expérience nous a changés,",
+                "en": "This experience has changed us,",
+                "de": "Diese Erfahrung hat uns verändert,",
+                "it": "Questa esperienza ci ha cambiati,",
+                "es": "Esta experiencia nos ha cambiado,",
+                "nl": "Deze ervaring heeft ons veranderd,",
+                "pt": "Esta experiência nos mudou, diz Sophie suavemente.",
+                "en_pt": "This experience changed us, Sophie says softly."
+            },
+            "ipa": {
+                "fr": "sɛt ɛkspeʁjˈɑ̃s nuz a ʃɑ̃ʒˈe",
+                "de": "[dˌiːzə ɛɾfˈɑːrʊŋ hat ʊns fɛɾˈɛndɜt]",
+                "it": "[kwˌɛsta ˌesperiˈɛntsa tʃˌɪ ˌa kambjˈaːtɪ]",
+                "es": "[ˈes.ta ekspeˈɾjen.θja nos a kamˈβja.ðo]",
+                "nl": "[dˌeːzə ɛrvˈaːrɪŋ heːft ɔns vərˈɑndərt]",
+                "pt": "[ˌɛstæ ˌespeɾjˈeɪŋsjæ nʊz mudˈow\n dʒˈis sˌofˈiy sˌuavemˈeɪŋtʃy]",
+                "en": "[ðɪs ɛkspˈiəɹɪəns hɐz tʃˈeɪndʒd ˌʌs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-018",
+            "text": {
+                "fr": "Mais elle nous a aussi coûté quelque chose.",
+                "en": "But it also cost us something.",
+                "de": "Aber sie hat uns auch etwas gekostet.",
+                "it": "Ma ci ha anche costato qualcosa.",
+                "es": "pero también nos ha costado algo.",
+                "nl": "Maar het heeft ons ook iets gekost.",
+                "pt": "Mas também nos custou algo."
+            },
+            "ipa": {
+                "fr": "mɛz ɛl nuz a osˌi kutˈe kˌɛlkə ʃˈoz",
+                "de": "[ˌɑːbɜ ziː hat ʊns ˌaʊx ˈɛtvɑːs ɡəkˈɔstət]",
+                "it": "[mˌa tʃˌɪ ˌa ˈanke kostˈaːto kwalkˈɔːza]",
+                "es": "[ˈpe.ro tamˈbjen nos a kosˈta.ðo ˈal.ɣo]",
+                "nl": "[maːr hət heːft ɔns oːk ˈits ɣəkˈɔst]",
+                "pt": "[mas tɐ̃mbˈeɪŋ nʊs kustˈow ˈaʊɡʊ]",
+                "en": "[bˌʌt ɪt ˈɒlsəʊ kˈɒst ˌʌs sˈʌmθɪŋ]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-019",
+            "text": {
+                "fr": "Qu'est-ce qu'elle nous a coûté?",
+                "en": "What did it cost us?",
+                "de": "Was hat sie uns gekostet?",
+                "it": "Cosa ci ha costato?",
+                "es": "¿Qué nos ha costado?",
+                "nl": "Wat heeft het ons gekost?",
+                "pt": "O que nos custou?"
+            },
+            "ipa": {
+                "fr": "kɛs kɛl nuz a kutˈe",
+                "de": "[vˈas hat ziː ʊns ɡəkˈɔstət]",
+                "it": "[kˈɔːza tʃˌɪ ˌa kostˈaːto]",
+                "es": "[ke nos a kosˈta.ðo]",
+                "nl": "[ʋɑt heːft hət ɔns ɣəkˈɔst]",
+                "pt": "[ʊ ky nʊs kustˈow]",
+                "en": "[wˌɒt dˈɪd ɪt kˈɒst ˌʌs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-020",
+            "text": {
+                "pt": "pergunta Lucas.",
+                "en": "Lucas asks."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ lˈukæs]",
+                "en": "[lˈuːkəz ˈasks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-021",
+            "text": {
+                "fr": "Notre innocence, peut-être",
+                "en": "Our innocence, perhaps",
+                "de": "Vielleicht unsere Unschuld",
+                "it": "Forse la nostra innocenza",
+                "es": "Quizás nuestra inocencia.",
+                "nl": "Onze onschuld, misschien",
+                "pt": "Nossa inocência, talvez.",
+                "en_pt": "Our innocence, perhaps."
+            },
+            "ipa": {
+                "fr": "nɔtʁ inɔsˈɑ̃s pˈøtˈɛtʁ",
+                "de": "[fiːllˈaɪçt ˌʊnzrə ˈʊnʃˌʊlt]",
+                "it": "[fˈoːrse lˌa nˌɔstra ˌinnotʃˈɛntsa]",
+                "es": "[kiˈθas nweˈstra i.noˈθen.θja]",
+                "nl": "[ɔnzˌə ɔnsxˈɵlt\n mɪsxˈin]",
+                "pt": "[nˌɔsæ ˌinosˈeɪŋsjæ taʊvˈes]",
+                "en": "[aʊəɹ ˈɪnəsəns pəhˈaps]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-022",
+            "text": {
+                "fr": "L'illusion que nous pouvions contrôler nos vies",
+                "en": "The illusion that we could control our lives",
+                "de": "Die Illusion, dass wir unser Leben kontrollieren können",
+                "it": "L'illusione che potessimo controllare le nostre vite",
+                "es": "La ilusión de que podíamos controlar nuestras vidas",
+                "nl": "De illusie dat we ons leven konden beheersen",
+                "pt": "A ilusão de que podíamos controlar nossas vidas.",
+                "en_pt": "The illusion that we could control our lives."
+            },
+            "ipa": {
+                "fr": "lilyzjˈɔ̃ kə nu puvjˈɔ̃ kɔ̃tʁolˈe no vˈi",
+                "de": "[diː ɪluːzjˈoːn\n das viːɾ ˌʊnzɜ lˈeːbən kɔntɾɔlˈiːrən kˈœnən]",
+                "it": "[lˌillʊziˈoːne kˌe potˈessimo kˌontrollˈaːre lˌe nˌɔstre vˈiːte]",
+                "es": "[la i.luˈsjon de ke poˈði.a.mos kon.tɾoˈlaɾ nweˈstɾas ˈβi.ðas]",
+                "nl": "[də ɪlˈyzˌi dɑt ʋə ɔns lˈeːvən kˌɔndən bəhˈɪːrsən]",
+                "pt": "[a ˌiluzˈɐ̃ʊ̃ dʒy ky podʒˌiæmʊs kˌoŋtrolˈar nˌɔsæz vˈidæs]",
+                "en": "[ðɪ ɪlˈuːʒən ðat wiː kʊd kəntɹˈəʊl aʊə lˈaɪvz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-023",
+            "text": {
+                "fr": "Le bonheur facile.",
+                "en": "Easy happiness.",
+                "de": "Das unbeschwerte Glück.",
+                "it": "La felicità facile.",
+                "es": "La felicidad fácil.",
+                "nl": "Het gemakkelijke geluk.",
+                "pt": "A felicidade fácil."
+            },
+            "ipa": {
+                "fr": "lə- bɔnˈœʁ fasˈil",
+                "de": "[das ˈʊnbəʃvˌeːɾtə ɡlˈʏk]",
+                "it": "[lˌa fˌɛlitʃitˈa fˈatʃile]",
+                "es": "[la fe.liθiˈðað ˈfa.θil]",
+                "nl": "[hət ɣəmˈɑkələkə ɣəlˈɵk]",
+                "pt": "[a fˌelisidˈadʒy fˈasiʊ]",
+                "en": "[ˈiːzi hˈapɪnəs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-024",
+            "text": {
+                "fr": "Je ne suis plus la même personne qu'avant",
+                "en": "I am no longer the same person as before",
+                "de": "Ich bin nicht mehr dieselbe Person wie früher",
+                "it": "Non sono più la stessa persona di prima",
+                "es": "Ya no soy la misma persona que antes.",
+                "nl": "Ik ben niet meer dezelfde persoon als voorheen",
+                "pt": "Não sou mais a mesma pessoa de antes.",
+                "en_pt": "I'm not the same person I was before."
+            },
+            "ipa": {
+                "fr": "ʒə- nə- syˌi ply la- mˈɛm pɛʁsˈɔn kavˈɑ̃",
+                "de": "[ɪç bɪn nˈɪçt mˌeːɾ diːzˈɛlbə pɛɾzˈoːn viː frˈyːɜ]",
+                "it": "[nˌon sˌono pjˌʊ lˌa stˈessa persˈoːna dˌɪ prˈiːma]",
+                "es": "[ʝa no soi la ˈmis.ma perˈso.na ke ˈan.tes]",
+                "nl": "[ɪk bɛn nˈit mˌeːr dəzˈɛlvdə pɛrsˈoːn ɑls vˈɔːrhˌeːn]",
+                "pt": "[nˌɐ̃ʊ̃ sow mˈaɪz a mˈezmæ pˌesˈoæ dʒj ˈɐ̃ŋtʃys]",
+                "en": "[aɪɐm nˌəʊ lˈɒŋɡə ðə sˈeɪm pˈɜːsən az bɪfˈɔː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-025",
+            "text": {
+                "fr": "Cette nuit dans la montagne.",
+                "en": "That night in the mountain.",
+                "de": "Diese Nacht in den Alpen.",
+                "it": "Quella notte sulla montagna.",
+                "es": "Esa noche en los Pirineos.",
+                "nl": "Die nacht in de Ardennen.",
+                "pt": "Esta noite na montanha...",
+                "en_pt": "This night on the mountain..."
+            },
+            "ipa": {
+                "fr": "sɛt nyˈi dɑ̃ la- mɔ̃tˈaɲ",
+                "de": "[dˌiːzə nˈaxt ɪn deːn ˈalpən]",
+                "it": "[kwˌɛlla nˈɔtːe sˌʊlla montˈaɲɲa]",
+                "es": "[ˈe.sa ˈno.tʃe en los piɾiˈne.os]",
+                "nl": "[di nˈɑxt ɪn də ˈɑrdɛnən]",
+                "pt": "[ˌɛstæ nˈoɪtʃy na mˌoŋtˈɐ̃ɲæ]",
+                "en": "[ðat nˈaɪt ɪnðə mˈaʊntɪn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-026",
+            "text": {
+                "fr": "Moi non plus, j'ai appris tellement de choses",
+                "en": "Me neither, I learned so many things",
+                "de": "Ich auch, ich habe so viel gelernt",
+                "it": "Nemmeno io, ho imparato tantissimo",
+                "es": "Yo también, he aprendido tantas cosas.",
+                "nl": "Ik ook niet, ik heb zoveel geleerd",
+                "pt": "Eu também, aprendi tantas coisas.",
+                "en_pt": "Me too, I learned so many things."
+            },
+            "ipa": {
+                "fr": "mwˌa nɔ̃ plˈy ʒe apʁˈi tɛlmˈɑ̃ də- ʃˈoz",
+                "de": "[ɪç ˈaʊx\n ɪç hɑːbə zoː fˈiːl ɡəlˈɛɾnt]",
+                "it": "[nemmˈeːno ˈio\n ˌo ˌimparˈaːto tantˈissimo]",
+                "es": "[ʝo tamˈbjen | e a.prenˈdi.ðo ˈtan.tas ˈko.sas]",
+                "nl": "[ɪk oːk nˈit\n ɪk hɛp zoːvˈeːl ɣəlˈɪːrt]",
+                "pt": "[eʊ tɐ̃mbˈeɪŋ\n ˌapreɪŋdʒˈi tˈɐ̃ŋtæs kˈoɪzæs]",
+                "en": "[mˌiː nˈaɪðə aɪ lˈɜːnd sˌəʊ mˈɛni θˈɪŋz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-027",
+            "text": {
+                "fr": "La chèvre qui m'a guidé, les gens qui m'ont aidé.",
+                "en": "The goat that guided me, the people who helped me.",
+                "de": "Die Ziege, die mich geführt hat, die Menschen, die mir geholfen haben.",
+                "it": "La capra che mi ha guidato, le persone che mi hanno aiutato.",
+                "es": "La cabra que me guió, las personas que me ayudaron.",
+                "nl": "De geit die me leidde, de mensen die me hielpen.",
+                "pt": "A cabra que me guiou, as pessoas que me ajudaram...",
+                "en_pt": "The goat that guided me, the people who helped me..."
+            },
+            "ipa": {
+                "fr": "la- ʃˈɛvʁ ki ma ɡidˈe le- ʒˈɑ̃ ki mɔ̃t ɛdˈe",
+                "de": "[diː tsˈiːɡə\n diː mɪç ɡəfˈyːɾt hat\n diː mˈɛnʃən\n diː miːɾ ɡəhˈɔlfən hˈɑːbən]",
+                "it": "[lˌa kˈaːpra kˌe mˌɪ ˌa ɡwidˈaːto\n lˌe persˈoːne kˌe mˌɪ ˌanno ˌajʊtˈaːto]",
+                "es": "[la ˈka.βɾa ke me ɣiˈo | las perˈso.nas ke me aʝuˈða.ɾon]",
+                "nl": "[də ɣˈɛɪt di mə lˈɛɪdə\n də mˈɛnsən di mə hˈilpən]",
+                "pt": "[a kˈabræ ky my ɡiˈow\n as pˌesˈoæs ky mj ˌaʒudˈaɾɐ̃ʊ̃]",
+                "en": "[ðə ɡˈəʊt ðat ɡˈaɪdɪd mˌiː ðə pˈiːpəl hˌuː hˈɛlpt mˌiː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-028",
             "text": {
                 "fr": "Sophie le regarde avec des yeux nouveaux, mais aussi avec une certaine tristesse.",
-                "en": "Sophie looks at him with new eyes, but also with some sadness.",
+                "en": "Sophie looks at him with new eyes, but also with a certain sadness.",
                 "de": "Sophie sieht ihn mit neuen Augen an, aber auch mit einer gewissen Traurigkeit.",
                 "it": "Sophie lo guarda con occhi nuovi, ma anche con una certa tristezza.",
                 "es": "Sophie lo mira con ojos nuevos, pero también con tristeza.",
                 "nl": "Sophie kijkt hem aan met nieuwe ogen, maar ook met een zekere droefheid.",
-                "pt": "Sophie o olha com olhos novos, mas também com certa tristeza.",
-                "en_pt": "Sophie looks at him with new eyes, but also with a certain sadness."
+                "pt": "Sophie o olha com olhos novos, mas também com certa tristeza."
             },
             "ipa": {
                 "fr": "sɔfˈi lə- ʁəɡˈaʁd avˌɛk de-z jˈø nuvˈo mɛz osˌi avˌɛk yn sɛʁtˈɛn tʁistˈɛs",
@@ -1429,7 +830,7 @@
                 "es": "[ˈso.fi lo ˈmi.ɾa kon ˈo.xos ˈnwe.βos | ˈpe.ro tamˈbjen kon tɾisˈte.θa]",
                 "nl": "[sɔphˈi kˈɛɪkt hˈɛm aːn mɛt nˈiwə ˈoːɣən\n maːr oːk mɛt ən zˈeːkərə drˈufhɛɪt]",
                 "pt": "[sˌofˈij u ˈɔljæ koŋ ˈɔljʊz nˈɔvʊs\n mas tɐ̃mbˈeɪŋ koŋ sˈɛɾətæ trˌistˈezæ]",
-                "en": "[sˈəʊfi lˈʊks at hˌɪm wɪð njˈuː ˈaɪz bˌʌt ˈɒlsəʊ wɪð sˌʌm sˈadnəs]"
+                "en": "[sˈəʊfi lˈʊks at hˌɪm wɪð njˈuː ˈaɪz bˌʌt ˈɒlsəʊ wɪð ɐ sˈɜːtən sˈadnəs]"
             },
             "provenance": {
                 "fr": "original",
@@ -1442,10 +843,425 @@
             }
         },
         {
-            "id": "scene-16-047",
+            "id": "scene-16-029",
+            "text": {
+                "fr": "Était-ce vraiment une chèvre guide, ou juste une chèvre ordinaire? Nous projetons tant de signification sur ce qui nous arrive.",
+                "en": "Was it really a guide goat, or just an ordinary goat? We project so much meaning onto what happens to us.",
+                "de": "War es wirklich eine Führungsziege, oder nur eine gewöhnliche Ziege? Wir legen so viel Bedeutung in das, was uns passiert.",
+                "it": "Era davvero una capra guida, o solo una capra normale? Proiettiamo così tanto significato su ciò che ci accade.",
+                "es": "¿Era realmente una cabra guía, o solo una cabra común? Proyectamos mucho significado en lo que nos pasa.",
+                "nl": "Was het echt een gidsgeit, of gewoon een gewone geit? We leggen zoveel betekenis in wat ons overkomt.",
+                "pt": "Era realmente uma cabra guia, ou apenas uma cabra comum?",
+                "en_pt": "Was it really a guide goat, or just an ordinary goat?"
+            },
+            "ipa": {
+                "fr": "etˈɛs vʁɛmˈɑ̃ yn ʃˈɛvʁ ɡˈid u ʒˈyst yn ʃˈɛvʁ ɔʁdinˈɛʁ nu pʁɔʒtˈɔ̃ tɑ̃ də- siɲifikasjˈɔ̃ syʁ sə- ki nuz aʁˈiv",
+                "de": "[vɑːɾ ɛs vˈɪɾklɪç ˌaɪnə fˈyːrʊŋstsˌiːɡə\n ˌoːdɜ nˈuːɾ ˌaɪnə ɡəvˈøːnlɪçə tsˈiːɡə\n viːɾ lˈeːɡən zoː fˈiːl bədˈɔøtʊŋ ɪn das\n vˈas ʊns pasˈiːɾt]",
+                "it": "[ˌɛra davvˈeːro ˌʊna kˈaːpra ɡwˈiːda\n ˌo sˈoːlo ˌʊna kˈaːpra normˈaːle\n prˌɔɪetːjˈaːmo kozˈi tˌanto sˌiɲifikˈaːto sˌʊ tʃˈɔ kˌe tʃˌɪ akːˈaːde]",
+                "es": "[ˈe.ɾa re.alˈmen.te uˈna ˈka.βɾa ˈɣi.a | o ˈso.lo uˈna ˈka.βɾa koˈmun | pɾo.jekˈta.mos ˈmu.tʃo siɣ.ni.fiˈka.ðo en lo ke nos ˈpa.sa]",
+                "nl": "[ʋˈɑs hət ˈɛxt ən ɣˈɪdsxɛɪt\n ɔf ɣəʋˈoːn ən ɣəʋˈoːnə ɣˈɛɪt\n ʋə lˈɛɣən zoːvˈeːl bətˈeːkənˌɪs ɪn ʋɑt ɔns ˌoːvərkˈɔmt]",
+                "pt": "[ˌɛɾæ xˌeaʊmˈeɪŋtʃj ˌumæ kˈabræ ɡˈiæ\n ow ˌapˈenæz ˌumæ kˈabræ komˈũŋ]",
+                "en": "[wɒz ɪt ɹˈiəlɪ ɐ ɡˈaɪd ɡˈəʊt ɔː dʒˈʌst ɐn ˈɔːdɪnəɹi ɡˈəʊt wiː pɹədʒˈɛkt sˈəʊ mˌʌtʃ mˈiːnɪŋ ˌɒntʊ wɒt hˈapənz tʊ ˌʌs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-030",
+            "text": {
+                "pt": "Projetamos tanto significado no que nos acontece.",
+                "en": "We project so much meaning onto what happens to us."
+            },
+            "ipa": {
+                "pt": "[prˌoʒetˈɐ̃mʊs tˈɐ̃ŋtʊ sˌiɡnifikˈadʊ nʊ ky nʊz ˌakoŋtˈɛsy]",
+                "en": "[wiː pɹədʒˈɛkt sˈəʊ mˌʌtʃ mˈiːnɪŋ ˌɒntʊ wɒt hˈapənz tʊ ˌʌs]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-031",
+            "text": {
+                "pt": "Lucas reflete.",
+                "en": "Lucas reflects."
+            },
+            "ipa": {
+                "pt": "[lˈukæz xˌeflˈɛtʃy]",
+                "en": "[lˈuːkəz ɹɪflˈɛkts]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-032",
+            "text": {
+                "fr": "Peut-être que cela n'a pas d'importance",
+                "en": "Maybe it doesn't matter",
+                "de": "Vielleicht macht das keinen Unterschied",
+                "it": "Forse non ha importanza",
+                "es": "Quizás eso no importa",
+                "nl": "Misschien maakt het niet uit",
+                "pt": "Talvez não importe.",
+                "en_pt": "Maybe it doesn't matter."
+            },
+            "ipa": {
+                "fr": "pˈøtˈɛtʁ kə səlˌa na pa dɛ̃pɔʁtˈɑ̃s",
+                "de": "[fiːllˈaɪçt mˈaxt das kˈaɪnən ˌʊntɜʃˈiːt]",
+                "it": "[fˈoːrse nˌon ˌa ˌimportˈantsa]",
+                "es": "[kiˈθas ˈe.so no imˈpor.ta]",
+                "nl": "[mɪsxˈin mˈaːkt hət nˌit ˈœyt]",
+                "pt": "[taʊvˈez nˌɐ̃ʊ̃ ˌimpˈɔɾətʃy]",
+                "en": "[mˈeɪbiː ɪt dˈʌzənt mˈatə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-033",
+            "text": {
+                "fr": "J'ai choisi de lui faire confiance, et cela m'a sauvé.",
+                "en": "I chose to trust him, and that saved me.",
+                "de": "Ich habe mich entschieden, ihr zu vertrauen, und das hat mich gerettet.",
+                "it": "Ho scelto di fidarmi di lei, e questo mi ha salvato.",
+                "es": "Elegí confiar en ella, y eso me salvó.",
+                "nl": "Ik koos ervoor om hem te vertrouwen, en dat heeft me gered.",
+                "pt": "Escolhi confiar nela, e isso me salvou.",
+                "en_pt": "I chose to trust her, and that saved me."
+            },
+            "ipa": {
+                "fr": "ʒe ʃwazˈi də- lyˌi fˈɛʁ kɔ̃fjˈɑ̃s e səlˌa ma sovˈe",
+                "de": "[ɪç hɑːbə mɪç ɛntʃˈiːdən\n iːɾ tsuː fɛɾtɾˈaʊən\n ʊnt das hat mɪç ɡərˈɛtət]",
+                "it": "[ˌo ʃˈelto dˌɪ fidˈaːrmɪ dˌɪ lˈɛj\n ˌe kwˌɛsto mˌɪ ˌa salvˈaːto]",
+                "es": "[eˈle.xi konˈfjar en ˈe.ʎa | i ˈe.so me salˈβo]",
+                "nl": "[ɪk kˈoːs ɛrvˈɔːr ɔm hˈɛm tə vərtrˈʌʊən\n ɛn dɑt heːft mə ɣərˈɛt]",
+                "pt": "[ˌeskoljˈi kˌoŋfiˈar nˈɛlæ\n i ˈisʊ my saʊvˈow]",
+                "en": "[aɪ tʃˈəʊz tə tɹˈʌst hˌɪm and ðat sˈeɪvd mˌiː]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-034",
+            "text": {
+                "fr": "Quand on est séparés, on réalise ce qui compte vraiment.",
+                "en": "When we are separated, we realize what really matters.",
+                "de": "Wenn wir getrennt sind, wird uns klar, was wirklich zählt.",
+                "it": "Quando siamo separati, ci rendiamo conto di ciò che conta davvero.",
+                "es": "Cuando estamos separados, nos damos cuenta de lo que realmente importa.",
+                "nl": "Als we apart zijn, realiseren we ons wat echt belangrijk is.",
+                "pt": "Quando estamos separados, percebemos o que realmente importa.",
+                "en_pt": "When we're separated, we realize what really matters."
+            },
+            "ipa": {
+                "fr": "kɑ̃t ɔ̃n ɛ sepaʁˈe ɔ̃ ʁealˈiz sə- ki kˈɔ̃t vʁɛmˈɑ̃",
+                "de": "[vˌɛn viːɾ ɡətɾˈɛnt zɪnt\n vˌɪɾt ʊns klˈɑːɾ\n vˈas vˈɪɾklɪç tsˈɛːlt]",
+                "it": "[kwˈando sjˌamo sˌeparˈaːtɪ\n tʃˌɪ rendjˈaːmo kˈonto dˌɪ tʃˈɔ kˌe kˈonta davvˈeːro]",
+                "es": "[ˈkwan.do esˈta.mos sepaˈɾa.ðos | nos ˈða.mos ˈkwenta de lo ke re.alˈmen.te imˈpor.ta]",
+                "nl": "[ɑls ʋə ˈaːpɑrt zɛɪn\n rˌeːaːlizˈɪːrən ʋə ɔns ʋɑt ˈɛxt bəlˈɑŋrɛɪk ɪs]",
+                "pt": "[kwˈɐ̃ŋdw estˌɐ̃mʊs sˌepaɾˈadʊs\n pˌeɾəsebˈemʊz ʊ ky xˌeaʊmˈeɪŋtʃj ˌimpˈɔɾətæ]",
+                "en": "[wˌɛn wiː ɑː sˈɛpəɹˌeɪtɪd wiː ɹˈiəlaɪz wɒt ɹˈiəlɪ mˈatəz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-035",
+            "text": {
+                "pt": "Lucas pega a mão dela.",
+                "en": "Lucas takes her hand."
+            },
+            "ipa": {
+                "pt": "[lˈukæs pˈɛɡæ a mˈɐ̃ʊ̃ dˈɛlæ]",
+                "en": "[lˈuːkəz tˈeɪks hɜː hˈand]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-036",
+            "text": {
+                "fr": "Je ne veux plus jamais te perdre.",
+                "en": "I never want to lose you again.",
+                "de": "Ich will dich nie wieder verlieren.",
+                "it": "Non voglio mai più perderti.",
+                "es": "No quiero perderte nunca más.",
+                "nl": "Ik wil je nooit meer kwijt.",
+                "pt": "Não quero nunca mais te perder."
+            },
+            "ipa": {
+                "fr": "ʒə- nə- vˈø ply ʒamˌɛ tə- pˈɛʁdʁ",
+                "de": "[ɪç vɪl dɪç nˈiː vˈiːdɜ fɛɾlˈiːrən]",
+                "it": "[nˌon vˈoːʎo mˌaɪ pjˌʊ pˈɛrdertɪ]",
+                "es": "[no ˈkje.ro perˈðer.te ˈnun.ka ˈmas]",
+                "nl": "[ɪk ʋɪl jə nˈoːjt mˈɪːr kʋˈɛɪt]",
+                "pt": "[nˌɐ̃ʊ̃ kˈɛɾʊ nˌũŋkæ mˈaɪs tʃy peɾədˈer]",
+                "en": "[aɪ nˈɛvə wˈɒnt tə lˈuːz juː ɐɡˈɛn]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-037",
+            "text": {
+                "fr": "Mais maintenant, je sais que je peux me débrouiller seule si nécessaire",
+                "en": "But now, I know that I can manage on my own if necessary",
+                "de": "Aber jetzt weiß ich, dass ich alleine zurechtkommen kann, wenn es sein muss",
+                "it": "Ma ora so che posso cavarmela da sola se necessario",
+                "es": "Pero ahora sé que puedo arreglármelas sola si es necesario",
+                "nl": "Maar nu weet ik dat ik alleen kan redden als het moet",
+                "pt": "Mas agora sei que posso me virar sozinha se necessário.",
+                "en_pt": "But now I know I can manage alone if necessary."
+            },
+            "ipa": {
+                "fr": "mɛ mɛ̃tnˈɑ̃ ʒə- sˈɛ kə ʒə- pˈø mə- debʁujˈe sˈœl sˈi nesɛsˈɛʁ",
+                "de": "[ˌɑːbɜ jˌɛtst vˈaɪs ɪç\n das ɪç alˈaɪnə tsuːrˈɛçtkɔmən kˌan\n vˌɛn ɛs zaɪn mˈʊs]",
+                "it": "[mˌa ˈɔːra sˈo kˌe pˈɔsso kavˈarmela dˌa sˈoːla sˌe nˌetʃessˈario]",
+                "es": "[ˈpe.ro aˈo.ɾa se ke ˈpwe.ðo a.reˈɣlar.me.las ˈso.la si es ne.seˈsa.ɾjo]",
+                "nl": "[maːr nˈy ʋˈeːt ɪk dɑt ɪk ɑlˈeːn kɑn rˈɛdən ɑls hət mˈut]",
+                "pt": "[maz ˌaɡˈɔɾæ sˈeɪ ky pˌɔsʊ my viɾˈar sˌozˈiɲæ sy nˌesesˈaɾjʊ]",
+                "en": "[bˌʌt nˈaʊ aɪ nˈəʊ ðat aɪ kan mˈanɪdʒ ˌɒn maɪ ˈəʊn ɪf nˈɛsəsəɹi]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-038",
+            "text": {
+                "fr": "J'ai fait du feu, j'ai trouvé de l'eau, j'ai fait une soupe avec des orties.",
+                "en": "I made a fire, I found water, I made a soup with nettles.",
+                "de": "Ich habe Feuer gemacht, Wasser gefunden, eine Suppe mit Brennnesseln gekocht.",
+                "it": "Ho fatto fuoco, ho trovato acqua, ho fatto una zuppa con le ortiche.",
+                "es": "Hice fuego, encontré agua, hice una sopa con ortigas.",
+                "nl": "Ik maakte vuur, vond water, en maakte een soep van brandnetels.",
+                "pt": "Acendi fogo, encontrei água, fiz sopa com urtigas.",
+                "en_pt": "I lit a fire, found water, made soup with nettles."
+            },
+            "ipa": {
+                "fr": "ʒe fˈɛ dy- fˈø ʒe tʁuvˈe də- lˈo ʒe fˈɛt yn sˈup avˌɛk de-z ɔʁtˈi",
+                "de": "[ɪç hɑːbə fˈɔøɜ ɡəmˈaxt\n vˈasɜ ɡəfˈʊndən\n ˌaɪnə zˈʊpə mɪt brˈɛnɛsəln ɡəkˈɔxt]",
+                "it": "[ˌo fˈatːo fʊˈɔːko\n ˌo trovˈaːto ˈakːwa\n ˌo fˈatːo ˌʊna dzˈupːa kˌon lˌe ˈɔrtike]",
+                "es": "[ˈi.θe ˈfwe.ɣo | en.konˈtɾe ˈa.ɣwa | ˈi.θe uˈna ˈso.pa kon orˈti.ɣas]",
+                "nl": "[ɪk mˈaːktə vˈyr\n vˈɔnt ʋˈaːtər\n ɛn mˈaːktə ən sˈup vɑn brˈɑndnətˌɛls]",
+                "pt": "[ˌaseɪŋdʒˈi fˈoɡʊ\n ˌeɪŋkoŋtrˈeɪ ˈaɡwæ\n fˈis sˈopæ koŋ ˌuɾətʃˈiɡæs]",
+                "en": "[aɪ mˌeɪd ɐ fˈaɪə aɪ fˈaʊnd wˈɔːtə aɪ mˌeɪd ɐ sˈuːp wɪð nˈɛtəlz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-039",
+            "text": {
+                "fr": "Et c'est exactement ce qui rend notre relation plus forte",
+                "en": "And that's exactly what makes our relationship stronger",
+                "de": "Und genau das macht unsere Beziehung stärker",
+                "it": "Ed è esattamente questo che rende la nostra relazione più forte",
+                "es": "Y eso es precisamente lo que hace nuestra relación más fuerte.",
+                "nl": "En dat is precies wat onze relatie sterker maakt",
+                "pt": "E é exatamente isso que torna nossa relação mais forte.",
+                "en_pt": "And that's exactly what makes our relationship stronger."
+            },
+            "ipa": {
+                "fr": "e sɛt ɛɡzaktəmˈɑ̃ sə- ki ʁˈɑ̃ nɔtʁ ʁəlasjˈɔ̃ ply fˈɔʁt",
+                "de": "[ʊnt ɡənˈaʊ das mˈaxt ˌʊnzrə bətsˈiːʊŋ ʃtˈɛɾkɜ]",
+                "it": "[ˌɛd ˌɛ ˌezatːamˈente kwˌɛsto kˌe rˈɛnde lˌa nˌɔstra rˌɛlatsiˈɔːne pjˌʊ fˈɔːrte]",
+                "es": "[i ˈe.so es preθiˈsa.mente lo ke aˈθe nweˈstɾa re.laˈθjon ˈmas ˈfwer.te]",
+                "nl": "[ɛn dɑt ɪs preːsˈis ʋɑt ɔnzˌə reːlˈaːtsi stˈɛrkər mˈaːkt]",
+                "pt": "[i ɛ ˌezatæmˈeɪŋtʃj ˈisʊ ky tˈɔɾənæ nˌɔsæ xˌelasˈɐ̃ʊ̃ mˈaɪs fˈɔɾətʃy]",
+                "en": "[and ðats ɛɡzˈaktli wɒt mˌeɪks aʊə ɹɪlˈeɪʃənʃˌɪp stɹˈɒŋɡə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-040",
+            "text": {
+                "fr": "Nous sommes deux personnes qui choisissent d'être ensemble.",
+                "en": "We are two people who choose to be together.",
+                "de": "Wir sind zwei Personen, die sich entscheiden, zusammen zu sein.",
+                "it": "Siamo due persone che scelgono di stare insieme.",
+                "es": "Somos dos personas que eligen estar juntas.",
+                "nl": "Wij zijn twee mensen die ervoor kiezen samen te zijn.",
+                "pt": "Somos duas pessoas que escolhem estar juntas—não por necessidade, mas por desejo.",
+                "en_pt": "We're two people who choose to be together—not out of necessity, but out of desire."
+            },
+            "ipa": {
+                "fr": "nu sɔm dˈø pɛʁsˈɔn ki ʃwazˈis dˈɛtʁ ɑ̃sˈɑ̃bl",
+                "de": "[viːɾ zɪnt tsvˈaɪ pɛɾzˈoːnən\n diː zɪç ɛntʃˈaɪdən\n tsuːzˈamən tsuː zaɪn]",
+                "it": "[sjˌamo dˈuːe persˈoːne kˌe ʃˈɛlɡono dˌɪ stˈaːre insjˈɛːme]",
+                "es": "[ˈso.mos dos perˈso.nas ke eˈli.xen esˈtar ˈxun.tas]",
+                "nl": "[ʋɛɪ zɛɪn tʋˈeː mˈɛnsən di ɛrvˈɔːr kˈizən sˈaːmən tə zɛɪn]",
+                "pt": "[sˌomʊz dˈuæs pˌesˈoæs ky ˌeskˈɔljeɪŋ estˌar ʒˈũŋtæs nˌɐ̃ʊ̃ por nˌesesidˈadʒy\n mas por dˌezˈeʒʊ]",
+                "en": "[wiː ɑː tˈuː pˈiːpəl hˌuː tʃˈuːz təbi təɡˈɛðə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-041",
+            "text": {
+                "fr": "Mais nous ne serons jamais, Lucas",
+                "en": "But we will never be, Lucas",
+                "de": "Aber wir werden nie, Lucas",
+                "it": "Ma noi non saremo mai, Lucas",
+                "es": "Pero nunca seremos los mismos, Lucas",
+                "nl": "Maar wij zullen nooit, Lucas",
+                "pt": "Mas nunca seremos \"completos\", Lucas.",
+                "en_pt": "But we'll never be \"complete,\" Lucas."
+            },
+            "ipa": {
+                "fr": "mɛ nu nə- səʁˈɔ̃ ʒamˈɛ lykˈa",
+                "de": "[ˌɑːbɜ viːɾ vˌɛɾdən nˈiː\n lˈuːkɑːs]",
+                "it": "[mˌa nˌɔɪ nˌon sarˌɛmo mˈaɪ\n lˈuːkas]",
+                "es": "[ˈpe.ro ˈnun.ka seˈɾe.mos los ˈmis.mos | ˈlu.kas]",
+                "nl": "[maːr ʋɛɪ zˌɵlən nˈoːjt\n lˈykɑs]",
+                "pt": "[maz nˌũŋkæ seɾˌemʊs kˌomplˈɛtʊs\n lˈukæs]",
+                "en": "[bˌʌt wiː wɪl nˈɛvə bˈiː lˈuːkəz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-042",
+            "text": {
+                "fr": "Nous continuerons toujours de changer, de devenir",
+                "en": "We will always continue to change, to become",
+                "de": "Wir werden immer weiterhin uns verändern, wachsen",
+                "it": "Continueremo sempre a cambiare, a diventare",
+                "es": "Siempre seguiremos cambiando, evolucionando.",
+                "nl": "We blijven altijd veranderen, worden",
+                "pt": "Continuaremos sempre mudando, nos tornando.",
+                "en_pt": "We'll always keep changing, becoming."
+            },
+            "ipa": {
+                "fr": "nu kɔ̃tinyʁˈɔ̃ tuʒˌuʁ də- ʃɑ̃ʒˈe də- dəvnˈiʁ",
+                "de": "[viːɾ vˌɛɾdən ˈɪmɜ vˈaɪtɜhˌɪn ʊns fɛɾˈɛndɜn\n vˈaxzən]",
+                "it": "[kˌontinˌʊerˈɛːmo sˈɛmpre ˌa kambjˈaːre\n ˌa dˌiventˈaːre]",
+                "es": "[ˈsjem.pɾe seɣiˈɾe.mos kamˈβjan.do | eβoluθjoˈnan.do]",
+                "nl": "[ʋə blˈɛɪvən ˈɑltɛɪt vərˈɑndərən\n ʋˈɔrdən]",
+                "pt": "[kˌoŋtʃinˌuaɾˈemʊs sˌeɪmpry mˌudˈɐ̃ŋdʊ\n nʊs tˌoɾənˈɐ̃ŋdʊ]",
+                "en": "[wiː wɪl ˈɔːlweɪz kəntˈɪnjuː tə tʃˈeɪndʒ tə bɪkˈʌm]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-043",
+            "text": {
+                "pt": "E está bom assim.",
+                "en": "And that's okay."
+            },
+            "ipa": {
+                "pt": "[i estˌa bˈoŋ asˈiŋ]",
+                "en": "[and ðats əʊkˈeɪ]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-044",
+            "text": {
+                "pt": "Eles olham as montanhas juntos, de mãos dadas.",
+                "en": "They look at the mountains together, holding hands."
+            },
+            "ipa": {
+                "pt": "[ˌelyz ˈɔljɐ̃ʊ̃ az mˌoŋtˈɐ̃ɲæz ʒˈũŋtʊs\n dʒy mˈɐ̃ʊ̃z dˈadæs]",
+                "en": "[ðeɪ lˈʊk at ðə mˈaʊntɪnz təɡˈɛðə hˈəʊldɪŋ hˈandz]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-045",
             "text": {
                 "fr": "Le soleil brille sur les sommets enneigés, indifférent à leurs histoires humaines.",
-                "en": "The sun shines on the snowy peaks of the Ardennes, indifferent to their human stories.",
+                "en": "The sun shines on the snow-covered peaks, indifferent to their human stories.",
                 "de": "Die Sonne scheint auf die verschneiten Gipfel, gleichgültig gegenüber ihren menschlichen Geschichten.",
                 "it": "Il sole splende sulle cime innevate delle Alpi, indifferente alle loro storie umane.",
                 "es": "El sol brilla sobre los picos nevados, indiferente a sus historias humanas.",
@@ -1460,7 +1276,69 @@
                 "es": "[el sol ˈβɾi.ʎa ˈso.βɾe los ˈpi.kos neˈβa.ðos | in.diˈfeɾen.te a sus isˈto.ɾjas uˈma.nas]",
                 "nl": "[də zˈɔn sxˈɛɪnt ɔp də bəsnˈeʊdə tˈɔpən vɑn də ˈɑrdɛnən\n ɔnvərsxˈɪləx vɔːr hɵn mˈɛnsələkə vərhˈaːlən]",
                 "pt": "[ʊ sˈɔl brˈiljæ nʊs pˈikʊs\n ˌiŋdʒifeɾˈeɪŋtʃj aːs sˌuæs ˌistˈɔɾjæs ˌumˈɐ̃næs]",
-                "en": "[ðə sˈʌn ʃˈaɪnz ɒnðə snˈəʊi pˈiːks ɒvðɪ ˈɑːdənz ɪndˈɪfɹənt tə ðeə hjˈuːmən stˈɔːɹɪz]"
+                "en": "[ðə sˈʌn ʃˈaɪnz ɒnðə snˈəʊkˈʌvəd pˈiːks ɪndˈɪfɹənt tə ðeə hjˈuːmən stˈɔːɹɪz]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-046",
+            "text": {
+                "fr": "Nous ne sommes pas venus ici pour fuir Paris,",
+                "en": "We did not come here to flee Paris,",
+                "de": "Wir sind nicht hierher gekommen, um Berlin zu verlassen,",
+                "it": "Non siamo venuti qui per scappare da Roma,",
+                "es": "No vinimos aquí para huir de Madrid,",
+                "nl": "We zijn hier niet gekomen om Amsterdam te ontvluchten,",
+                "pt": "Não viemos aqui para fugir de São Paulo, diz Sophie.",
+                "en_pt": "We didn't come here to escape from São Paulo, Sophie says."
+            },
+            "ipa": {
+                "fr": "nu nə- sɔm pa vənˈy isˈi puʁ fyˈiʁ paʁˈi",
+                "de": "[viːɾ zɪnt nˈɪçt hˈiːɾhɜ ɡəkˈɔmən\n ʊm bɛɾlˈiːn tsuː fɛɾlˈasən]",
+                "it": "[nˌon sjˌamo venˈuːtɪ kwˈi pˌɛr skapːˈaːre dˌa rˈɔːma]",
+                "es": "[no βiˈni.mos aˈki paɾa ˈwiɾ de maˈðɾið]",
+                "nl": "[ʋə zɛɪn hˈir nˌit ɣəkˈoːmən ɔm ˈɑmstərdˌɑm tə ɔntvlˈɵxtən]",
+                "pt": "[nˌɐ̃ʊ̃ vˌiˈemʊz akˈi pˌaɾæ fuʒˈir dʒy sɐ̃ʊ̃ pˈaʊlʊ\n dʒˈis sˌofˈiy]",
+                "en": "[wiː dɪdnˌɒt kˈʌm hˈiə tə flˈiː pˈaɹɪs]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-047",
+            "text": {
+                "fr": "Nous sommes venus pour découvrir quelque chose",
+                "en": "We came to discover something",
+                "de": "wir sind gekommen, um etwas zu entdecken",
+                "it": "siamo venuti per scoprire qualcosa",
+                "es": "vinimos para descubrir algo.",
+                "nl": "we kwamen om iets nieuws te ontdekken",
+                "pt": "Viemos para descobrir algo.",
+                "en_pt": "We came to discover something."
+            },
+            "ipa": {
+                "fr": "nu sɔm vənˈy puʁ dekuvʁˈiʁ kˌɛlkə ʃˈoz",
+                "de": "[viːɾ zɪnt ɡəkˈɔmən\n ʊm ˈɛtvɑːs tsuː ɛntdˈɛkən]",
+                "it": "[sjˌamo venˈuːtɪ pˌɛr skoprˈiːre kwalkˈɔːza]",
+                "es": "[biˈni.mos paɾa deskuˈβɾir ˈal.ɣo]",
+                "nl": "[ʋə kʋˈaːmən ɔm ˈits nˈiws tə ɔntdˈɛkən]",
+                "pt": "[vˌiˈemʊs pˌaɾæ dˌeskobrˈiɾ ˈaʊɡʊ]",
+                "en": "[wiː kˈeɪm tə dɪskˈʌvə sˈʌmθɪŋ]"
             },
             "provenance": {
                 "fr": "original",
@@ -1474,6 +1352,81 @@
         },
         {
             "id": "scene-16-048",
+            "text": {
+                "fr": "Et nous l'avons trouvé.",
+                "en": "And we found it.",
+                "de": "Und wir haben es gefunden.",
+                "it": "E l'abbiamo trovato.",
+                "es": "Y lo hemos encontrado.",
+                "nl": "en dat hebben we gevonden.",
+                "pt": "E encontramos."
+            },
+            "ipa": {
+                "fr": "e nu lavˈɔ̃ tʁuvˈe",
+                "de": "[ʊnt viːɾ hˌɑːbən ɛs ɡəfˈʊndən]",
+                "it": "[ˌe labːjˌamo trovˈaːto]",
+                "es": "[i lo ˈe.mos en.konˈtɾa.ðo]",
+                "nl": "[ɛn dɑt hˌɛbən ʋə ɣəvˈɔndən]",
+                "pt": "[i ˌeɪŋkoŋtrˈɐ̃mʊs]",
+                "en": "[and wiː fˈaʊnd ɪt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-049",
+            "text": {
+                "fr": "Qu'avons-nous trouvé exactement?",
+                "en": "What exactly did we find?",
+                "de": "Was haben wir genau gefunden?",
+                "it": "Cosa abbiamo trovato esattamente?",
+                "es": "¿Qué hemos encontrado exactamente?",
+                "nl": "Wat hebben we precies gevonden?",
+                "pt": "O que encontramos exatamente?"
+            },
+            "ipa": {
+                "fr": "kavˈɔ̃nu tʁuvˈe ɛɡzaktəmˈɑ̃",
+                "de": "[vˈas hˌɑːbən viːɾ ɡənˈaʊ ɡəfˈʊndən]",
+                "it": "[kˈɔːza abːjˌamo trovˈaːto ˌezatːamˈente]",
+                "es": "[ke ˈe.mos en.konˈtɾa.ðo eksakˈta.mente]",
+                "nl": "[ʋɑt hˌɛbən ʋə preːsˈis ɣəvˈɔndən]",
+                "pt": "[ʊ ky ˌeɪŋkoŋtrˈɐ̃mʊz ˌezatæmˈeɪŋtʃy]",
+                "en": "[wˌɒt ɛɡzˈaktli dˈɪd wiː fˈaɪnd]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-050",
+            "text": {
+                "pt": "pergunta Lucas.",
+                "en": "Lucas asks."
+            },
+            "ipa": {
+                "pt": "[pˌeɾəɡˈũŋtæ lˈukæs]",
+                "en": "[lˈuːkəz ˈasks]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-051",
             "text": {
                 "fr": "Sophie sourit, mais c'est un sourire différent maintenant.",
                 "en": "Sophie smiles, but it's a different smile now.",
@@ -1504,10 +1457,216 @@
             }
         },
         {
-            "id": "scene-16-049",
+            "id": "scene-16-052",
+            "text": {
+                "fr": "Peut-être simplement que nous sommes capables d'affronter l'incertitude",
+                "en": "Maybe simply that we are capable of facing uncertainty",
+                "de": "Vielleicht einfach, dass wir fähig sind, der Ungewissheit zu begegnen",
+                "it": "Forse solo che siamo capaci di affrontare l'incertezza",
+                "es": "Quizás simplemente que somos capaces de enfrentar la incertidumbre",
+                "nl": "Misschien gewoon dat we in staat zijn om onzekerheid het hoofd te bieden",
+                "pt": "Talvez simplesmente que somos capazes de enfrentar a incerteza.",
+                "en_pt": "Perhaps simply that we're capable of facing uncertainty."
+            },
+            "ipa": {
+                "fr": "pˈøtˈɛtʁ sɛ̃pləmˈɑ̃ kə nu sɔm kapˈabl dafʁɔ̃tˈe lɛ̃sɛʁtitˈyd",
+                "de": "[fiːllˈaɪçt ˈaɪnfˌax\n das viːɾ fˈɛːɪç zɪnt\n dɛɾ ˈʊnɡəvˌɪshaɪt tsuː bəɡˈeːɡnən]",
+                "it": "[fˈoːrse sˈoːlo kˌe sjˌamo kapˈaːtʃɪ dˌɪ ˌaffrontˈaːre lˌintʃertˈetsːa]",
+                "es": "[kiˈθas sim.pleˈmen.te ke ˈso.mos kaˈpa.θes de en.fɾenˈtaɾ la inθerˈti.ðum.bɾe]",
+                "nl": "[mɪsxˈin ɣəʋˈoːn dɑt ʋə ɪn stˈaːt zɛɪn ɔm ɔnzˈeːkərhˌɛɪt hət hˈoːvd tə bˈidən]",
+                "pt": "[taʊvˈes sˌimplezmˈeɪŋtʃy ky sˌomʊs kˌapˈazyz dʒj ˌeɪŋfreɪŋtˈaɾ a ˌiŋseɾətˈezæ]",
+                "en": "[mˈeɪbiː sˈɪmpli ðat wiː ɑː kˈeɪpəbəl ɒv fˈeɪsɪŋ ʌnsˈɜːtənti]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-053",
+            "text": {
+                "fr": "Et que notre amour peut exister même dans cette incertitude.",
+                "en": "And that our love can exist even in this uncertainty.",
+                "de": "Und dass unsere Liebe auch in dieser Ungewissheit bestehen kann.",
+                "it": "E che il nostro amore può esistere anche in questa incertezza.",
+                "es": "y que nuestro amor puede existir incluso en esa incertidumbre.",
+                "nl": "en dat onze liefde zelfs in die onzekerheid kan bestaan.",
+                "pt": "E que nosso amor pode existir mesmo nesta incerteza."
+            },
+            "ipa": {
+                "fr": "e kə nɔtʁ amˈuʁ pˈøt ɛɡzistˈe mˈɛm dɑ̃ sɛt ɛ̃sɛʁtitˈyd",
+                "de": "[ʊnt das ˌʊnzrə lˈiːbə ˌaʊx ɪn dˌiːzɜ ˈʊnɡəvˌɪshaɪt bəʃtˈeːən kˌan]",
+                "it": "[ˌe kˌe ˌil nˌɔstro amˈoːre pʊˈɔ ezˈistere ˈanke ˌin kwˌɛsta ˌintʃertˈetsːa]",
+                "es": "[i ke nweˈstɾo aˈmoɾ ˈpwe.ðe eksisˈtiɾ inˈklu.so en ˈe.sa inθerˈti.ðum.bɾe]",
+                "nl": "[ɛn dɑt ɔnzˌə lˈivdə zˈɛlfs ɪn di ɔnzˈeːkərhˌɛɪt kɑn bəstˈaːn]",
+                "pt": "[i ky nˌɔsʊ æmˈor pˌɔdʒj ˌezistʃˈir mˈezmʊ nˌɛstæ ˌiŋseɾətˈezæ]",
+                "en": "[and ðat aʊə lˈʌv kan ɛɡzˈɪst ˈiːvən ɪn ðɪs ʌnsˈɜːtənti]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-054",
+            "text": {
+                "fr": "Oui. C'est déjà beaucoup.",
+                "en": "Yes. That's already a lot.",
+                "de": "Ja. Das ist schon viel.",
+                "it": "Sì. È già tanto.",
+                "es": "Sí. Ya es mucho.",
+                "nl": "Ja. Dat is al heel wat.",
+                "pt": "Já é muito, diz Lucas.",
+                "en_pt": "That's already a lot, Lucas says."
+            },
+            "ipa": {
+                "fr": "wˈi sɛ deʒˈa bokˈu",
+                "de": "[jˈɑː\n das ɪst ʃˌoːn fˈiːl]",
+                "it": "[sˈi\n ˌɛ dʒˈa tˈanto]",
+                "es": "[si | ʝa es ˈmu.tʃo]",
+                "nl": "[jˈaː\n dɑt ɪs ˈɑl hˈeːl ʋɑt]",
+                "pt": "[ʒˈa ɛ mwˈiŋtʊ\n dʒˈiz lˈukæs]",
+                "en": "[jˈɛs ðats ɔːlɹˌɛdi ɐ lˈɒt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-055",
+            "text": {
+                "pt": "Sim.",
+                "en": "Yes."
+            },
+            "ipa": {
+                "pt": "[sˈiŋ]",
+                "en": "[jˈɛs]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-056",
+            "text": {
+                "fr": "C'est déjà beaucoup,",
+                "en": "That's already a lot,",
+                "de": "Das ist schon viel,",
+                "it": "È già tanto,",
+                "es": "Eso ya es mucho,",
+                "nl": "Dat is al heel wat,",
+                "pt": "Já é muito.",
+                "en_pt": "It's already a lot."
+            },
+            "ipa": {
+                "fr": "sɛ deʒˈa bokˈu",
+                "de": "[das ɪst ʃˌoːn fˈiːl]",
+                "it": "[ˌɛ dʒˈa tˈanto]",
+                "es": "[ˈe.so ʝa es ˈmu.tʃo]",
+                "nl": "[dɑt ɪs ˈɑl hˈeːl ʋɑt]",
+                "pt": "[ʒˈa ɛ mwˈiŋtʊ]",
+                "en": "[ðats ɔːlɹˌɛdi ɐ lˈɒt]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-057",
+            "text": {
+                "pt": "--- FIM ---",
+                "en": "--- THE END ---"
+            },
+            "ipa": {
+                "pt": "[]"
+            },
+            "provenance": {
+                "pt": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-058",
+            "text": {
+                "fr": "pas par besoin, mais par désir.",
+                "en": "not out of need, but out of desire.",
+                "de": "Nicht aus Notwendigkeit, sondern aus Wunsch.",
+                "it": "non per necessità, ma per desiderio.",
+                "es": "no por necesidad, sino por deseo.",
+                "nl": "niet uit noodzaak, maar uit verlangen."
+            },
+            "ipa": {
+                "fr": "pa paʁ bəzwˈɛ̃ mɛ paʁ dezˈiʁ",
+                "de": "[nˈɪçt ˌaʊs nˈɔtvəndˌɪçkaɪt\n zˈɔndɜn ˌaʊs vˈʊnʃ]",
+                "it": "[nˌon pˌɛr nˌetʃessitˈa\n mˌa pˌɛr dˌezidˈɛrio]",
+                "es": "[no por neθeˈsi.ðað | si.no por deˈse.o]",
+                "nl": "[nˌit œyt noːdzˈaːk\n maːr œyt vərlˈɑŋən]",
+                "en": "[nˌɒt ˌaʊtəv nˈiːd bˌʌt ˌaʊtəv dɪzˈaɪə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-059",
+            "text": {
+                "fr": "Et c'est bien comme ça.",
+                "en": "And that's exactly what makes our relationship stronger",
+                "de": "Und das ist gut so.",
+                "it": "Ed è bene così.",
+                "es": "Y eso está bien así.",
+                "nl": "En dat is goed zo."
+            },
+            "ipa": {
+                "fr": "e sɛ bjˈɛ̃ kɔm sˈa",
+                "de": "[ʊnt das ɪst ɡˈuːt zˈoː]",
+                "it": "[ˌɛd ˌɛ bˈɛːne kozˈi]",
+                "es": "[i ˈe.so esˈta ˈβjen aˈsi]",
+                "nl": "[ɛn dɑt ɪs ɣˈut zˈoː]",
+                "en": "[and ðats ɛɡzˈaktli wɒt mˌeɪks aʊə ɹɪlˈeɪʃənʃˌɪp stɹˈɒŋɡə]"
+            },
+            "provenance": {
+                "fr": "original",
+                "de": "original",
+                "it": "original",
+                "es": "original",
+                "nl": "original",
+                "en": "original"
+            }
+        },
+        {
+            "id": "scene-16-060",
             "text": {
                 "fr": "plus profond, plus conscient de la fragilité des choses.",
-                "en": "deeper, more aware of the fragility of things.",
+                "en": "Deeper, more aware of the fragility of things.",
                 "de": "tiefer, mehr bewusst über die Zerbrechlichkeit der Dinge.",
                 "it": "più profondo, più consapevole della fragilità delle cose.",
                 "es": "más profunda, más consciente de la fragilidad de las cosas.",
@@ -1527,170 +1686,6 @@
                 "it": "original",
                 "es": "original",
                 "nl": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-050",
-            "text": {
-                "pt": "Sophie!",
-                "en": "Sophie!"
-            },
-            "ipa": {
-                "pt": "[sˌofˈiy]",
-                "en": "[sˈəʊfi]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-051",
-            "text": {
-                "pt": "Lucas!",
-                "en": "Lucas!"
-            },
-            "ipa": {
-                "pt": "[lˈukæs]",
-                "en": "[lˈuːkəz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-052",
-            "text": {
-                "pt": "pergunta Lucas.",
-                "en": "Lucas asks."
-            },
-            "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ lˈukæs]",
-                "en": "[lˈuːkəz ˈasks]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-053",
-            "text": {
-                "pt": "Projetamos tanto significado no que nos acontece.",
-                "en": "We project so much meaning onto what happens to us."
-            },
-            "ipa": {
-                "pt": "[prˌoʒetˈɐ̃mʊs tˈɐ̃ŋtʊ sˌiɡnifikˈadʊ nʊ ky nʊz ˌakoŋtˈɛsy]",
-                "en": "[wiː pɹədʒˈɛkt sˈəʊ mˌʌtʃ mˈiːnɪŋ ˌɒntʊ wɒt hˈapənz tʊ ˌʌs]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-054",
-            "text": {
-                "pt": "Lucas reflete.",
-                "en": "Lucas reflects."
-            },
-            "ipa": {
-                "pt": "[lˈukæz xˌeflˈɛtʃy]",
-                "en": "[lˈuːkəz ɹɪflˈɛkts]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-055",
-            "text": {
-                "pt": "Lucas pega a mão dela.",
-                "en": "Lucas takes her hand."
-            },
-            "ipa": {
-                "pt": "[lˈukæs pˈɛɡæ a mˈɐ̃ʊ̃ dˈɛlæ]",
-                "en": "[lˈuːkəz tˈeɪks hɜː hˈand]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-056",
-            "text": {
-                "pt": "E está bom assim.",
-                "en": "And that's okay."
-            },
-            "ipa": {
-                "pt": "[i estˌa bˈoŋ asˈiŋ]",
-                "en": "[and ðats əʊkˈeɪ]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-057",
-            "text": {
-                "pt": "Eles olham as montanhas juntos, de mãos dadas.",
-                "en": "They look at the mountains together, holding hands."
-            },
-            "ipa": {
-                "pt": "[ˌelyz ˈɔljɐ̃ʊ̃ az mˌoŋtˈɐ̃ɲæz ʒˈũŋtʊs\n dʒy mˈɐ̃ʊ̃z dˈadæs]",
-                "en": "[ðeɪ lˈʊk at ðə mˈaʊntɪnz təɡˈɛðə hˈəʊldɪŋ hˈandz]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-058",
-            "text": {
-                "pt": "pergunta Lucas.",
-                "en": "Lucas asks."
-            },
-            "ipa": {
-                "pt": "[pˌeɾəɡˈũŋtæ lˈukæs]",
-                "en": "[lˈuːkəz ˈasks]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-059",
-            "text": {
-                "pt": "Sim.",
-                "en": "Yes."
-            },
-            "ipa": {
-                "pt": "[sˈiŋ]",
-                "en": "[jˈɛs]"
-            },
-            "provenance": {
-                "pt": "original",
-                "en": "original"
-            }
-        },
-        {
-            "id": "scene-16-060",
-            "text": {
-                "pt": "--- FIM ---",
-                "en": "--- THE END ---"
-            },
-            "ipa": {
-                "pt": "[]"
-            },
-            "provenance": {
-                "pt": "original",
                 "en": "original"
             }
         }

--- a/scripts/merge_materials.py
+++ b/scripts/merge_materials.py
@@ -268,16 +268,70 @@ def merge_story_scenes(materials_dir, output_dir, dry_run=False, verbose=False):
             # No core languages for this scene — PT becomes the base
             pt_unmatched = list(lang_data["pt"])
 
-        # Build unified phrases: first the core set, then PT-only extras
+        # Build unified phrases: PT source order first, then unmatched FR positions.
+        # This preserves the Portuguese narrative arc rather than scrambling PT
+        # phrases to French-canonical positions via fuzzy matching.
         unified_phrases = []
+        used_fr_positions = set()
 
+        if "pt" in lang_data:
+            # Build reverse map: pt_phrase object id -> matched FR position
+            pt_entry_to_fr_pos = {id(pe): ci for ci, pe in pt_matched.items()}
+
+            for pt_entry in lang_data["pt"]:
+                fr_pos = pt_entry_to_fr_pos.get(id(pt_entry))
+                idx = len(unified_phrases) + 1
+                phrase_id = f"scene-{scene_num:02d}-{idx:03d}"
+                text = {}
+                ipa = {}
+                provenance = {}
+
+                # Add core languages from the matched FR position (if any)
+                if fr_pos is not None:
+                    used_fr_positions.add(fr_pos)
+                    for lang in CORE_LANGS:
+                        phrases = lang_data.get(lang, [])
+                        if fr_pos < len(phrases):
+                            entry = phrases[fr_pos]
+                            text[lang] = entry.get(lang, "")
+                            if entry.get("ipa"):
+                                ipa[lang] = entry["ipa"]
+                            provenance[lang] = "original"
+                            eng = entry.get("english", "")
+                            if eng and "en" not in text:  # first-wins: FR sets en
+                                text["en"] = eng
+
+                # Add PT data
+                text["pt"] = pt_entry.get("pt", "")
+                if pt_entry.get("ipa"):
+                    ipa["pt"] = pt_entry["ipa"]
+                provenance["pt"] = "original"
+                pt_en = pt_entry.get("english", "")
+                if pt_en:
+                    if "en" not in text:
+                        text["en"] = pt_en
+                    elif pt_en != text["en"]:
+                        text["en_pt"] = pt_en  # preserve PT's English variant
+
+                if "en" in text:
+                    provenance["en"] = "original"
+
+                unified_phrases.append({
+                    "id": phrase_id,
+                    "text": text,
+                    "ipa": ipa,
+                    "provenance": provenance,
+                })
+
+        # Append any FR positions not matched by any PT phrase (core-only entries)
         for i in range(core_count):
-            phrase_id = f"scene-{scene_num:02d}-{i + 1:03d}"
+            if i in used_fr_positions:
+                continue
+            idx = len(unified_phrases) + 1
+            phrase_id = f"scene-{scene_num:02d}-{idx:03d}"
             text = {}
             ipa = {}
             provenance = {}
-
-            # Add core languages by position
             for lang in CORE_LANGS:
                 phrases = lang_data.get(lang, [])
                 if i < len(phrases):
@@ -287,49 +341,14 @@ def merge_story_scenes(materials_dir, output_dir, dry_run=False, verbose=False):
                         ipa[lang] = entry["ipa"]
                     provenance[lang] = "original"
                     eng = entry.get("english", "")
-                    if eng:
+                    if eng and "en" not in text:  # first-wins: FR sets en
                         text["en"] = eng
-
-            # Add PT if it matched this core position
-            if i in pt_matched:
-                pt_entry = pt_matched[i]
-                text["pt"] = pt_entry.get("pt", "")
-                if pt_entry.get("ipa"):
-                    ipa["pt"] = pt_entry["ipa"]
-                provenance["pt"] = "original"
-                # Store PT's own English as alternate (may differ from core)
-                pt_en = pt_entry.get("english", "")
-                if pt_en and pt_en != text.get("en", ""):
-                    text["en_pt"] = pt_en  # preserve PT's English variant
-
             if "en" in text:
                 provenance["en"] = "original"
-
             unified_phrases.append({
                 "id": phrase_id,
                 "text": text,
                 "ipa": ipa,
-                "provenance": provenance,
-            })
-
-        # Append unmatched PT phrases as sparse entries (PT + EN only)
-        for j, pt_entry in enumerate(pt_unmatched):
-            idx = core_count + j + 1
-            phrase_id = f"scene-{scene_num:02d}-{idx:03d}"
-            text = {"pt": pt_entry.get("pt", "")}
-            ipa_dict = {}
-            provenance = {"pt": "original"}
-            pt_en = pt_entry.get("english", "")
-            if pt_en:
-                text["en"] = pt_en
-                provenance["en"] = "original"
-            if pt_entry.get("ipa"):
-                ipa_dict["pt"] = pt_entry["ipa"]
-
-            unified_phrases.append({
-                "id": phrase_id,
-                "text": text,
-                "ipa": ipa_dict,
                 "provenance": provenance,
             })
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.3.5-claude-dev"
+__version__ = "7.3.6-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Summary

- **Bug:** Portuguese phrases in all 16 unified story scenes were scrambled — `merge_materials.py` assigned PT phrases to French-canonical positions via fuzzy matching, completely ignoring PT source order. Scene 01 opened with dialogue ("Bom dia Sophie") instead of the atmospheric scene-setting prose ("O sol nasce suavemente sobre São Paulo") that begins the Portuguese story.
- **Fix:** New algorithm iterates PT source phrases in their original narrative order, attaches matching core-language data (FR/DE/IT/ES/NL) where fuzzy matching found a correspondence, then appends any unmatched FR positions as core-only entries at the end.
- **Bonus fix:** English gloss now uses first-wins semantics (FR wins, not NL — the previous overwrite-on-each-iteration bug caused e.g. "A coffee and a stroopwafel" to appear alongside the French "café et croissant" phrase).
- Regenerated all 32 unified JSON files and re-ran `add_english_ipa.py` to restore English IPA entries after phrase ID renumbering.

## Test plan
- [ ] Open `language_materials/unified/stories/scene-01.json` — first 3 phrases should be PT atmospheric prose, not dialogue
- [ ] Verify `en` gloss for "croissant" phrase is `"A coffee and a croissant, please."` not stroopwafel
- [ ] App loads Story Reader without errors; PT scene plays in narrative order
- [ ] `python scripts/merge_materials.py --validate-only` returns `✓ All files valid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)