### PR TITLE
fix: English materials in Quick Practice — handle no-directory case (v7.3.11)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.3.11] - 2026-04-15
+
+### Changed
+
+- Version bump
+
+
 ## [7.3.10] - 2026-04-15
 
 ### Changed

--- a/src/app_language_materials.py
+++ b/src/app_language_materials.py
@@ -14,7 +14,7 @@ DATA_DIR = Path(__file__).parent.parent / "language_materials"
 UNIFIED_DIR = DATA_DIR / "unified"
 
 # Cache version - increment when language list or structure changes
-CACHE_VERSION = "1.10.0"
+CACHE_VERSION = "1.10.1"
 
 
 @st.cache_data
@@ -78,20 +78,18 @@ def get_language_structure(language: str, _cache_version: str = CACHE_VERSION) -
         }
     """
     lang_dir = DATA_DIR / language
-    if not lang_dir.exists():
-        return {}
-    
+
     # Aggregated structure
     aggregated = {
         'phrases': [],
         'words': [],
     }
-    
+
     # Directories to exclude from category discovery (backup/deprecated)
     excluded_dirs = {'phrases-original', 'story-scenes'}
-    
-    # Scan all subdirectories
-    for category_dir in sorted(lang_dir.iterdir()):
+
+    # Scan per-language subdirectory (may not exist for unified-only languages like 'en')
+    for category_dir in sorted(lang_dir.iterdir()) if lang_dir.exists() else []:
         if not category_dir.is_dir() or category_dir.name.startswith('.'):
             continue
         

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.3.10"
+__version__ = "7.3.11"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Root cause

\`get_language_structure(language)\` opened with an early-return guard:
\`\`\`python
if not lang_dir.exists():
    return {}
\`\`\`
For English (\`en\`), there is no \`language_materials/en/\` directory — content lives in \`unified/\`. The function bailed out *before* reaching the unified injection block (lines 130+), so English always got an empty structure and Quick Practice showed "No materials found."

## Fix

Replace the early-return with a conditional loop: per-language directory scan only runs when the directory exists; the unified injection block always runs regardless. English now surfaces 32 items across \`unified-stories\`, \`unified-phrases\`, and \`unified-phrasebook\`.

\`CACHE_VERSION\` bumped to \`1.10.1\`.

## Tested (preview server, user fluffy)

- Target = English → Quick Practice shows 3 unified categories, 32 files
- Target = French/Portuguese → unchanged, per-language + unified categories both present