### PR TITLE
fix: unified_admin versioning, stale connection purge, worktree setup improvements

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -78,7 +78,7 @@ TARGETS = {
         "tag_prefix": "v",
     },
     "admin": {
-        "version_file": PROJECT_ROOT / "src" / "miolingo-admin.py",
+        "version_file": PROJECT_ROOT / "src" / "unified_admin.py",
         "changelog_file": PROJECT_ROOT / "ADMIN_CHANGELOG.md",
         "version_pattern": r'(__version__\s*=\s*["\'])([^"\']+)(["\'])',
         "tag_prefix": "admin-v",

--- a/src/unified_admin.py
+++ b/src/unified_admin.py
@@ -22,7 +22,7 @@ import streamlit as st
 
 import app_mysql
 
-__version__ = "1.0.0"
+__version__ = "1.0.1-claude-dev"
 
 
 REFRESH_INTERVAL_MINUTES = 5

--- a/src/unified_admin.py
+++ b/src/unified_admin.py
@@ -22,6 +22,8 @@ import streamlit as st
 
 import app_mysql
 
+__version__ = "1.0.0"
+
 
 REFRESH_INTERVAL_MINUTES = 5
 
@@ -110,7 +112,7 @@ if st.session_state.get('session_id'):
         pass
 
 with st.sidebar:
-    st.caption("Miolingo Admin Dashboard v2.0.5")
+    st.caption(f"Miolingo Admin Dashboard v{__version__}")
     st.caption("Local monitoring interface")
     st.divider()
     


### PR DESCRIPTION
## Summary

- ae6a999 admin-v1.0.1-claude-dev: version bump
- 8bc16e2 fix: add __version__ to unified_admin.py and retarget bump script
- 1a67a6a fix: read __version__ for admin sidebar/title instead of hardcoded string

## Test plan
- [ ] App starts without import errors
- [ ] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)