### PR TITLE
fix(auth): logout race — blank page + auto re-login (v7.5.1)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.5.1] - 2026-04-18
+
+### Fixed
+
+- Logout: clicking Logout no longer leaves the user auto-re-logged-in or
+  on a blank page. Two related races are closed:
+  - `st.session_state.clear()` used to drop the `cookie_manager`
+    reference, forcing a fresh `EncryptedCookieManager` to be built mid-
+    logout. That new instance could read the pre-logout cookie state
+    before the just-queued `cookies.save()` had committed to the
+    browser. The manager is now preserved across the clear.
+  - `check_authentication()` could run `resolve_session()` on the very
+    next rerun and re-attach the still-present session cookie. It now
+    short-circuits when `voluntary_logout` is set, deferring cookie
+    reads until the browser has had a chance to catch up.
+
+Logging in as a different user in the same browser now works without
+incognito. Tab-independent logout is not addressed — cookies are shared
+per-domain and would need a separate identity mechanism.
+
+
 ## [7.5.0] - 2026-04-17
 
 ### Added

--- a/src/auth.py
+++ b/src/auth.py
@@ -419,8 +419,13 @@ def check_authentication():
     if 'authenticated' not in st.session_state:
         st.session_state['authenticated'] = False
 
-    # Attempt cookie-based reattach (feature-flagged)
-    if ENABLE_SESSION_MANAGER and not st.session_state.get('authenticated', False):
+    # Attempt cookie-based reattach (feature-flagged).
+    # Skip on the run immediately after a voluntary logout: the browser may
+    # not have committed the cleared session cookie yet, and re-attaching
+    # here would silently log the user back in.
+    if (ENABLE_SESSION_MANAGER
+            and not st.session_state.get('authenticated', False)
+            and not st.session_state.get('voluntary_logout', False)):
         if _session_manager:
             context = _session_manager.resolve_session()
             if context.authenticated and context.user:

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.5.0"
+__version__ = "7.5.1"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -120,7 +120,17 @@ def render_user_panel():
 
             on_logout()
             app_mysql.cleanup_session_resources()
+
+            # Preserve the cookie_manager across the clear so the already-queued
+            # save() in on_logout() can finish committing to the browser on
+            # the next render. Re-instantiating it mid-logout races the
+            # component and can leave the session cookie in place (auto
+            # re-login) or block the login page from rendering (blank page).
+            preserved = {}
+            if 'cookie_manager' in st.session_state:
+                preserved['cookie_manager'] = st.session_state['cookie_manager']
             st.session_state.clear()
+            st.session_state.update(preserved)
             st.session_state['voluntary_logout'] = True
             st.rerun()
 


### PR DESCRIPTION
## Summary

Fixes the logout flow on dev.miolingo.io: clicking Logout was leaving the user either auto-re-logged-in or on a blank page, preventing a second user from logging in the same browser.

Two related races closed:

- **Cookie manager lost mid-logout.** `st.session_state.clear()` was dropping the cached `cookie_manager`, forcing a fresh `EncryptedCookieManager` on the next rerun. That new instance could read browser cookies before the just-queued `cookies.save()` had committed — seeing the pre-logout state (stale session cookie, LOGOUT flag not yet set). The manager is now preserved across the clear.
- **Stale-cookie reattach.** `check_authentication()` could run `resolve_session()` on the very next rerun and silently reattach the still-present session cookie. It now short-circuits when `voluntary_logout` is set.

Tab-independent logout is out of scope — cookies are per-domain and would require a separate identity mechanism.

## Why it started happening now

Latent since commit `295ab7d` (2026-04-06, "batch logout cookie mutations"). Before that commit, `on_logout()` called `cookies.save()` twice, with the second raising `StreamlitDuplicateElementKey` and crashing mid-logout *before* `session_state.clear()` + `st.rerun()` ran. The April-6 fix collapsed the two saves into one — logout now runs to completion, exposing the race.

## Test plan
- [ ] Log in on dev.miolingo.io.
- [ ] Click Logout. Login page appears (no blank screen, no auto re-login).
- [ ] Log in as a *different* user in the same browser without incognito.
- [ ] Sidebar shows `v7.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)