### PR TITLE
feat: personal vocabulary tracker (F2, v7.6.0)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.0] - 2026-04-18
+
+### Added
+
+- **Personal Vocabulary Tracker** (F2): a new "📚 Vocabulary" tab that holds a
+  per-user, per-language dictionary of single words captured from everywhere
+  they appear in Miolingo. Each entry stores the source (poem title,
+  practice material, paste label) plus ±2 lines of context around the word,
+  so you can jog your memory of where you learned it. Sortable
+  alphabetically or by recency; searchable; with per-entry notes, TTS
+  playback, and CSV export.
+- Capture routes:
+  - **Story Reader**: "Add a word from this phrase" input beside the
+    displayed line; ±2 surrounding phrases captured as context.
+  - **Quick Practice**: auto-capture on a perfect match for single-word
+    practice targets; "Add a word" input for multi-word phrases.
+  - **Paste + click**: paste a passage into the Vocabulary tab and pick a
+    word from it; the containing line + ±2 neighbours become its context.
+  - **Bulk upload**: pipe-delimited `word | source | context` `.txt` file
+    imported in one go; multi-word rows are reported and skipped.
+- Auto-enrichment: translation (via the existing cached LLM provider) and
+  IPA (via espeak) are fetched at capture time. TTS is on-demand per entry.
+- Practice-from-vocab: a new "📚 My Vocab" source in Quick Practice loads
+  your vocab list as a practice queue.
+- New `vocab_entries` table. Apply `scripts/add_vocab_entries.sql` to each
+  environment before deploying. Unique index on
+  `(user_id, language_code, word)` enforces one-entry-per-word dedup;
+  re-captures bump `times_seen` / `last_seen_at` and fill previously-NULL
+  fields without overwriting existing values (first encounter wins).
+- Integration test coverage: 11 new tests in `tests/integration/test_vocab.py`.
+
+
 ## [7.5.2] - 2026-04-18
 
 ### Fixed

--- a/scripts/add_vocab_entries.sql
+++ b/scripts/add_vocab_entries.sql
@@ -1,0 +1,28 @@
+-- F2: Personal Vocabulary Tracker
+--
+-- One-time schema change: adds the `vocab_entries` table used by the
+-- Vocabulary tab. Apply manually against both local MySQL and the remote
+-- production database. See scripts/sync_db.py for how prior schema changes
+-- have been rolled out.
+
+CREATE TABLE IF NOT EXISTS `vocab_entries` (
+  `vocab_id` BIGINT NOT NULL AUTO_INCREMENT,
+  `user_id` INT NOT NULL,
+  `language_code` VARCHAR(10) NOT NULL,
+  `word` VARCHAR(100) NOT NULL,
+  `display_word` VARCHAR(100) NOT NULL,
+  `translation` TEXT NULL,
+  `ipa` VARCHAR(512) NULL,
+  `source_name` VARCHAR(255) NULL,
+  `context_before` TEXT NULL,
+  `context_line` TEXT NULL,
+  `context_after` TEXT NULL,
+  `times_seen` INT NOT NULL DEFAULT 1,
+  `first_seen_at` DATETIME NOT NULL,
+  `last_seen_at` DATETIME NOT NULL,
+  `notes` TEXT NULL,
+  PRIMARY KEY (`vocab_id`),
+  UNIQUE KEY `uq_user_lang_word` (`user_id`, `language_code`, `word`),
+  KEY `idx_user_lang_last_seen` (`user_id`, `language_code`, `last_seen_at`),
+  CONSTRAINT `fk_vocab_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/app.py
+++ b/src/app.py
@@ -98,6 +98,7 @@ from ui.story_tab import render_story_reader
 from ui.statistics_tab import render_statistics_tab
 from ui.history_tab import load_history, save_history, render_history_tab
 from ui.quick_practice_tab import render_quick_practice_tab
+from ui.vocabulary_tab import render_vocabulary_tab
 from ui.sidebar import render_user_panel, render_settings_panel, is_debug
 
 # Import API usage logger for cost tracking
@@ -433,7 +434,7 @@ def main():
     render_settings_panel()
 
     # Main content - Tabs with state management
-    tab_names = ["🎯 Quick Practice", "📖 Story Reader", "📊 Statistics", "📜 History"]
+    tab_names = ["🎯 Quick Practice", "📖 Story Reader", "📚 Vocabulary", "📊 Statistics", "📜 History"]
 
     # Use radio buttons to preserve tab state across reruns
     selected_tab_index = st.radio(
@@ -453,12 +454,16 @@ def main():
     elif selected_tab_index == 1:
         render_story_reader()
 
-    # Tab 3: Statistics
+    # Tab 3: Vocabulary
     elif selected_tab_index == 2:
+        render_vocabulary_tab()
+
+    # Tab 4: Statistics
+    elif selected_tab_index == 3:
         render_statistics_tab()
 
-    # Tab 4: History
-    elif selected_tab_index == 3:
+    # Tab 5: History
+    elif selected_tab_index == 4:
         render_history_tab()
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.5.2"
+__version__ = "7.6.0"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -24,6 +24,7 @@ from difflib import SequenceMatcher
 from pathlib import Path
 
 import app_mysql
+import vocab
 from audio.tts import generate_target_audio
 from scoring.phonemes import format_ipa, normalize_for_phoneme_scoring
 from scoring.practice import practice_word_from_audio as _practice_word_from_audio_core
@@ -67,6 +68,33 @@ def practice_word_from_audio(text: str, audio_bytes: bytes, settings: dict):
                 )
             except Exception as e:
                 st.warning(f"⚠️ Could not save to database: {e}")
+
+            # F2: auto-capture single-word perfect matches to the vocab tracker.
+            # Multi-word targets are handled by the "Add a word" input rendered
+            # next to the practice interface (see render_practice_results).
+            try:
+                target = (result.get('target') or '').strip()
+                if (result.get('exact_match')
+                        and target
+                        and ' ' not in target):
+                    vocab.capture_vocab_entry(
+                        user_id=user_id,
+                        language=st.session_state.language,
+                        word=target,
+                        source_name=st.session_state.get(
+                            'material_source'
+                        ) or 'Quick Practice',
+                        context_line=target,
+                        enrich=True,
+                        source_language=st.session_state.get(
+                            'source_language', 'English'
+                        ),
+                        secrets=st.secrets if hasattr(st, 'secrets') else None,
+                    )
+            except Exception as e:
+                # Never let vocab capture break the practice flow
+                import logging
+                logging.warning("vocab auto-capture failed: %s", e)
 
     return _practice_word_from_audio_core(
         text,
@@ -178,6 +206,55 @@ def render_practice_interface(text, key_prefix="practice"):
 # ---------------------------------------------------------------------------
 # render_practice_results
 # ---------------------------------------------------------------------------
+
+def _render_practice_vocab_capture(result, key_prefix):
+    """Capture a single word from a multi-word practice phrase into the vocab tracker.
+
+    Single-word targets are already auto-captured on perfect match (see
+    `practice_word_from_audio._persist_result`); we only show the input for
+    multi-word phrases so the user can pick which word is worth keeping.
+    """
+    if not st.session_state.get("authenticated", False):
+        return
+    target = (result.get("target") or "").strip()
+    if not target or " " not in target:
+        return
+
+    col1, col2 = st.columns([3, 1])
+    with col1:
+        word = st.text_input(
+            "📚 Add a word from this phrase to my vocabulary",
+            key=f"{key_prefix}_vocab_word",
+            placeholder="type a single word from the phrase…",
+            label_visibility="collapsed",
+        )
+    with col2:
+        if st.button("➕ Add", key=f"{key_prefix}_vocab_btn"):
+            if not word.strip():
+                st.warning("Type a word first.")
+            else:
+                r = vocab.capture_vocab_entry(
+                    user_id=st.session_state["user"]["user_id"],
+                    language=st.session_state.language,
+                    word=word,
+                    source_name=st.session_state.get(
+                        "material_source"
+                    ) or "Quick Practice",
+                    context_line=target,
+                    enrich=True,
+                    source_language=st.session_state.get(
+                        "source_language", "English"
+                    ),
+                    secrets=st.secrets if hasattr(st, "secrets") else None,
+                )
+                if r["ok"]:
+                    st.success(
+                        f"✅ {'Added' if r['created'] else 'Already in'} vocab: "
+                        f"**{word}**"
+                    )
+                else:
+                    st.error(f"⚠️ {r['message']}")
+
 
 def render_practice_results(result, key_prefix="practice"):
     """
@@ -300,6 +377,9 @@ def render_practice_results(result, key_prefix="practice"):
             if result.get('edit_distance') is not None:
                 st.metric("Edit Distance", result['edit_distance'],
                         help="Number of edits needed to match target")
+
+    # F2: let the user capture a single word from a multi-word practice phrase.
+    _render_practice_vocab_capture(result, key_prefix)
 
     col1, col2 = st.columns(2)
     with col1:

--- a/src/ui/quick_practice_tab.py
+++ b/src/ui/quick_practice_tab.py
@@ -49,7 +49,7 @@ def _render_materials_loader():
         st.session_state.qp_materials_expanded = True
 
         # Use radio buttons for material source to preserve state across reruns
-        material_source_names = ["📦 Built-in Library", "📁 Upload File"]
+        material_source_names = ["📦 Built-in Library", "📁 Upload File", "📚 My Vocab"]
         material_source_index = st.radio(
             "Material Source",
             range(len(material_source_names)),
@@ -63,8 +63,53 @@ def _render_materials_loader():
             _render_builtin_materials(get_available_languages, get_language_structure,
                                       get_file_metadata, load_phrase_file,
                                       format_category_name, format_language_name)
-        else:
+        elif material_source_index == 1:
             _render_upload_materials(format_language_name)
+        else:
+            _render_vocab_materials()
+
+
+def _render_vocab_materials():
+    """Load the user's personal vocab list as a practice phrase queue."""
+    import vocab as vocab_mod
+
+    if not st.session_state.get('authenticated', False):
+        st.info("🔒 Sign in to practise from your personal vocabulary.")
+        return
+
+    language = st.session_state.get('language', 'Portuguese')
+    user_id = st.session_state['user']['user_id']
+
+    sort = st.selectbox(
+        "Order",
+        options=["alpha", "recent", "oldest"],
+        format_func=lambda s: {
+            "alpha": "Alphabetical",
+            "recent": "Most recently added",
+            "oldest": "Oldest first",
+        }[s],
+        key="qp_vocab_sort",
+    )
+
+    phrases = vocab_mod.vocab_as_practice_phrases(
+        user_id=user_id, language=language, sort=sort
+    )
+    st.caption(f"**{len(phrases)}** word(s) in your {language} vocab.")
+
+    if not phrases:
+        st.info(
+            "No vocabulary for this language yet. Add some from the Story Reader, "
+            "paste a passage, or upload a dictionary file (see the Vocabulary tab)."
+        )
+        return
+
+    if st.button("📂 Load My Vocab", type="primary", key="load_vocab"):
+        st.session_state.phrase_list = phrases
+        st.session_state.qp_phrase_position = 0
+        st.session_state.quick_last_result = None
+        st.session_state.material_source = f"My Vocab ({language})"
+        st.session_state.qp_materials_expanded = False
+        st.rerun()
 
 
 def _render_builtin_materials(get_available_languages, get_language_structure,

--- a/src/ui/story_tab.py
+++ b/src/ui/story_tab.py
@@ -15,10 +15,62 @@ import json
 import streamlit as st
 from pathlib import Path
 
+import vocab
 from app_language_materials import format_language_name
 from scoring.phonemes import format_ipa
 from translation import get_translation_from_llm
 from ui.practice_tab import render_practice_interface, render_practice_results
+
+
+def _render_vocab_capture(phrases, current_idx, scene_title):
+    """Small "add a word to my vocab" input below the displayed phrase.
+
+    Captures ±2 surrounding phrases as context so the user can jog their
+    memory later. Only visible to authenticated users.
+    """
+    if not st.session_state.get("authenticated", False):
+        return
+
+    lines = [p.get("text", "") for p in phrases]
+    context_before = "\n".join(lines[max(0, current_idx - 2):current_idx])
+    context_line = lines[current_idx] if 0 <= current_idx < len(lines) else ""
+    context_after = "\n".join(lines[current_idx + 1:current_idx + 3])
+
+    col1, col2 = st.columns([3, 1])
+    with col1:
+        word = st.text_input(
+            "📚 Add a word from this phrase to my vocabulary",
+            key=f"story_vocab_word_{current_idx}",
+            placeholder="type a single word…",
+            label_visibility="collapsed",
+        )
+    with col2:
+        if st.button("➕ Add", key=f"story_vocab_btn_{current_idx}"):
+            if not word.strip():
+                st.warning("Type a word first.")
+            else:
+                user_id = st.session_state["user"]["user_id"]
+                r = vocab.capture_vocab_entry(
+                    user_id=user_id,
+                    language=st.session_state.get("language", "Portuguese"),
+                    word=word,
+                    source_name=scene_title,
+                    context_before=context_before,
+                    context_line=context_line,
+                    context_after=context_after,
+                    enrich=True,
+                    source_language=st.session_state.get(
+                        "source_language", "English"
+                    ),
+                    secrets=st.secrets if hasattr(st, "secrets") else None,
+                )
+                if r["ok"]:
+                    st.success(
+                        f"✅ {'Added' if r['created'] else 'Already in'} vocab: "
+                        f"**{word}**"
+                    )
+                else:
+                    st.error(f"⚠️ {r['message']}")
 
 # Unified materials directory
 _UNIFIED_STORIES = Path(__file__).parent.parent.parent / "language_materials" / "unified" / "stories"
@@ -215,6 +267,12 @@ def render_scene_practice_mode(scenes_dir):
                     st.caption("Compare with eSpeak IPA generated below")
 
         st.markdown(f"#### 🎯 **{current_phrase}**")
+
+        _render_vocab_capture(
+            phrases=phrases,
+            current_idx=current_idx,
+            scene_title=selected_scene_display,
+        )
 
         # Practice interface with unique key prefix for story mode
         render_practice_interface(current_phrase, key_prefix="story")

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -1,0 +1,287 @@
+"""
+Vocabulary tab — per-user, per-language personal dictionary (F2).
+
+Capture routes wired in this tab:
+  - Paste a passage, then type a word to capture from it (source = label)
+  - Bulk upload a pipe-delimited dictionary file (word | source | context)
+Capture from Story Reader and Quick Practice hooks into `vocab.capture_vocab_entry`
+directly; this tab is the view layer + paste/upload routes + export.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import List
+
+import streamlit as st
+
+import vocab
+from audio.tts import generate_target_audio
+
+
+def _current_language() -> str:
+    return st.session_state.get("language", "Portuguese")
+
+
+def _source_language() -> str:
+    return st.session_state.get("source_language", "English")
+
+
+def _require_auth() -> bool:
+    if not st.session_state.get("authenticated", False):
+        st.info("🔒 Sign in to use the personal vocabulary tracker.")
+        return False
+    if "user" not in st.session_state or "user_id" not in st.session_state["user"]:
+        st.warning("Could not resolve your user id — try signing in again.")
+        return False
+    return True
+
+
+def _user_id() -> int:
+    return st.session_state["user"]["user_id"]
+
+
+def _capture_from_passage(passage: str, word: str, source_label: str) -> dict:
+    """Capture a single word from a pasted passage, pulling ±2 lines of context."""
+    lines = [ln for ln in passage.splitlines() if ln.strip()]
+    # Find the first line containing the word (case-insensitive).
+    lower_word = word.strip().lower()
+    idx = next(
+        (i for i, ln in enumerate(lines) if lower_word in ln.lower()),
+        None,
+    )
+    context_before = context_line = context_after = ""
+    if idx is not None:
+        context_line = lines[idx]
+        context_before = "\n".join(lines[max(0, idx - 2):idx])
+        context_after = "\n".join(lines[idx + 1:idx + 3])
+
+    return vocab.capture_vocab_entry(
+        user_id=_user_id(),
+        language=_current_language(),
+        word=word,
+        source_name=source_label or "(pasted)",
+        context_before=context_before,
+        context_line=context_line,
+        context_after=context_after,
+        enrich=True,
+        source_language=_source_language(),
+        secrets=st.secrets if hasattr(st, "secrets") else None,
+    )
+
+
+def _render_paste_capture():
+    with st.expander("✍️ Paste a passage and add a word", expanded=False):
+        passage = st.text_area(
+            "Paste source text (poem, passage, paragraph)",
+            key="vocab_paste_passage",
+            height=140,
+        )
+        col1, col2 = st.columns([2, 3])
+        with col1:
+            word = st.text_input("Word to add", key="vocab_paste_word")
+        with col2:
+            source_label = st.text_input(
+                "Source label (e.g. poem title)",
+                key="vocab_paste_source",
+                placeholder="(pasted)",
+            )
+        if st.button("➕ Add from passage", key="vocab_paste_btn", type="primary"):
+            if not word.strip():
+                st.warning("Type a word to add.")
+            elif not passage.strip():
+                st.warning("Paste a passage first.")
+            else:
+                r = _capture_from_passage(passage, word, source_label)
+                if r["ok"]:
+                    st.success(
+                        f"✅ {r['message'].capitalize()}: **{word}** "
+                        f"({'new entry' if r['created'] else 'already in your vocab'})"
+                    )
+                else:
+                    st.error(f"⚠️ {r['message']}")
+
+
+def _render_bulk_upload():
+    with st.expander("📥 Upload a dictionary file", expanded=False):
+        st.caption(
+            "Pipe-delimited `.txt`: `word | source | context` — one entry per line. "
+            "Lines starting with `#` are ignored. Multi-word entries are skipped."
+        )
+        uploaded = st.file_uploader(
+            "Upload .txt",
+            type=["txt"],
+            key="vocab_bulk_upload",
+        )
+        enrich = st.checkbox(
+            "Auto-fetch translation + IPA on import",
+            value=True,
+            key="vocab_bulk_enrich",
+            help="Slower but more useful. Uncheck for a raw import you'll enrich later.",
+        )
+        if uploaded is not None and st.button(
+            "Import file", key="vocab_bulk_btn", type="primary"
+        ):
+            try:
+                contents = uploaded.getvalue().decode("utf-8")
+            except UnicodeDecodeError:
+                st.error("File is not UTF-8 encoded.")
+                return
+            with st.spinner("Importing..."):
+                summary = vocab.import_from_file_contents(
+                    user_id=_user_id(),
+                    language=_current_language(),
+                    contents=contents,
+                    enrich=enrich,
+                    source_language=_source_language(),
+                    secrets=st.secrets if hasattr(st, "secrets") else None,
+                )
+            st.success(
+                f"✅ Imported — {summary['added']} new, "
+                f"{summary['updated']} updated."
+            )
+            if summary["skipped_not_single"]:
+                st.warning(
+                    f"⚠️ {len(summary['skipped_not_single'])} multi-word rows skipped: "
+                    + ", ".join(f"`{w}`" for w in summary["skipped_not_single"][:10])
+                )
+            if summary["skipped_other"]:
+                st.warning(
+                    f"⚠️ {len(summary['skipped_other'])} other rows skipped."
+                )
+
+
+def _render_export_csv(rows: List[dict]):
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow([
+        "word", "translation", "ipa", "source",
+        "context_before", "context_line", "context_after",
+        "times_seen", "first_seen_at", "last_seen_at", "notes",
+    ])
+    for r in rows:
+        writer.writerow([
+            r.get("display_word", r.get("word", "")),
+            r.get("translation") or "",
+            r.get("ipa") or "",
+            r.get("source_name") or "",
+            r.get("context_before") or "",
+            r.get("context_line") or "",
+            r.get("context_after") or "",
+            r.get("times_seen", 1),
+            r.get("first_seen_at") or "",
+            r.get("last_seen_at") or "",
+            r.get("notes") or "",
+        ])
+    st.download_button(
+        "⬇️ Export CSV",
+        data=buf.getvalue(),
+        file_name=f"vocab_{_current_language()}.csv",
+        mime="text/csv",
+        key="vocab_export_csv",
+    )
+
+
+def _render_entry_row(row: dict):
+    # Summary line: word · translation · IPA · source · date
+    summary_bits = [f"**{row['display_word']}**"]
+    if row.get("translation"):
+        summary_bits.append(f"_{row['translation']}_")
+    if row.get("ipa"):
+        summary_bits.append(f"`{row['ipa']}`")
+    summary_bits.append(f"· {row.get('source_name') or '—'}")
+    summary_bits.append(f"· {str(row.get('last_seen_at') or '')[:16]}")
+    with st.expander(" ".join(summary_bits), expanded=False):
+        if row.get("context_before") or row.get("context_line") or row.get("context_after"):
+            st.markdown("**Context:**")
+            if row.get("context_before"):
+                st.caption(row["context_before"])
+            if row.get("context_line"):
+                st.markdown(f"> {row['context_line']}")
+            if row.get("context_after"):
+                st.caption(row["context_after"])
+
+        notes = st.text_area(
+            "Notes",
+            value=row.get("notes") or "",
+            key=f"vocab_notes_{row['vocab_id']}",
+            height=60,
+        )
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            if st.button("💾 Save notes", key=f"vocab_save_{row['vocab_id']}"):
+                if vocab.update_vocab_notes(
+                    user_id=_user_id(),
+                    vocab_id=row["vocab_id"],
+                    notes=notes,
+                ):
+                    st.success("Notes saved.")
+                    st.rerun()
+        with col2:
+            if st.button("🔊 Play", key=f"vocab_tts_{row['vocab_id']}"):
+                try:
+                    audio_bytes, fmt = generate_target_audio(
+                        row["display_word"], st.session_state.settings
+                    )
+                    st.audio(audio_bytes, format=fmt, autoplay=True)
+                except Exception as e:
+                    st.warning(f"TTS failed: {e}")
+        with col3:
+            if st.button("🗑️ Delete", key=f"vocab_del_{row['vocab_id']}"):
+                vocab.delete_vocab_entry(
+                    user_id=_user_id(), vocab_id=row["vocab_id"]
+                )
+                st.success("Deleted.")
+                st.rerun()
+
+
+def render_vocabulary_tab():
+    """Top-level entry point for the Vocabulary tab."""
+    st.header("📚 My Vocabulary")
+    if not _require_auth():
+        return
+
+    language = _current_language()
+    st.caption(f"Language: **{language}** — change in sidebar to view another language's vocab.")
+
+    col1, col2 = st.columns([2, 3])
+    with col1:
+        sort = st.selectbox(
+            "Sort by",
+            options=["alpha", "recent", "oldest"],
+            format_func=lambda s: {
+                "alpha": "Alphabetical",
+                "recent": "Most recent",
+                "oldest": "Oldest first",
+            }[s],
+            key="vocab_sort",
+        )
+    with col2:
+        search = st.text_input(
+            "Search (word or translation)",
+            key="vocab_search",
+            placeholder="type to filter…",
+        )
+
+    rows = vocab.list_vocab(
+        user_id=_user_id(), language=language, sort=sort, search=search
+    )
+
+    st.caption(f"**{len(rows)}** entr{'y' if len(rows) == 1 else 'ies'}")
+
+    if rows:
+        _render_export_csv(rows)
+
+    if not rows:
+        st.info(
+            "No vocabulary yet for this language. Add words from the Story Reader, "
+            "Quick Practice, or paste a passage below."
+        )
+    else:
+        for row in rows:
+            _render_entry_row(row)
+
+    st.markdown("---")
+    _render_paste_capture()
+    _render_bulk_upload()

--- a/src/vocab.py
+++ b/src/vocab.py
@@ -1,0 +1,365 @@
+"""
+Personal Vocabulary Tracker — data helpers (F2).
+
+Single-word dictionary of terms the user has encountered, per language,
+with source + ±2 lines of context stored for every entry.
+
+Callers from the UI layer pass explicit args (no streamlit imports here) so
+these helpers can be integration-tested against a real MySQL instance.
+
+Enrichment (translation + IPA) is opt-in via `enrich=True`. Both underlying
+calls are cheap (translation is LLM-cached; espeak is local), but tests
+disable enrichment to stay hermetic.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import app_mysql
+
+logger = logging.getLogger(__name__)
+
+# Trimmed when normalising a captured token — keep hyphen/apostrophe since
+# many languages use them inside single words (e.g. "l'amour", "well-being").
+_TRIM_PUNCT = ".,;:!?\"'“”‘’«»()[]{}—–-…"
+
+
+def _normalise(word: str) -> Tuple[str, str]:
+    """
+    Return (display_word, lookup_key). `display_word` preserves the user's
+    case; `lookup_key` is lowercased and stripped of surrounding punctuation
+    for deduplication.
+    """
+    trimmed = word.strip()
+    # Strip leading/trailing punctuation only — never inner characters.
+    while trimmed and trimmed[0] in _TRIM_PUNCT:
+        trimmed = trimmed[1:]
+    while trimmed and trimmed[-1] in _TRIM_PUNCT:
+        trimmed = trimmed[:-1]
+    return trimmed, trimmed.lower()
+
+
+class VocabCaptureError(ValueError):
+    """Raised when the captured token is not a valid single word."""
+
+
+def validate_single_word(word: str) -> Tuple[str, str]:
+    """
+    Enforce the single-word invariant. Returns (display_word, lookup_key).
+    Raises VocabCaptureError if empty or contains whitespace.
+    """
+    if not word or not word.strip():
+        raise VocabCaptureError("Empty word")
+    display, key = _normalise(word)
+    if not key:
+        raise VocabCaptureError("Word is only punctuation")
+    if re.search(r"\s", key):
+        raise VocabCaptureError(
+            "Dictionary entries are single words — "
+            "use the context field to capture phrases"
+        )
+    if len(key) > 100:
+        raise VocabCaptureError("Word too long (max 100 characters)")
+    return display, key
+
+
+def _enrich(
+    word: str,
+    language: str,
+    source_language: str,
+    secrets: Any,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Best-effort translation + IPA. Returns (translation, ipa), either may be None."""
+    translation: Optional[str] = None
+    ipa: Optional[str] = None
+    try:
+        from translation import get_translation_from_llm
+        t = get_translation_from_llm(
+            word,
+            source_lang=language,
+            target_lang=source_language,
+            secrets=secrets,
+            db_module=app_mysql,
+        )
+        if t and not t.startswith("[error"):
+            translation = t
+    except Exception as e:
+        logger.warning("Translation enrichment failed for %r: %s", word, e)
+
+    try:
+        from config import get_language_code
+        from scoring.phonemes import get_ipa_from_espeak
+        code = get_language_code(language)
+        i = get_ipa_from_espeak(word, code)
+        if i and not i.startswith("[") and i != "[IPA unavailable]":
+            ipa = i
+    except Exception as e:
+        logger.warning("IPA enrichment failed for %r: %s", word, e)
+
+    return translation, ipa
+
+
+def capture_vocab_entry(
+    *,
+    user_id: int,
+    language: str,
+    word: str,
+    source_name: Optional[str] = None,
+    context_before: str = "",
+    context_line: str = "",
+    context_after: str = "",
+    enrich: bool = False,
+    source_language: str = "English",
+    secrets: Any = None,
+) -> Dict[str, Any]:
+    """
+    Insert a vocab entry, or bump `times_seen` / `last_seen_at` if the word
+    already exists for this (user, language). First encounter wins for
+    source/context/translation/ipa — never overwrite non-null existing fields.
+
+    Returns {"ok": bool, "vocab_id": int | None, "created": bool, "message": str}.
+    """
+    try:
+        display, key = validate_single_word(word)
+    except VocabCaptureError as e:
+        return {"ok": False, "vocab_id": None, "created": False, "message": str(e)}
+
+    translation: Optional[str] = None
+    ipa: Optional[str] = None
+    if enrich:
+        translation, ipa = _enrich(display, language, source_language, secrets)
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn = app_mysql.get_connection()
+    cur = conn.cursor()
+
+    # Upsert — on duplicate, bump counters and fill any NULL fields but
+    # never overwrite existing non-null values.
+    cur.execute(
+        """
+        INSERT INTO vocab_entries (
+            user_id, language_code, word, display_word,
+            translation, ipa, source_name,
+            context_before, context_line, context_after,
+            times_seen, first_seen_at, last_seen_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 1, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            times_seen = times_seen + 1,
+            last_seen_at = VALUES(last_seen_at),
+            translation   = COALESCE(translation, VALUES(translation)),
+            ipa           = COALESCE(ipa, VALUES(ipa)),
+            source_name   = COALESCE(source_name, VALUES(source_name)),
+            context_before= COALESCE(NULLIF(context_before,''), VALUES(context_before)),
+            context_line  = COALESCE(NULLIF(context_line,''),   VALUES(context_line)),
+            context_after = COALESCE(NULLIF(context_after,''),  VALUES(context_after))
+        """,
+        (
+            user_id, language, key, display,
+            translation, ipa, source_name,
+            context_before or None, context_line or None, context_after or None,
+            now, now,
+        ),
+    )
+    conn.commit()
+    created = cur.rowcount == 1  # MySQL returns 1 on insert, 2 on update
+    # Fetch the vocab_id (lastrowid is 0 on pure update in some drivers)
+    vocab_id = cur.lastrowid
+    if not vocab_id:
+        cur.execute(
+            "SELECT vocab_id FROM vocab_entries "
+            "WHERE user_id=%s AND language_code=%s AND word=%s",
+            (user_id, language, key),
+        )
+        row = cur.fetchone()
+        vocab_id = row[0] if row else None
+    cur.close()
+    return {
+        "ok": True,
+        "vocab_id": vocab_id,
+        "created": created,
+        "message": "added" if created else "updated",
+    }
+
+
+def list_vocab(
+    *,
+    user_id: int,
+    language: str,
+    sort: str = "alpha",
+    search: str = "",
+    limit: int = 500,
+) -> List[Dict[str, Any]]:
+    """
+    List the user's vocabulary for a language.
+
+    sort: 'alpha' (default, by lookup key), 'recent' (last_seen_at DESC),
+          'oldest' (first_seen_at ASC).
+    search: case-insensitive substring match over word OR translation.
+    """
+    order = {
+        "alpha": "word ASC",
+        "recent": "last_seen_at DESC",
+        "oldest": "first_seen_at ASC",
+    }.get(sort, "word ASC")
+
+    conn = app_mysql.get_connection()
+    cur = conn.cursor(dictionary=True)
+    if search:
+        like = f"%{search.lower()}%"
+        cur.execute(
+            f"""
+            SELECT * FROM vocab_entries
+            WHERE user_id=%s AND language_code=%s
+              AND (LOWER(word) LIKE %s OR LOWER(COALESCE(translation,'')) LIKE %s)
+            ORDER BY {order}
+            LIMIT %s
+            """,
+            (user_id, language, like, like, limit),
+        )
+    else:
+        cur.execute(
+            f"""
+            SELECT * FROM vocab_entries
+            WHERE user_id=%s AND language_code=%s
+            ORDER BY {order}
+            LIMIT %s
+            """,
+            (user_id, language, limit),
+        )
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
+def get_vocab_entry(*, user_id: int, vocab_id: int) -> Optional[Dict[str, Any]]:
+    conn = app_mysql.get_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute(
+        "SELECT * FROM vocab_entries WHERE vocab_id=%s AND user_id=%s",
+        (vocab_id, user_id),
+    )
+    row = cur.fetchone()
+    cur.close()
+    return row
+
+
+def delete_vocab_entry(*, user_id: int, vocab_id: int) -> bool:
+    conn = app_mysql.get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "DELETE FROM vocab_entries WHERE vocab_id=%s AND user_id=%s",
+        (vocab_id, user_id),
+    )
+    conn.commit()
+    affected = cur.rowcount
+    cur.close()
+    return affected > 0
+
+
+def update_vocab_notes(*, user_id: int, vocab_id: int, notes: str) -> bool:
+    conn = app_mysql.get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE vocab_entries SET notes=%s WHERE vocab_id=%s AND user_id=%s",
+        (notes, vocab_id, user_id),
+    )
+    conn.commit()
+    affected = cur.rowcount
+    cur.close()
+    return affected > 0
+
+
+def _parse_import_line(line: str) -> Optional[Dict[str, str]]:
+    """Pipe-delimited: `word | source | context`. All three required; context may be empty."""
+    parts = [p.strip() for p in line.split("|")]
+    if len(parts) < 2:
+        return None
+    word = parts[0]
+    source = parts[1] if len(parts) >= 2 else ""
+    context = parts[2] if len(parts) >= 3 else ""
+    if not word:
+        return None
+    return {"word": word, "source": source, "context": context}
+
+
+def import_from_file_contents(
+    *,
+    user_id: int,
+    language: str,
+    contents: str,
+    enrich: bool = False,
+    source_language: str = "English",
+    secrets: Any = None,
+) -> Dict[str, Any]:
+    """
+    Parse a pipe-delimited dictionary file and capture each valid row.
+    Returns a summary dict with `added`, `updated`, `skipped_not_single`,
+    `skipped_other`, and a list of skipped rows for display.
+    """
+    added = 0
+    updated = 0
+    skipped_not_single: List[str] = []
+    skipped_other: List[Tuple[str, str]] = []
+
+    for lineno, raw in enumerate(contents.splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parsed = _parse_import_line(line)
+        if not parsed:
+            skipped_other.append((f"line {lineno}", "unparseable"))
+            continue
+        result = capture_vocab_entry(
+            user_id=user_id,
+            language=language,
+            word=parsed["word"],
+            source_name=parsed["source"] or None,
+            context_line=parsed["context"],
+            enrich=enrich,
+            source_language=source_language,
+            secrets=secrets,
+        )
+        if not result["ok"]:
+            msg = result["message"]
+            if "single" in msg:
+                skipped_not_single.append(parsed["word"])
+            else:
+                skipped_other.append((parsed["word"], msg))
+            continue
+        if result["created"]:
+            added += 1
+        else:
+            updated += 1
+
+    return {
+        "added": added,
+        "updated": updated,
+        "skipped_not_single": skipped_not_single,
+        "skipped_other": skipped_other,
+    }
+
+
+def vocab_as_practice_phrases(
+    *,
+    user_id: int,
+    language: str,
+    sort: str = "alpha",
+) -> List[Dict[str, Any]]:
+    """
+    Shape vocab entries to match the phrase-dict interface expected by the
+    practice UI: {text, translation, ipa}. Used by the 'Practice from vocab'
+    material source.
+    """
+    rows = list_vocab(user_id=user_id, language=language, sort=sort)
+    return [
+        {
+            "text": r["display_word"],
+            "translation": r.get("translation") or "",
+            "ipa": r.get("ipa") or "",
+        }
+        for r in rows
+    ]

--- a/tests/integration/schema.sql
+++ b/tests/integration/schema.sql
@@ -145,3 +145,24 @@ CREATE TABLE `users` (
   KEY `idx_username` (`username`),
   KEY `idx_email` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `vocab_entries` (
+  `vocab_id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `language_code` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `word` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `display_word` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `translation` text COLLATE utf8mb4_unicode_ci,
+  `ipa` varchar(512) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `source_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `context_before` text COLLATE utf8mb4_unicode_ci,
+  `context_line` text COLLATE utf8mb4_unicode_ci,
+  `context_after` text COLLATE utf8mb4_unicode_ci,
+  `times_seen` int NOT NULL DEFAULT '1',
+  `first_seen_at` datetime NOT NULL,
+  `last_seen_at` datetime NOT NULL,
+  `notes` text COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`vocab_id`),
+  UNIQUE KEY `uq_user_lang_word` (`user_id`,`language_code`,`word`),
+  KEY `idx_user_lang_last_seen` (`user_id`,`language_code`,`last_seen_at`),
+  CONSTRAINT `fk_vocab_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/tests/integration/test_vocab.py
+++ b/tests/integration/test_vocab.py
@@ -1,0 +1,209 @@
+"""
+Integration tests: Personal Vocabulary Tracker (F2).
+
+Exercises the `vocab_entries` table and `src/vocab.py` helpers against the
+real `miolingo_test` database. `enrich=False` everywhere to stay hermetic
+(no LLM / espeak calls).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_capture_and_list_roundtrip(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_alice")
+    r = vocab.capture_vocab_entry(
+        user_id=u["user_id"],
+        language="Portuguese",
+        word="saudade",
+        source_name="Pessoa: Autopsicografia",
+        context_before="Fingidor tão completamente",
+        context_line="Que chega a fingir que é dor",
+        context_after="A dor que deveras sente.",
+    )
+    assert r["ok"] is True and r["created"] is True and r["vocab_id"]
+
+    rows = vocab.list_vocab(user_id=u["user_id"], language="Portuguese")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["word"] == "saudade"
+    assert row["display_word"] == "saudade"
+    assert row["source_name"] == "Pessoa: Autopsicografia"
+    assert row["context_line"] == "Que chega a fingir que é dor"
+    assert row["times_seen"] == 1
+
+
+def test_recapture_bumps_counters_and_fills_nulls(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_bob")
+
+    # First capture — only word + source, no translation
+    vocab.capture_vocab_entry(
+        user_id=u["user_id"], language="French", word="bonjour",
+        source_name="Lesson 1",
+    )
+
+    # Re-capture — provide context this time. times_seen bumps, NULL context fills,
+    # but source_name (already set) is NOT overwritten.
+    r2 = vocab.capture_vocab_entry(
+        user_id=u["user_id"], language="French", word="bonjour",
+        source_name="Lesson 99 (should not overwrite)",
+        context_line="Bonjour, ça va?",
+    )
+    assert r2["created"] is False
+
+    rows = vocab.list_vocab(user_id=u["user_id"], language="French")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["times_seen"] == 2
+    assert row["source_name"] == "Lesson 1"  # first encounter wins
+    assert row["context_line"] == "Bonjour, ça va?"  # was NULL, now filled
+
+
+def test_multiword_rejected(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_carol")
+    r = vocab.capture_vocab_entry(
+        user_id=u["user_id"], language="Portuguese", word="boa tarde",
+    )
+    assert r["ok"] is False
+    assert "single words" in r["message"]
+    assert vocab.list_vocab(user_id=u["user_id"], language="Portuguese") == []
+
+
+def test_normalisation_strips_punctuation_and_lowercases_key(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_dan")
+    # Capture "Saudade," — trailing comma, capital S
+    r1 = vocab.capture_vocab_entry(
+        user_id=u["user_id"], language="Portuguese", word="Saudade,",
+    )
+    assert r1["created"] is True
+
+    # Capture "saudade" — should dedup on lookup key
+    r2 = vocab.capture_vocab_entry(
+        user_id=u["user_id"], language="Portuguese", word="saudade",
+    )
+    assert r2["created"] is False
+    assert r2["vocab_id"] == r1["vocab_id"]
+
+    rows = vocab.list_vocab(user_id=u["user_id"], language="Portuguese")
+    assert len(rows) == 1
+    assert rows[0]["word"] == "saudade"  # lowercase key
+    assert rows[0]["display_word"] == "Saudade"  # first encounter, punct trimmed
+
+
+def test_per_language_isolation(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_ellen")
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="Portuguese", word="sol")
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="French", word="sol")
+
+    pt = vocab.list_vocab(user_id=u["user_id"], language="Portuguese")
+    fr = vocab.list_vocab(user_id=u["user_id"], language="French")
+    assert len(pt) == 1 and len(fr) == 1
+    assert pt[0]["vocab_id"] != fr[0]["vocab_id"]
+
+
+def test_list_sort_orders(db_conn, make_user):
+    import time
+    import vocab
+
+    u = make_user(username="vocab_frank")
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="Portuguese", word="zebra")
+    time.sleep(1.1)  # last_seen_at has second precision; ensure distinct timestamps
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="Portuguese", word="abelha")
+
+    alpha = [r["word"] for r in vocab.list_vocab(
+        user_id=u["user_id"], language="Portuguese", sort="alpha")]
+    assert alpha == ["abelha", "zebra"]
+
+    recent = [r["word"] for r in vocab.list_vocab(
+        user_id=u["user_id"], language="Portuguese", sort="recent")]
+    assert recent == ["abelha", "zebra"]  # abelha captured last
+
+
+def test_search_filter(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_gina")
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="Portuguese", word="mar")
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="Portuguese", word="sol")
+
+    hits = vocab.list_vocab(
+        user_id=u["user_id"], language="Portuguese", search="ma")
+    assert [r["word"] for r in hits] == ["mar"]
+
+
+def test_delete_and_notes(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_hank")
+    r = vocab.capture_vocab_entry(
+        user_id=u["user_id"], language="Portuguese", word="lua")
+    vid = r["vocab_id"]
+
+    assert vocab.update_vocab_notes(
+        user_id=u["user_id"], vocab_id=vid, notes="moon") is True
+    entry = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert entry["notes"] == "moon"
+
+    assert vocab.delete_vocab_entry(user_id=u["user_id"], vocab_id=vid) is True
+    assert vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid) is None
+
+
+def test_cross_user_isolation(db_conn, make_user):
+    import vocab
+
+    u1 = make_user(username="vocab_owner")
+    u2 = make_user(username="vocab_intruder")
+    r = vocab.capture_vocab_entry(
+        user_id=u1["user_id"], language="Portuguese", word="casa")
+    # u2 cannot read or delete u1's entry
+    assert vocab.get_vocab_entry(user_id=u2["user_id"], vocab_id=r["vocab_id"]) is None
+    assert vocab.delete_vocab_entry(
+        user_id=u2["user_id"], vocab_id=r["vocab_id"]) is False
+
+
+def test_bulk_import(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_importer")
+    text = (
+        "# comment line ignored\n"
+        "\n"
+        "lua | Cancao da Lua | A lua cheia ilumina\n"
+        "mar | Cancao do Mar | \n"
+        "boa tarde | phrases.txt | this should be rejected\n"
+        "sol | Lesson 1 | O sol brilha\n"
+    )
+    summary = vocab.import_from_file_contents(
+        user_id=u["user_id"], language="Portuguese", contents=text)
+
+    assert summary["added"] == 3
+    assert summary["updated"] == 0
+    assert summary["skipped_not_single"] == ["boa tarde"]
+
+    rows = vocab.list_vocab(user_id=u["user_id"], language="Portuguese")
+    assert sorted(r["word"] for r in rows) == ["lua", "mar", "sol"]
+
+
+def test_vocab_as_practice_phrases_shape(db_conn, make_user):
+    import vocab
+
+    u = make_user(username="vocab_practiser")
+    vocab.capture_vocab_entry(user_id=u["user_id"], language="Portuguese", word="lua")
+    phrases = vocab.vocab_as_practice_phrases(
+        user_id=u["user_id"], language="Portuguese")
+    assert len(phrases) == 1
+    assert set(phrases[0].keys()) >= {"text", "translation", "ipa"}
+    assert phrases[0]["text"] == "lua"


### PR DESCRIPTION
## Summary

- New `vocab_entries` table (migration: `scripts/add_vocab_entries.sql`) with per-user, per-language word tracking, dedup via `(user_id, language_code, word)` unique index, and first-encounter-wins semantics on re-capture
- Four capture routes: Story Reader text input, Quick Practice auto-capture on perfect single-word match, Vocabulary tab paste+click, bulk pipe-delimited file upload
- New **📚 Vocabulary** tab (5th tab): alphabetical/recent/oldest sort, substring search, per-entry expand showing translation · IPA · source · ±2 lines of context · notes · TTS playback · delete
- Export CSV download
- **Practice from vocab**: "📚 My Vocab" option added to Quick Practice material selector loads vocab entries as phrase queue
- Auto-enrichment (translation + IPA via espeak) at capture time
- 11 new integration tests in `tests/integration/test_vocab.py`; all 125 tests (100 unit + 25 integration) pass

## Migration

Apply `scripts/add_vocab_entries.sql` to production DB before deploying.

## Test plan

- [ ] `pytest` → 100 passed
- [ ] `pytest -m integration` → 25 passed
- [ ] Story Reader: load a Portuguese scene, add a word, confirm it appears in Vocabulary tab with context + translation/IPA
- [ ] Quick Practice: score a perfect single-word match, confirm auto-capture
- [ ] Vocabulary tab: toggle sort, search, expand row, play TTS, delete entry
- [ ] Bulk upload a 3-line pipe-delimited file, confirm enrichment
- [ ] Quick Practice → 📚 My Vocab: load and practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)