### PR TITLE
fix: Unix socket for local MySQL + sync bug fix (v7.4.1)

### DIFF
--- a/scripts/sync_db.py
+++ b/scripts/sync_db.py
@@ -127,16 +127,30 @@ def open_remote_connection(secrets: dict) -> tuple[SSHTunnelForwarder, mysql.con
 
 
 def open_local_connection(secrets: dict) -> mysql.connector.MySQLConnection:
-    """Open direct connection to local MySQL."""
+    """Open direct connection to local MySQL.
+
+    Prefers Unix socket (``unix_socket`` in secrets) so it works with
+    MacPorts' default ``skip-networking``.  Falls back to TCP host/port.
+    """
     cfg = secrets["local_db"]
-    conn = mysql.connector.connect(
-        host=cfg["host"],
-        port=int(cfg.get("port", 3306)),
-        database=cfg["database"],
-        user=cfg["user"],
-        password=cfg["password"],
-        autocommit=False,
-    )
+    socket_path = cfg.get("unix_socket", "")
+    if socket_path:
+        conn = mysql.connector.connect(
+            unix_socket=socket_path,
+            database=cfg["database"],
+            user=cfg["user"],
+            password=cfg["password"],
+            autocommit=False,
+        )
+    else:
+        conn = mysql.connector.connect(
+            host=cfg["host"],
+            port=int(cfg.get("port", 3306)),
+            database=cfg["database"],
+            user=cfg["user"],
+            password=cfg["password"],
+            autocommit=False,
+        )
     log.info("Local: connected")
     return conn
 
@@ -478,7 +492,11 @@ def run_sync(full: bool = False, dry_run: bool = False):
             if strategy == "overwrite":
                 stats = sync_overwrite(remote_conn, local_conn, table, dry_run)
             elif strategy == "append_by_date":
-                date_col = "practice_date" if table == "user_progress" else "created_at"
+                DATE_COL_MAP = {
+                    "user_progress": "practice_date",
+                    "activity_log": "timestamp",
+                }
+                date_col = DATE_COL_MAP.get(table, "created_at")
                 stats = sync_append_by_date(
                     local_conn, remote_conn, table, last_sync_ts,
                     date_col=date_col, dry_run=dry_run,

--- a/src/app_mysql.py
+++ b/src/app_mysql.py
@@ -83,16 +83,31 @@ def _is_local_mode() -> bool:
 
 
 def _get_local_connection() -> mysql.connector.MySQLConnection:
-    """Direct localhost MySQL connection — no tunnel, no pool."""
+    """Direct localhost MySQL connection — no tunnel, no pool.
+
+    Prefers Unix socket (``unix_socket`` key in secrets) which works even when
+    MySQL's ``skip-networking`` is enabled (the MacPorts default).  Falls back
+    to TCP host/port if no socket path is configured.
+    """
     cfg = st.secrets["local_db"]
-    conn = mysql.connector.connect(
-        host=cfg["host"],
-        port=int(cfg.get("port", 3306)),
-        database=cfg["database"],
-        user=cfg["user"],
-        password=cfg["password"],
-        autocommit=False,
-    )
+    socket_path = cfg.get("unix_socket", "")
+    if socket_path:
+        conn = mysql.connector.connect(
+            unix_socket=socket_path,
+            database=cfg["database"],
+            user=cfg["user"],
+            password=cfg["password"],
+            autocommit=False,
+        )
+    else:
+        conn = mysql.connector.connect(
+            host=cfg["host"],
+            port=int(cfg.get("port", 3306)),
+            database=cfg["database"],
+            user=cfg["user"],
+            password=cfg["password"],
+            autocommit=False,
+        )
     return conn
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.4.0"
+__version__ = "7.4.1"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Summary
- Local MySQL connections now use Unix sockets by default, avoiding the need to disable MacPorts' `skip-networking` setting
- Fixed `sync_db.py` crash on `activity_log` table — column is `timestamp`, not `created_at`
- Patch bump to v7.4.1

## Context
Follow-up to PR #66 (local MySQL mode). Discovered during first real setup that MacPorts MySQL ships with `skip-networking` enabled, blocking TCP connections. Unix sockets are faster and more secure anyway.

## Note
Originally merged as PR #67 into `main` in error. That merge has been reverted (aa5d9b6). This PR correctly targets `claude/dev-swept`.

## Test plan
- [x] Local MySQL connects via socket with `skip-networking` enabled
- [x] `sync_db.py --full` completes all tables including `activity_log`
- [x] App starts and serves on local DB (v7.4.1 confirmed in sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)