### PR TITLE
fix(vocab): fix SyntaxError in empty-search message (v7.6.3)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.3] - 2026-04-19
+
+### Fixed
+
+- Vocabulary tab: fix SyntaxError in empty-search message (curly quotes broke f-string).
+
 ## [7.6.2] - 2026-04-19
 
 ### Fixed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.2"
+__version__ = "7.6.3"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -273,7 +273,7 @@ def render_vocabulary_tab():
 
     if not rows:
         if search.strip():
-            st.info(f"**"{search.strip()}"** not in your vocabulary — add it below.")
+            st.info(f'**\"{search.strip()}\"** not in your vocabulary — add it below.')
         else:
             st.info(
                 "No vocabulary yet for this language. Add words from the Story Reader, "


### PR DESCRIPTION
## Summary

- Fix `SyntaxError` on line 276 of `vocabulary_tab.py`: curly/typographic quotes (`"`) inside a double-quoted f-string were being parsed as string delimiters. Changed to single-quoted f-string with escaped inner quotes.

## Test plan

- [ ] `pytest` → 100 passed
- [ ] App loads without SyntaxError
- [ ] Search for a missing word in Vocabulary tab → shows the "not in your vocabulary" message correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)