### PR TITLE
fix: admin version display reads __version__ not hardcoded string

### DIFF
--- a/src/miolingo-admin.py
+++ b/src/miolingo-admin.py
@@ -127,12 +127,12 @@ def check_authentication():
 check_authentication()
 
 st.title("🔧 Miolingo Admin Dashboard")
-st.caption("Local monitoring and management interface • v2.0.5")
+st.caption(f"Local monitoring and management interface • v{__version__}")
 
 if not HOSTED_BY_UNIFIED_ADMIN:
     # Quick reconnect button in sidebar (standalone mode)
     with st.sidebar:
-        st.caption("Miolingo Admin Dashboard v2.0.5")
+        st.caption(f"Miolingo Admin Dashboard v{__version__}")
         st.caption("Local monitoring interface")
         st.divider()
         


### PR DESCRIPTION
## Summary

- 1a67a6a fix: read __version__ for admin sidebar/title instead of hardcoded string

## Test plan
- [ ] App starts without import errors
- [ ] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)