### PR TITLE
fix: English materials appear in Quick Practice via unified discovery (v7.3.10)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.3.10] - 2026-04-15
+
+### Changed
+
+- Version bump
+
+
 ## [7.3.9] - 2026-04-15
 
 ### Changed

--- a/src/app_language_materials.py
+++ b/src/app_language_materials.py
@@ -14,26 +14,48 @@ DATA_DIR = Path(__file__).parent.parent / "language_materials"
 UNIFIED_DIR = DATA_DIR / "unified"
 
 # Cache version - increment when language list or structure changes
-CACHE_VERSION = "1.9.0"
+CACHE_VERSION = "1.10.0"
 
 
 @st.cache_data
 def get_available_languages(_cache_version: str = CACHE_VERSION) -> List[str]:
     """Get list of languages with available materials.
-    
+
+    Includes languages from per-language directories AND languages declared
+    in unified multi-language files (e.g. 'en', which has no separate
+    directory but is fully present in language_materials/unified/).
+
     Args:
-        _cache_version: Version string to bust cache (leading underscore prevents it from being used)
-    
+        _cache_version: Version string to bust cache (leading underscore
+            prevents Streamlit from using it as a cache key argument)
+
     Returns:
-        List of language codes (e.g., ['fr', 'pt', 'nl'])
+        Sorted list of language codes (e.g., ['de', 'en', 'fr', 'pt', ...])
     """
     if not DATA_DIR.exists():
         return []
-    
-    return sorted([
+
+    per_lang = {
         d.name for d in DATA_DIR.iterdir()
         if d.is_dir() and not d.name.startswith('.') and d.name != 'unified'
-    ])
+    }
+
+    # Also surface languages that only exist in unified files (e.g. 'en')
+    unified_langs: set = set()
+    for subdir_name in ('phrases', 'phrasebook', 'stories'):
+        subdir = UNIFIED_DIR / subdir_name
+        if subdir.is_dir():
+            candidates = sorted(subdir.glob("*.json"))
+            if candidates:
+                try:
+                    with open(candidates[0], 'r', encoding='utf-8') as f:
+                        meta = json.load(f).get('meta', {})
+                    unified_langs.update(meta.get('languages', []))
+                    break  # one file is sufficient
+                except Exception:
+                    pass
+
+    return sorted(per_lang | unified_langs)
 
 
 @st.cache_data

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.3.9"
+__version__ = "7.3.10"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Problem

After the sidebar fix (v7.3.9), English is selectable as a target language — but Quick Practice showed no materials for it. \`get_available_languages()\` only scanned per-language directories (\`de/\`, \`fr/\`, etc.) and explicitly skipped \`unified/\`. Since there is no \`en/\` directory, English was never returned.

All loading infrastructure was already correct: \`get_language_structure('en')\` injects unified categories, \`load_unified_phrase_file()\` projects \`text.en\`/\`ipa.en\`, and every unified JSON declares \`"languages": ["de","en","es","fr","it","nl","pt"]\`.

## Fix

\`get_available_languages()\` now unions per-language directories with language codes found in \`meta.languages\` of the first unified JSON file. English (and any future unified-only language) surfaces automatically without requiring a stub directory.

\`CACHE_VERSION\` bumped to \`1.10.0\` to bust the Streamlit cache on restart.

## Unchanged

- Sidebar language selectors (v7.3.9)
- Story Reader (already working)
- All loading functions — no changes to how content is fetched