### PR TITLE
feat(stats): charts + weakest-phrases on Statistics tab (v7.5.0)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.5.0] - 2026-04-17
+
+### Added
+
+- Statistics tab: four compact charts + breakdown, replacing the previous
+  metrics-only view. Window is the last 90 days:
+  - Accuracy trend (per-practice score + rolling-10 average overlay)
+  - Practices per day (bar)
+  - Score distribution (histogram, 20 bins)
+  - Weakest phrases table (min 3 attempts, lowest average score first)
+- `app_mysql.get_user_progress_timeseries()` — time-series rows for charts
+- `app_mysql.get_user_weakest_phrases()` — GROUP BY target_phrase
+  aggregate for the breakdown table
+
+Charts use Streamlit's native Altair (no new dependency). Heights are
+fixed at 220px to keep the tab scrollable.
+
+
 ## [7.4.2] - 2026-04-17
 
 ### Changed

--- a/src/app_mysql.py
+++ b/src/app_mysql.py
@@ -1648,6 +1648,66 @@ def get_user_stats(user_id: int, language_code: str) -> Dict:
         return {'total': 0, 'perfect_count': 0, 'avg_score': 0, 'recent_avg': 0}
     
 
+def get_user_progress_timeseries(
+    user_id: int,
+    language_code: str,
+    days: int = 90,
+) -> List[Dict]:
+    """
+    Raw time-series rows for Statistics-tab charts.
+
+    One row per practice in the window, ordered oldest-first so downstream
+    rolling averages compute correctly without a re-sort.
+    """
+    conn = None
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+        query = """
+            SELECT practice_date, similarity_score, perfect_match, target_phrase
+            FROM user_progress
+            WHERE user_id = %s
+              AND language_code = %s
+              AND practice_date >= DATE_SUB(NOW(), INTERVAL %s DAY)
+            ORDER BY practice_date ASC
+        """
+        cursor.execute(query, (user_id, language_code, days))
+        return cursor.fetchall()
+    except Error as e:
+        st.error(f"❌ Error fetching timeseries: {e}")
+        return []
+
+
+def get_user_weakest_phrases(
+    user_id: int,
+    language_code: str,
+    min_attempts: int = 3,
+    limit: int = 10,
+) -> List[Dict]:
+    """Phrases with the lowest average score, filtered to ones practised enough to be meaningful."""
+    conn = None
+    try:
+        conn = get_connection()
+        cursor = conn.cursor(dictionary=True)
+        query = """
+            SELECT target_phrase,
+                   COUNT(*) AS attempts,
+                   AVG(similarity_score) AS avg_score,
+                   MAX(practice_date) AS last_attempt
+            FROM user_progress
+            WHERE user_id = %s AND language_code = %s
+            GROUP BY target_phrase
+            HAVING attempts >= %s
+            ORDER BY avg_score ASC, attempts DESC
+            LIMIT %s
+        """
+        cursor.execute(query, (user_id, language_code, min_attempts, limit))
+        return cursor.fetchall()
+    except Error as e:
+        st.error(f"❌ Error fetching weakest phrases: {e}")
+        return []
+
+
 # ============================================================================
 # RATE LIMITING
 # ============================================================================

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.4.2"
+__version__ = "7.5.0"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/statistics_tab.py
+++ b/src/ui/statistics_tab.py
@@ -1,23 +1,29 @@
 """
-Statistics tab UI: current session and all-time practice stats.
+Statistics tab UI: current session and all-time practice stats, plus
+compact charts for accuracy trend, practice volume, score distribution,
+and weakest phrases.
 
-Extracted from app.py (Phase 4.2 of refactor).
-
-Exports
--------
-    render_statistics_tab()  — top-level Statistics tab entry point
+Extracted from app.py (Phase 4.2 of refactor); charts added in v7.5.0.
 """
 
+from __future__ import annotations
+
+import pandas as pd
 import streamlit as st
+import altair as alt
 
 import app_mysql
 
 
+CHART_HEIGHT = 220  # compact — deliberately small so the tab stays scrollable
+WINDOW_DAYS = 90
+
+
 def render_statistics_tab():
-    """Render the Statistics tab with current session and all-time metrics."""
+    """Render the Statistics tab with current session, all-time metrics, and charts."""
     st.header("📊 Practice Statistics")
 
-    # Current session stats
+    # ── Current session ────────────────────────────────────────────────
     current_session = st.session_state.current_sessions[st.session_state.language]
     if current_session["practices"]:
         st.subheader("🔵 Current Session")
@@ -30,22 +36,124 @@ def render_statistics_tab():
         col2.metric("Perfect", f"{perfect} ({perfect/len(practices):.1%})")
         col3.metric("Avg Similarity", f"{avg_sim:.1%}")
 
-    # Overall stats - from database for authenticated users
-    if st.session_state.get('authenticated', False):
-        st.subheader("📈 All Time")
-        try:
-            user_id = st.session_state['user']['user_id']
-            stats = app_mysql.get_user_stats(user_id, st.session_state.language)
+    # ── All-time (auth required) ───────────────────────────────────────
+    if not st.session_state.get("authenticated", False):
+        st.info("Log in to see all-time statistics and charts.")
+        return
 
-            if stats and stats['total'] > 0:
-                col1, col2, col3, col4 = st.columns(4)
-                col1.metric("Total Practices", stats['total'])
-                col2.metric("Total Perfect", f"{stats['perfect_count']} ({stats['perfect_count']/stats['total']:.1%})")
-                col3.metric("Overall Avg", f"{stats['avg_score']:.1%}")
-                col4.metric("Recent Avg (last 10)", f"{stats['recent_avg']:.1%}")
-            else:
-                st.info("No practice history yet. Start practicing!")
-        except Exception as e:
-            st.error(f"Could not load stats: {e}")
-    else:
+    user_id = st.session_state["user"]["user_id"]
+    lang = st.session_state.language
+
+    st.subheader("📈 All Time")
+    try:
+        stats = app_mysql.get_user_stats(user_id, lang)
+    except Exception as e:
+        st.error(f"Could not load stats: {e}")
+        return
+
+    if not stats or stats["total"] == 0:
         st.info("No practice history yet. Start practicing!")
+        return
+
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Total Practices", stats["total"])
+    col2.metric("Total Perfect", f"{stats['perfect_count']} ({stats['perfect_count']/stats['total']:.1%})")
+    col3.metric("Overall Avg", f"{stats['avg_score']:.1%}")
+    col4.metric("Recent Avg (last 10)", f"{stats['recent_avg']:.1%}")
+
+    # ── Charts ─────────────────────────────────────────────────────────
+    rows = app_mysql.get_user_progress_timeseries(user_id, lang, days=WINDOW_DAYS)
+    if not rows:
+        st.caption(f"No practice data in the last {WINDOW_DAYS} days.")
+        return
+
+    df = pd.DataFrame(rows)
+    df["practice_date"] = pd.to_datetime(df["practice_date"])
+    df["similarity_score"] = pd.to_numeric(df["similarity_score"], errors="coerce")
+
+    st.markdown(f"_Charts below cover the last {WINDOW_DAYS} days ({len(df)} practices)._")
+
+    _render_accuracy_trend(df)
+    col_a, col_b = st.columns(2)
+    with col_a:
+        _render_volume_chart(df)
+    with col_b:
+        _render_score_distribution(df)
+    _render_weakest_phrases(user_id, lang)
+
+
+def _render_accuracy_trend(df: pd.DataFrame) -> None:
+    """Per-practice score + rolling-10 average overlay."""
+    st.markdown("**Accuracy trend**")
+    plot_df = df[["practice_date", "similarity_score"]].copy()
+    plot_df["rolling10"] = plot_df["similarity_score"].rolling(window=10, min_periods=1).mean()
+
+    base = alt.Chart(plot_df).encode(x=alt.X("practice_date:T", title=None))
+    points = base.mark_circle(size=20, opacity=0.4).encode(
+        y=alt.Y("similarity_score:Q", title="score", scale=alt.Scale(domain=[0, 1])),
+        tooltip=[
+            alt.Tooltip("practice_date:T", title="when"),
+            alt.Tooltip("similarity_score:Q", title="score", format=".1%"),
+        ],
+    )
+    line = base.mark_line(color="#ff6b35", strokeWidth=2).encode(
+        y=alt.Y("rolling10:Q", scale=alt.Scale(domain=[0, 1])),
+    )
+    chart = (points + line).properties(height=CHART_HEIGHT)
+    st.altair_chart(chart, use_container_width=True)
+
+
+def _render_volume_chart(df: pd.DataFrame) -> None:
+    """Bar chart of practices per day."""
+    st.markdown("**Practices per day**")
+    by_day = (
+        df.assign(day=df["practice_date"].dt.date)
+        .groupby("day")
+        .size()
+        .reset_index(name="count")
+    )
+    chart = (
+        alt.Chart(by_day)
+        .mark_bar()
+        .encode(
+            x=alt.X("day:T", title=None),
+            y=alt.Y("count:Q", title="practices"),
+            tooltip=["day:T", "count:Q"],
+        )
+        .properties(height=CHART_HEIGHT)
+    )
+    st.altair_chart(chart, use_container_width=True)
+
+
+def _render_score_distribution(df: pd.DataFrame) -> None:
+    """Histogram of similarity scores."""
+    st.markdown("**Score distribution**")
+    chart = (
+        alt.Chart(df)
+        .mark_bar()
+        .encode(
+            x=alt.X("similarity_score:Q", bin=alt.Bin(maxbins=20), title="score"),
+            y=alt.Y("count():Q", title="practices"),
+            tooltip=[alt.Tooltip("count():Q", title="practices")],
+        )
+        .properties(height=CHART_HEIGHT)
+    )
+    st.altair_chart(chart, use_container_width=True)
+
+
+def _render_weakest_phrases(user_id: int, lang: str) -> None:
+    """Small table of the hardest phrases (min 3 attempts)."""
+    rows = app_mysql.get_user_weakest_phrases(user_id, lang, min_attempts=3, limit=10)
+    if not rows:
+        return
+    st.markdown("**Weakest phrases** (min 3 attempts)")
+    tbl = pd.DataFrame(rows)
+    tbl["avg_score"] = pd.to_numeric(tbl["avg_score"], errors="coerce")
+    tbl["avg_score"] = tbl["avg_score"].map(lambda v: f"{v:.1%}")
+    tbl = tbl.rename(columns={
+        "target_phrase": "phrase",
+        "attempts": "attempts",
+        "avg_score": "avg score",
+        "last_attempt": "last attempt",
+    })
+    st.dataframe(tbl, hide_index=True, use_container_width=True)


### PR DESCRIPTION
## Summary

Replaces the placeholder Statistics tab with four compact charts + a weakest-phrases breakdown, covering the last 90 days of practice data. Addresses the "charts/breakdowns not yet implemented" item from `CLAUDE.md` known issues and F1 from the perf/UX review.

## Charts (all 220px tall, Streamlit native Altair — no new dep)

- **Accuracy trend** — per-practice scatter + rolling-10 moving average line
- **Practices per day** — bar chart
- **Score distribution** — 20-bin histogram
- **Weakest phrases** — table grouped by `target_phrase`, min 3 attempts, lowest avg score first

Top-line metrics (Total / Perfect / Overall Avg / Recent Avg) are unchanged.

## New DB helpers (`src/app_mysql.py`)

- `get_user_progress_timeseries(user_id, lang, days=90)` — raw rows, oldest-first for correct rolling computation
- `get_user_weakest_phrases(user_id, lang, min_attempts=3, limit=10)` — GROUP BY aggregate

Both are bounded by a date window or LIMIT; no full-table scans.

## Test plan

- [x] `pytest tests/` — 100 pass
- [x] Smoke import of `ui.statistics_tab` (all helper functions + top-level entry point)
- [ ] Reviewer: log into dev.miolingo.io, record a few practices, open Statistics tab, verify charts render and heights stay compact
- [ ] Reviewer: verify unauthenticated state still shows "Log in to see all-time statistics"

## Notes

- Charts are deliberately small (220px) per your preference. Easy to tweak via the `CHART_HEIGHT` constant at the top of `statistics_tab.py`.
- Window is 90 days — easy to adjust via `WINDOW_DAYS` constant.
- No version tag yet — created on merge per your tagging workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)