### PR TITLE
chore: copy secrets.toml in setup-worktree.sh

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -177,8 +177,8 @@ def git_tag(tag_name: str, message: str) -> None:
 
 
 def git_push() -> None:
-    subprocess.run(["git", "push"], check=True)
-    subprocess.run(["git", "push", "--tags"], check=True)
+    subprocess.run(["git", "push", "origin", "HEAD"], check=True)
+    subprocess.run(["git", "push", "origin", "--tags"], check=True)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # setup-worktree.sh — Bootstrap a fresh Claude Code worktree with the standard
-# permissions allowlist (settings.local.json).
+# permissions allowlist (settings.local.json) and secrets.toml.
 #
 # Usage:
 #   scripts/setup-worktree.sh                    # target = cwd
 #   scripts/setup-worktree.sh <worktree-path>    # target = explicit path
 #
 # The template lives in scripts/worktree-settings.json (checked in).
-# Run once after EnterWorktree, or whenever settings.local.json is missing.
+# secrets.toml is copied from the main repo root (gitignored, never committed).
+# Run once after EnterWorktree, or whenever either file is missing.
 
 set -euo pipefail
 
@@ -28,4 +29,21 @@ if [[ -f "$DEST/settings.local.json" ]]; then
 else
     cp "$TEMPLATE" "$DEST/settings.local.json"
     echo "Installed $DEST/settings.local.json"
+fi
+
+# ── Copy secrets.toml from main repo (gitignored, never committed) ────────────
+MAIN_ROOT="$(dirname "$(git -C "$TARGET" rev-parse --git-common-dir)")"
+SECRETS_SRC="$MAIN_ROOT/.streamlit/secrets.toml"
+SECRETS_DEST="$TARGET/.streamlit/secrets.toml"
+
+if [[ -f "$SECRETS_SRC" ]]; then
+    if [[ -f "$SECRETS_DEST" ]]; then
+        echo "secrets.toml already exists at $SECRETS_DEST — skipping."
+    else
+        mkdir -p "$TARGET/.streamlit"
+        cp "$SECRETS_SRC" "$SECRETS_DEST"
+        echo "Installed $SECRETS_DEST"
+    fi
+else
+    echo "WARNING: no secrets.toml found at $SECRETS_SRC — skipping."
 fi

--- a/src/miolingo-admin.py
+++ b/src/miolingo-admin.py
@@ -9,7 +9,7 @@ Then open: http://localhost:8505
 Version: 2.1.0
 """
 
-__version__ = "2.2.0"
+__version__ = "2.2.1-claude-dev"
 
 # Auto-refresh interval in minutes
 REFRESH_INTERVAL_MINUTES = 5


### PR DESCRIPTION
## Summary

- 32b8374 chore: copy secrets.toml in setup-worktree.sh
- 4640721 fix: purge stale connection_monitor rows to fix bogus capacity warning
- bd87df4 fix: add git -C * variants to bash allowlist
- 4c563f2 chore: add setup-worktree.sh and settings template

## Test plan
- [ ] App starts without import errors
- [ ] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)