### PR TITLE
chore(workflow): add push-guard hook + PR branch recipe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,5 +60,18 @@
       "Bash(bash -n *)",
       "Bash(zsh -n *)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); case \"$cmd\" in *\"git push\"*) ;; *) exit 0 ;; esac; case \"$cmd\" in *\"HEAD:refs/heads/\"*) exit 0 ;; esac; local_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo \"\"); upstream=$(git rev-parse --abbrev-ref \"@{u}\" 2>/dev/null || echo \"\"); if [ -z \"$upstream\" ] || [ -z \"$local_branch\" ]; then exit 0; fi; upstream_branch=${upstream#*/}; if [ \"$local_branch\" = \"$upstream_branch\" ]; then exit 0; fi; jq -n --arg local \"$local_branch\" --arg up \"$upstream\" '{hookSpecificOutput: {hookEventName: \"PreToolUse\", permissionDecision: \"deny\", permissionDecisionReason: (\"Blocked: local branch `\" + $local + \"` tracks `\" + $up + \"`. A plain `git push` would land commits on `\" + $up + \"` and bypass PR review. Use `git push origin HEAD:refs/heads/\" + $local + \"` to create/update a new remote branch matching the local name, or run `git branch --unset-upstream` first.\")}}'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,46 @@
 # Miolingo — Claude Code Instructions
 
+## Git Workflow — PR Branches (read before any `git push`)
+
+All work lands via PRs targeting `claude/dev-swept`. **Never push directly to
+`claude/dev-swept` or `claude/dev`.**
+
+When `git checkout -b` or `git switch -c` derives a branch from
+`origin/claude/dev-swept`, the new local branch silently inherits
+`claude/dev-swept` as its upstream. A subsequent `git push -u` will then push
+*onto the parent branch*, bypassing PR review. Use the explicit refspec form
+on the first push.
+
+**Recipe — start a PR branch:**
+
+```bash
+git fetch origin claude/dev-swept
+git switch -c claude/<descriptive-name> origin/claude/dev-swept
+
+# ... make commits ...
+
+# First push — explicit refspec forces a NEW remote branch matching the
+# local name, regardless of inherited upstream:
+git push -u origin HEAD:refs/heads/claude/<descriptive-name>
+```
+
+**Before every first push on a new branch, verify the upstream:**
+
+```bash
+git rev-parse --abbrev-ref @{u}   # should match local branch name after push
+git symbolic-ref --short HEAD      # local branch name
+```
+
+If they don't match, use the `HEAD:refs/heads/<name>` refspec form. Never use
+bare `git push -u origin <branch>` as the first push on a branch that was
+created from another tracking branch — the inherited upstream will win.
+
+A `PreToolUse` hook in `.claude/settings.json` now blocks `git push` when the
+local branch name does not match its upstream, but the hook is a safety net,
+not a substitute for following this recipe.
+
+---
+
 ## Python Environment
 
 **Always activate the project virtual environment before running any Python, pip, or related command.**


### PR DESCRIPTION
## Summary

- Add a `PreToolUse`/Bash hook in `.claude/settings.json` that blocks `git push` when local branch name does not match its upstream (after stripping remote prefix). Skips when the command uses the explicit `HEAD:refs/heads/...` refspec form, or when no upstream is set.
- Add a "Git Workflow — PR Branches" section to `CLAUDE.md` at the top of the file, documenting the trap, the recipe, and the verification commands.

## Why

On 2026-04-17, a Dockerfile performance fix was branched from `origin/claude/dev-swept`. The new local branch silently inherited `claude/dev-swept` as its upstream; a later `git push -u` then landed the commit directly on `dev-swept`, bypassing the PR workflow. The user surfaced this as a recurring class of error and asked for belt-and-braces safeguards.

The hook is the mechanical guardrail (model-independent). The CLAUDE.md recipe is the human-readable counterpart and keeps the correct pattern in context on every session.

## Test plan

- [x] Pipe-tested hook against three scenarios (non-push command, explicit-refspec push, mismatched-upstream push) before wiring it in
- [x] Verified hook fires in this session — it blocked a meta-test command that contained the literal string "git push" as test data (safer false-positive than false-negative)
- [x] Verified the recipe (`git push origin HEAD:refs/heads/<name>`) bypasses the hook cleanly — this very PR's push used that form
- [x] Existing permissions array preserved; new `hooks` key added as a sibling
- [ ] Reviewer: run `/hooks` once after pulling this branch so Claude Code picks up the new hook registration

## Notes

- No app version bump — tooling/workflow only, no runtime code change.
- The hook's substring match on "git push" will flag shell commands that echo or grep for the literal string. In practice this is rare and the false-positive is safer than the inverse; can be tightened later if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)