### PR TITLE
fix: purge stale connection_monitor rows to fix bogus capacity warning

### DIFF
--- a/src/connection_pool.py
+++ b/src/connection_pool.py
@@ -903,6 +903,33 @@ class ConnectionPool:
         
         return cleaned
     
+    def cleanup_stale_connections(self, stale_hours: int = 12) -> int:
+        """
+        Delete rows from connection_monitor that are no longer useful:
+          - Any row with status = 'closed'
+          - Any row with status = 'active' but last_activity older than stale_hours
+
+        Returns count of rows deleted.
+        """
+        deleted = 0
+        try:
+            with self.get_bootstrap_connection() as admin_conn:
+                cursor = admin_conn.cursor()
+                cursor.execute(
+                    """
+                    DELETE FROM connection_monitor
+                    WHERE status = 'closed'
+                       OR (status = 'active' AND last_activity < NOW() - INTERVAL %s HOUR)
+                    """,
+                    (stale_hours,),
+                )
+                deleted = cursor.rowcount
+                admin_conn.commit()
+                cursor.close()
+        except Exception as e:
+            print(f"Stale connection cleanup error: {e}")
+        return deleted
+
     def init_monitoring_tables(self) -> Tuple[bool, str]:
         """
         Create database tables for connection monitoring.

--- a/src/miolingo-admin.py
+++ b/src/miolingo-admin.py
@@ -478,8 +478,8 @@ if selected_page == "👥 Users":
             st.markdown("---")
             
             # Cleanup buttons
-            col_btn1, col_btn2 = st.columns(2)
-            
+            col_btn1, col_btn2, col_btn3 = st.columns(3)
+
             with col_btn1:
                 if expired_count > 0:
                     if st.button("🧹 Clean Up Expired Sessions", type="secondary"):
@@ -490,7 +490,18 @@ if selected_page == "👥 Users":
                             st.rerun()
                         except Exception as e:
                             st.error(f"❌ Cleanup failed: {e}")
-            
+
+            with col_btn3:
+                if st.button("🗑️ Purge Stale Connections", type="secondary",
+                             help="Delete closed and 12 h+ idle rows from connection_monitor"):
+                    try:
+                        pool = app_mysql.get_connection_pool_instance()
+                        purged = pool.cleanup_stale_connections(stale_hours=12)
+                        st.success(f"✅ Purged {purged} stale connection row(s)")
+                        st.rerun()
+                    except Exception as e:
+                        st.error(f"❌ Purge failed: {e}")
+
             with col_btn2:
                 if len(active_sessions) > 0:
                     with st.popover("⚠️ Force Logout All Users"):


### PR DESCRIPTION
## Summary

- 4640721 fix: purge stale connection_monitor rows to fix bogus capacity warning
- bd87df4 fix: add git -C * variants to bash allowlist
- 4c563f2 chore: add setup-worktree.sh and settings template

## Test plan
- [ ] App starts without import errors
- [ ] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)