### PR TITLE
test: integration tests against local MySQL (F3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 settings.json
 *.code-workspace
 
+# Claude Code per-project local overrides (permissions, etc.)
+.claude/settings.local.json
+
 # intermediate build output:
 
 *.o

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+markers =
+    integration: integration tests that hit a real local MySQL (see tests/integration/README.md)
+testpaths = tests
+# By default, skip integration tests — they require a local MySQL.
+# Opt in explicitly with `pytest -m integration` or `pytest tests/integration`.
+addopts = -m "not integration"

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,56 @@
+# Integration tests
+
+Hit a real local MySQL instance. Opt-in:
+
+```bash
+source venv/bin/activate
+pytest tests/integration              # run this suite
+pytest -m integration                 # same, via marker
+pytest                                # default suite — integration excluded
+```
+
+## One-time setup
+
+1. Local MySQL 8 running (MacPorts `mysql8-server`).
+2. `.streamlit/secrets.toml` has a `[local_db]` block with `enabled = true`.
+3. Create the test database and grant the app user access:
+
+```sql
+-- Run as a MySQL admin (root or equivalent)
+CREATE DATABASE IF NOT EXISTS miolingo_test
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+GRANT ALL PRIVILEGES ON miolingo_test.* TO 'miolingo_local'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+The test user is NOT granted CREATE/DROP DATABASE — the fixture only manages
+tables *within* `miolingo_test`, which is intentional (production-parity
+privilege model).
+
+If `local_db.enabled` is missing, or the test DB isn't reachable, the suite
+is **skipped**, not failed.
+
+## What happens
+
+- Session setup: create throwaway database `miolingo_test`, apply
+  `schema.sql` (dumped from the live local DB with `mysqldump --no-data`).
+- Per-test: fresh connection, all tables truncated after the test.
+- `app_mysql.get_connection()` is monkeypatched to return the test
+  connection, so product code under test routes to the test DB transparently.
+- Session teardown: drop `miolingo_test`.
+
+## Updating the schema
+
+When real schema changes land, refresh the dump:
+
+```bash
+/opt/local/bin/mysqldump \
+  --socket=/opt/local/var/run/mysql8/mysqld.sock \
+  -u <local_db.user> -p<local_db.password> \
+  --no-data --skip-comments --compact --skip-dump-date \
+  --set-gtid-purged=OFF \
+  <local_db.database> > tests/integration/schema.sql
+
+# Strip auto-increment noise so diffs are clean:
+sed -i '' -E 's/ AUTO_INCREMENT=[0-9]+//g' tests/integration/schema.sql
+```

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,245 @@
+"""
+Integration-test fixtures. Target: a local MySQL instance via Unix socket
+(the `local_db` block in `.streamlit/secrets.toml`).
+
+Session-scoped: create throwaway DB `miolingo_test`, apply schema.sql, drop on
+teardown.
+
+Function-scoped: open a fresh connection, truncate all tables after each test.
+app_mysql.get_connection() is monkeypatched per-test so product code is routed
+at the same DB.
+
+Requires `local_db.enabled = true` in secrets.toml. If absent, tests are
+skipped rather than failed — this keeps `pytest` green for users without a
+local MySQL setup (e.g. CI before we wire a MySQL service).
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+try:
+    import mysql.connector
+except ImportError:  # pragma: no cover - dependency is in requirements.txt
+    mysql = None  # type: ignore
+
+TEST_DB_NAME = os.environ.get("MIOLINGO_TEST_DB_NAME", "miolingo_test")
+
+_SECRETS_CANDIDATES = [
+    # Worktree-local (if the user symlinked it in — see project_worktree_secrets memory)
+    Path(__file__).resolve().parent.parent.parent / ".streamlit" / "secrets.toml",
+    # Main repo checkout, one level up from any worktree
+    Path("/Users/matthew/Software/working/miolingo/.streamlit/secrets.toml"),
+    # Streamlit global location
+    Path.home() / ".streamlit" / "secrets.toml",
+]
+
+
+def _load_local_db_creds() -> Optional[dict]:
+    """Return the [local_db] block from secrets.toml, or None if unavailable."""
+    for path in _SECRETS_CANDIDATES:
+        if not path.exists():
+            continue
+        try:
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+        except Exception:
+            continue
+        block = data.get("local_db")
+        if block and block.get("enabled"):
+            return block
+    return None
+
+
+def _connect_kwargs(creds: dict, database: Optional[str] = None) -> dict:
+    kwargs = {
+        "user": creds["user"],
+        "password": creds["password"],
+    }
+    if creds.get("unix_socket"):
+        kwargs["unix_socket"] = creds["unix_socket"]
+    else:
+        kwargs["host"] = creds.get("host", "127.0.0.1")
+        kwargs["port"] = creds.get("port", 3306)
+    if database:
+        kwargs["database"] = database
+    return kwargs
+
+
+@pytest.fixture(scope="session")
+def db_creds() -> dict:
+    if mysql is None:
+        pytest.skip("mysql-connector-python not installed")
+    creds = _load_local_db_creds()
+    if not creds:
+        pytest.skip(
+            "No local_db block in secrets.toml — see tests/integration/README.md "
+            "to enable."
+        )
+    return creds
+
+
+@pytest.fixture(scope="session")
+def test_db(db_creds: dict) -> str:
+    """Apply schema.sql to the pre-existing `miolingo_test` database.
+
+    The database itself must be created once, out of band, by a MySQL admin —
+    the `local_db.user` is not granted CREATE/DROP DATABASE. See
+    tests/integration/README.md for the one-time setup.
+
+    The fixture drops all existing tables in `miolingo_test` and reapplies the
+    dumped schema, so each test run starts clean.
+    """
+    try:
+        admin = mysql.connector.connect(
+            **_connect_kwargs(db_creds, database=TEST_DB_NAME)
+        )
+    except mysql.connector.errors.ProgrammingError as e:
+        pytest.skip(
+            f"Cannot connect to test DB '{TEST_DB_NAME}': {e}. "
+            "See tests/integration/README.md for one-time setup."
+        )
+    cur = admin.cursor()
+
+    cur.execute("SET FOREIGN_KEY_CHECKS=0")
+    cur.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = %s",
+        (TEST_DB_NAME,),
+    )
+    for (tbl,) in cur.fetchall():
+        cur.execute(f"DROP TABLE IF EXISTS `{tbl}`")
+    cur.execute("SET FOREIGN_KEY_CHECKS=1")
+
+    schema_sql = (Path(__file__).parent / "schema.sql").read_text()
+    # Match the production sql_mode that generated the dump — the live
+    # schema has `timestamp NOT NULL DEFAULT '0000-00-00 00:00:00'` which
+    # MySQL 8 strict mode rejects. NO_ZERO_DATE/NO_ZERO_IN_DATE off for the
+    # session so DDL applies; tests don't depend on strict-mode behaviour.
+    cur.execute(
+        "SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'"
+    )
+    cur.execute("SET FOREIGN_KEY_CHECKS=0")
+    for stmt in _split_sql_statements(schema_sql):
+        cur.execute(stmt)
+    cur.execute("SET FOREIGN_KEY_CHECKS=1")
+    admin.commit()
+    cur.close()
+    admin.close()
+
+    yield TEST_DB_NAME
+
+
+def _split_sql_statements(sql: str) -> list[str]:
+    """Naive statement splitter — fine for pure DDL without stored procedures."""
+    statements = []
+    buf: list[str] = []
+    for line in sql.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        buf.append(line)
+        if stripped.endswith(";"):
+            statements.append("\n".join(buf).rstrip(";").strip())
+            buf = []
+    return [s for s in statements if s]
+
+
+class _FakePool:
+    """Minimal pool stand-in: routes all connection paths to the test conn.
+
+    Product code calls either `app_mysql.get_connection()` (monkeypatched
+    separately) or `pool.get_bootstrap_connection()` (context manager). We
+    alias both to the same test connection so every query lands in
+    `miolingo_test`, not the remote production DB.
+    """
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def get_bootstrap_connection(self):
+        return _CtxConn(self._conn)
+
+    # Some call sites also do `with pool.get_connection() as c:` — same deal.
+    def get_connection(self):
+        return _CtxConn(self._conn)
+
+
+class _CtxConn:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self._conn
+
+    def __exit__(self, *exc):
+        # Don't close — the test fixture owns the connection lifetime.
+        return False
+
+
+@pytest.fixture
+def db_conn(test_db: str, db_creds: dict, monkeypatch):
+    """Per-test connection on the test DB. Truncates every table after the test.
+
+    Monkeypatches `app_mysql.get_connection()` AND the connection pool's
+    bootstrap path so every product-code connection hits the test DB.
+    """
+    conn = mysql.connector.connect(**_connect_kwargs(db_creds, database=test_db))
+    conn.autocommit = True
+
+    import app_mysql
+
+    fake_pool = _FakePool(conn)
+    monkeypatch.setattr(app_mysql, "get_connection", lambda: conn)
+    monkeypatch.setattr(app_mysql, "get_connection_pool_instance", lambda: fake_pool)
+
+    # delete_session() reads `st.session_state['db_connection']` — populate it
+    # so logout paths operate on the test DB.
+    import streamlit as st
+    st.session_state["db_connection"] = conn
+
+    yield conn
+
+    cur = conn.cursor()
+    cur.execute("SET FOREIGN_KEY_CHECKS=0")
+    cur.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = %s",
+        (test_db,),
+    )
+    tables = [row[0] for row in cur.fetchall()]
+    for t in tables:
+        cur.execute(f"TRUNCATE TABLE `{t}`")
+    cur.execute("SET FOREIGN_KEY_CHECKS=1")
+    cur.close()
+    conn.close()
+
+
+@pytest.fixture
+def make_user(db_conn):
+    """Factory: create a real user via app_mysql.create_user and return a dict
+    with user_id, username, email, password (plaintext for login tests).
+    """
+    import app_mysql
+
+    counter = {"n": 0}
+
+    def _make(username: Optional[str] = None, password: str = "TestPass123!") -> dict:
+        counter["n"] += 1
+        uname = username or f"testuser{counter['n']}"
+        email = f"{uname}@example.com"
+        user_id = app_mysql.create_user(uname, email, password)
+        assert user_id, "create_user returned None — check schema / unique constraints"
+        return {
+            "user_id": user_id,
+            "username": uname,
+            "email": email,
+            "password": password,
+        }
+
+    return _make

--- a/tests/integration/schema.sql
+++ b/tests/integration/schema.sql
@@ -1,0 +1,147 @@
+CREATE TABLE `activity_log` (
+  `log_id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int DEFAULT NULL,
+  `action` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `details` text COLLATE utf8mb4_unicode_ci,
+  `ip_address` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`log_id`),
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_timestamp` (`timestamp`),
+  CONSTRAINT `activity_log_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `announcements` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `type` enum('system','feature') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `message` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `active` tinyint(1) DEFAULT '1',
+  `display_on` enum('login','app','both') COLLATE utf8mb4_unicode_ci DEFAULT 'both',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `expires_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_active_type` (`active`,`type`),
+  KEY `idx_display_on` (`display_on`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `connection_monitor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `connection_id` varchar(100) COLLATE utf8mb4_general_ci NOT NULL,
+  `mysql_connection_id` int DEFAULT NULL,
+  `tunnel_id` varchar(50) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `session_id` varchar(100) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `username` varchar(100) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `app_name` varchar(100) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_activity` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `status` enum('active','idle','closed') COLLATE utf8mb4_general_ci DEFAULT 'active',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `connection_id` (`connection_id`),
+  KEY `idx_connection_id` (`connection_id`),
+  KEY `idx_tunnel_id` (`tunnel_id`),
+  KEY `idx_session_id` (`session_id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_app_name` (`app_name`),
+  CONSTRAINT `connection_monitor_ibfk_1` FOREIGN KEY (`tunnel_id`) REFERENCES `tunnel_monitor` (`tunnel_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE `debug_logs` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `environment` varchar(20) COLLATE utf8mb4_general_ci NOT NULL,
+  `username` varchar(100) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `user_id` int DEFAULT NULL,
+  `event_type` varchar(50) COLLATE utf8mb4_general_ci NOT NULL,
+  `message` text COLLATE utf8mb4_general_ci NOT NULL,
+  `user_agent` varchar(500) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `session_id_partial` varchar(8) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_timestamp` (`timestamp`),
+  KEY `idx_environment` (`environment`),
+  KEY `idx_username` (`username`),
+  KEY `idx_event_type` (`event_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE `rate_limits` (
+  `limit_id` int NOT NULL AUTO_INCREMENT,
+  `identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `action` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `attempt_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`limit_id`),
+  KEY `idx_identifier_action_time` (`identifier`,`action`,`attempt_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `sessions` (
+  `session_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int NOT NULL,
+  `username` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `expires_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `last_activity` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `status` enum('active','expired','forced_logout') COLLATE utf8mb4_unicode_ci DEFAULT 'active',
+  `ip_address` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_agent` text COLLATE utf8mb4_unicode_ci,
+  `device_type` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `browser` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `app_name` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT 'app',
+  PRIMARY KEY (`session_id`),
+  KEY `idx_user_id` (`user_id`),
+  KEY `idx_expires_at` (`expires_at`),
+  KEY `idx_username` (`username`),
+  KEY `idx_status` (`status`),
+  KEY `idx_app_name` (`app_name`),
+  KEY `idx_last_activity` (`last_activity`),
+  CONSTRAINT `sessions_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `tunnel_monitor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `tunnel_id` varchar(50) COLLATE utf8mb4_general_ci NOT NULL,
+  `pid` int DEFAULT NULL,
+  `local_port` int DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_used` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `status` enum('active','idle','dead') COLLATE utf8mb4_general_ci DEFAULT 'active',
+  `connection_count` int DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `tunnel_id` (`tunnel_id`),
+  KEY `idx_tunnel_id` (`tunnel_id`),
+  KEY `idx_status` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+CREATE TABLE `user_progress` (
+  `progress_id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `language_code` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `practice_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `target_phrase` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `recognized_phrase` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `similarity_score` decimal(5,2) NOT NULL,
+  `perfect_match` tinyint(1) NOT NULL,
+  `target_phonemes` text COLLATE utf8mb4_unicode_ci,
+  `user_phonemes` text COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`progress_id`),
+  KEY `idx_user_language` (`user_id`,`language_code`),
+  KEY `idx_practice_date` (`practice_date`),
+  CONSTRAINT `user_progress_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `user_settings` (
+  `setting_id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `setting_key` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `setting_value` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`setting_id`),
+  UNIQUE KEY `unique_user_setting` (`user_id`,`setting_key`),
+  KEY `idx_user_id` (`user_id`),
+  CONSTRAINT `user_settings_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `users` (
+  `user_id` int NOT NULL AUTO_INCREMENT,
+  `username` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `password_hash` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_login` timestamp NULL DEFAULT NULL,
+  `email_verified` tinyint(1) DEFAULT '0',
+  `is_active` tinyint(1) DEFAULT '1',
+  `role` enum('user','admin') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'user',
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `username` (`username`),
+  UNIQUE KEY `email` (`email`),
+  KEY `idx_username` (`username`),
+  KEY `idx_email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/tests/integration/test_auth_flow.py
+++ b/tests/integration/test_auth_flow.py
@@ -1,0 +1,85 @@
+"""
+Integration tests: end-to-end auth flow against a real MySQL database.
+
+These hit real tables (`users`, `sessions`, `activity_log`), exercising the
+actual argon2 hashing, SQL, and transaction behaviour — NOT mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_create_and_authenticate_user(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="alice")
+
+    # Correct password authenticates
+    user = app_mysql.authenticate_user(u["username"], u["password"])
+    assert user is not None
+    assert user["user_id"] == u["user_id"]
+    assert user["username"] == "alice"
+
+    # Wrong password is rejected
+    assert app_mysql.authenticate_user(u["username"], "wrongpass") is None
+
+    # Nonexistent user is rejected
+    assert app_mysql.authenticate_user("nobody", "anything") is None
+
+
+def test_duplicate_username_is_rejected(db_conn, make_user):
+    import app_mysql
+
+    make_user(username="bob")
+    duplicate = app_mysql.create_user("bob", "other@example.com", "x")
+    assert duplicate is None
+
+
+def test_duplicate_email_is_rejected(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="carol")
+    duplicate = app_mysql.create_user("different", u["email"], "x")
+    assert duplicate is None
+
+
+def test_session_lifecycle(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="dave")
+    session_id = app_mysql.create_session(
+        user_id=u["user_id"],
+        username=u["username"],
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+    )
+    assert session_id, "create_session should return a session_id string"
+
+    # validate_session resolves back to the user
+    resolved = app_mysql.validate_session(session_id, ip_address="127.0.0.1")
+    assert resolved is not None
+    assert resolved["user_id"] == u["user_id"]
+    assert resolved["username"] == "dave"
+
+    # delete_session invalidates it
+    assert app_mysql.delete_session(session_id) is True
+    assert app_mysql.validate_session(session_id, ip_address="127.0.0.1") is None
+
+
+def test_validate_session_rejects_unknown_id(db_conn):
+    import app_mysql
+
+    assert app_mysql.validate_session("does-not-exist", ip_address="127.0.0.1") is None
+
+
+def test_get_user_by_id_roundtrip(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="eve")
+    got = app_mysql.get_user_by_id(u["user_id"])
+    assert got is not None
+    assert got["username"] == "eve"
+    assert got["email"] == u["email"]

--- a/tests/integration/test_practice_logging.py
+++ b/tests/integration/test_practice_logging.py
@@ -1,0 +1,82 @@
+"""
+Integration tests: practice-session logging and stats roll-up against real MySQL.
+
+Exercises save_practice → get_user_progress / get_user_stats round-trips,
+plus activity logging. Uses the real `user_progress` and `activity_log`
+tables in `miolingo_test`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_save_practice_roundtrip(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="frank")
+    assert app_mysql.save_practice(
+        user_id=u["user_id"],
+        language_code="pt-BR",
+        target_phrase="bom dia",
+        recognized_phrase="bom dia",
+        similarity_score=98.5,
+        perfect_match=True,
+        target_phonemes="bõ ˈdʒi.ɐ",
+        user_phonemes="bõ ˈdʒi.ɐ",
+    ) is True
+
+    rows = app_mysql.get_user_progress(u["user_id"], "pt-BR", limit=10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["target_phrase"] == "bom dia"
+    assert row["recognized_phrase"] == "bom dia"
+    assert float(row["similarity_score"]) == pytest.approx(98.5)
+    assert bool(row["perfect_match"]) is True
+
+
+def test_user_stats_aggregates(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="gina")
+    scores = [(50.0, False), (80.0, False), (100.0, True), (90.0, False)]
+    for score, perfect in scores:
+        app_mysql.save_practice(
+            user_id=u["user_id"],
+            language_code="fr-FR",
+            target_phrase="bonjour",
+            recognized_phrase="bonjour",
+            similarity_score=score,
+            perfect_match=perfect,
+        )
+
+    stats = app_mysql.get_user_stats(u["user_id"], "fr-FR")
+    assert stats["total"] == 4
+    assert stats["perfect_count"] == 1
+    assert stats["avg_score"] == pytest.approx(80.0)
+    assert stats["recent_avg"] == pytest.approx(80.0)
+
+
+def test_progress_scoped_by_language(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="hank")
+    app_mysql.save_practice(u["user_id"], "pt-BR", "a", "a", 100.0, True)
+    app_mysql.save_practice(u["user_id"], "fr-FR", "b", "b", 100.0, True)
+
+    pt = app_mysql.get_user_progress(u["user_id"], "pt-BR")
+    fr = app_mysql.get_user_progress(u["user_id"], "fr-FR")
+    assert len(pt) == 1 and pt[0]["target_phrase"] == "a"
+    assert len(fr) == 1 and fr[0]["target_phrase"] == "b"
+
+
+def test_activity_log_records_events(db_conn, make_user):
+    import app_mysql
+
+    u = make_user(username="ivy")
+    app_mysql.log_activity(u["user_id"], "TEST_EVENT", "hello", "pytest")
+
+    rows = app_mysql.get_user_activity_log(u["user_id"], limit=10)
+    assert any(r["action"] == "TEST_EVENT" and r["details"] == "hello" for r in rows)

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,0 +1,74 @@
+"""
+Integration tests: schema sanity — ensure the dumped schema applied cleanly
+and exposes the tables and key columns product code relies on.
+
+If these fail after a schema.sql refresh, the dump is likely stale or the
+production schema drifted from what the app expects.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+REQUIRED_TABLES = {
+    "users",
+    "sessions",
+    "user_progress",
+    "user_settings",
+    "activity_log",
+    "announcements",
+    "rate_limits",
+    "debug_logs",
+}
+
+
+def _table_names(conn, schema: str) -> set[str]:
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = %s",
+        (schema,),
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
+def _columns(conn, schema: str, table: str) -> set[str]:
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = %s AND table_name = %s",
+        (schema, table),
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
+def test_required_tables_exist(db_conn):
+    tables = _table_names(db_conn, "miolingo_test")
+    missing = REQUIRED_TABLES - tables
+    assert not missing, f"Missing tables in test schema: {missing}"
+
+
+def test_users_table_has_auth_columns(db_conn):
+    cols = _columns(db_conn, "miolingo_test", "users")
+    for expected in ("user_id", "username", "email", "password_hash"):
+        assert expected in cols, f"users.{expected} missing"
+
+
+def test_sessions_table_has_lifecycle_columns(db_conn):
+    cols = _columns(db_conn, "miolingo_test", "sessions")
+    for expected in ("session_id", "user_id", "status", "expires_at", "last_activity"):
+        assert expected in cols, f"sessions.{expected} missing"
+
+
+def test_user_progress_has_scoring_columns(db_conn):
+    cols = _columns(db_conn, "miolingo_test", "user_progress")
+    for expected in (
+        "user_id",
+        "language_code",
+        "target_phrase",
+        "recognized_phrase",
+        "similarity_score",
+        "perfect_match",
+    ):
+        assert expected in cols, f"user_progress.{expected} missing"


### PR DESCRIPTION
## Summary
- Opt-in integration suite against a local MySQL (`miolingo_test` DB on Unix socket); default `pytest` run unaffected (100 unit tests still green, 14 new tests deselected by marker).
- 14 tests: auth/session lifecycle, practice logging + stats aggregation, activity log, schema sanity.
- Monkeypatches both `app_mysql.get_connection()` and `get_connection_pool_instance()` (bootstrap path) so product code routes to the test DB transparently.

## Why
Catches regressions that unit-mocked tests can't — real SQL, FK constraints, argon2 hashing, commit/rollback. Runs in ~1.6s against the local socket, so it's cheap to wire into CI later.

## Test plan
- [x] `pytest` (default) — 100 passed, 14 deselected
- [x] `pytest -m integration` — 14 passed
- [ ] Reviewer: follow `tests/integration/README.md` one-time setup, then run the suite locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)