### PR TITLE
fix(quick-practice): reset recorder on phrase navigation (v7.5.2)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.5.2] - 2026-04-18
+
+### Fixed
+
+- Quick Practice: navigating to another phrase via Previous/Next/Jump-to
+  with a recording still in the widget no longer leaves Streamlit's
+  `st.audio_input` showing "An error occurred. Please try again." The
+  audio_input widget is now remounted (key rotation) and the stale
+  result cleared on every navigation event, mirroring what the Remove
+  Recording button already did. Also prevents a recording made for
+  phrase N from being submittable against phrase N+1.
+
+
 ## [7.5.1] - 2026-04-18
 
 ### Fixed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.5.1"
+__version__ = "7.5.2"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/quick_practice_tab.py
+++ b/src/ui/quick_practice_tab.py
@@ -549,14 +549,25 @@ def _render_guided_mode():
     in_edit_mode = st.session_state.get('edit_mode', False)
     col1, col2, col3, col4 = st.columns([1, 1, 2, 1])
 
+    def _reset_recorder():
+        # Remount the st.audio_input widget so a stale blob / MediaRecorder
+        # handle from the previous phrase can't surface as the generic
+        # "An error occurred. Please try again." in-widget message.
+        st.session_state["quick_audio_input_key"] = (
+            st.session_state.get("quick_audio_input_key", 0) + 1
+        )
+        st.session_state["quick_last_result"] = None
+
     def _on_prev():
         st.session_state.qp_phrase_position -= 1
         st.session_state.phrase_selector_widget = st.session_state.qp_phrase_position
+        _reset_recorder()
         if is_debug(): st.session_state.state_change_log.append(f"Prev button: qp_phrase_position → {st.session_state.qp_phrase_position}")
 
     def _on_next():
         st.session_state.qp_phrase_position += 1
         st.session_state.phrase_selector_widget = st.session_state.qp_phrase_position
+        _reset_recorder()
         if is_debug(): st.session_state.state_change_log.append(f"Next button: qp_phrase_position → {st.session_state.qp_phrase_position}")
 
     with col1:
@@ -591,6 +602,7 @@ def _render_guided_mode():
         # Detect user interaction with selectbox (no on_change — avoids callback conflicts)
         if selected_pos != st.session_state.qp_phrase_position:
             st.session_state.qp_phrase_position = selected_pos
+            _reset_recorder()
             if is_debug(): st.session_state.state_change_log.append(f"Dropdown: qp_phrase_position → {selected_pos} (user selected)")
             st.rerun()
 


### PR DESCRIPTION
## Summary

Fixes the in-widget error reported on the Quick Practice tab: clicking Previous / Next / Jump-to with a recording still in `st.audio_input` showed \"An error occurred. Please try again.\" and could leave a recording made for phrase N submittable against phrase N+1.

Refactors the reset logic the Remove Recording button already had into `_reset_recorder()` and calls it from all three navigation entry points in `render_phrase_navigation()`.

- Rotates `quick_audio_input_key` → Streamlit remounts the widget cleanly
- Clears `quick_last_result` → stale score for the prior phrase doesn't linger

Story Reader uses a separate practice flow and is not affected by this path.

## Test plan
- [ ] Quick Practice → record phrase → click Next. No error banner, widget is empty, ready for a new recording.
- [ ] Record, click Previous. Same expectation.
- [ ] Record, use \"Jump to phrase\" dropdown. Same expectation.
- [ ] Record, click Remove Recording. Still works as before (regression check).
- [ ] Sidebar shows `v7.5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)