### PR TITLE
fix(vocab): UX fixes from manual testing (v7.6.2)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.1] - 2026-04-19
+
+### Fixed
+
+- Vocabulary tab paste capture: passage and source label are now optional; only "Word to add" is required.
+
 ## [7.6.0] - 2026-04-18
 
 ### Added

--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.2] - 2026-04-19
+
+### Fixed
+
+- Vocabulary tab: empty search results now show "not in your vocabulary — add it below" instead of the misleading "no vocabulary yet" message.
+
 ## [7.6.1] - 2026-04-19
 
 ### Fixed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.0"
+__version__ = "7.6.1"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.1"
+__version__ = "7.6.2"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -272,10 +272,13 @@ def render_vocabulary_tab():
         _render_export_csv(rows)
 
     if not rows:
-        st.info(
-            "No vocabulary yet for this language. Add words from the Story Reader, "
-            "Quick Practice, or paste a passage below."
-        )
+        if search.strip():
+            st.info(f"**"{search.strip()}"** not in your vocabulary — add it below.")
+        else:
+            st.info(
+                "No vocabulary yet for this language. Add words from the Story Reader, "
+                "Quick Practice, or paste a passage below."
+            )
     else:
         for row in rows:
             _render_entry_row(row)

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -90,8 +90,6 @@ def _render_paste_capture():
         if st.button("➕ Add from passage", key="vocab_paste_btn", type="primary"):
             if not word.strip():
                 st.warning("Type a word to add.")
-            elif not passage.strip():
-                st.warning("Paste a passage first.")
             else:
                 r = _capture_from_passage(passage, word, source_label)
                 if r["ok"]:


### PR DESCRIPTION
## Summary

Two small fixes found during manual testing of F2 (personal vocabulary tracker):

- **v7.6.1** — paste capture: passage and source label are now optional; only "Word to add" is required (previously rejected silently if passage was empty)
- **v7.6.2** — vocabulary tab: empty search results now show `"<word>" not in your vocabulary — add it below` instead of the misleading "No vocabulary yet for this language" message

## Test plan

- [x] `pytest` → 100 passed
- [ ] Vocabulary tab: type a word that doesn't exist in the search box → "not in your vocabulary" message appears
- [ ] Paste capture: add a word with passage left blank → succeeds (no warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)