### PR TITLE
fix(vocab): progress bar + word count for bulk import (v7.6.4)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.4] - 2026-04-19
+
+### Fixed
+
+- Vocabulary bulk import: show word count + estimated time before import starts; replace silent spinner with a live progress bar (N/total).
+
 ## [7.6.3] - 2026-04-19
 
 ### Fixed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.3"
+__version__ = "7.6.4"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -118,23 +118,35 @@ def _render_bulk_upload():
             key="vocab_bulk_enrich",
             help="Slower but more useful. Uncheck for a raw import you'll enrich later.",
         )
-        if uploaded is not None and st.button(
-            "Import file", key="vocab_bulk_btn", type="primary"
-        ):
+        if uploaded is not None:
             try:
                 contents = uploaded.getvalue().decode("utf-8")
             except UnicodeDecodeError:
                 st.error("File is not UTF-8 encoded.")
                 return
-            with st.spinner("Importing..."):
-                summary = vocab.import_from_file_contents(
-                    user_id=_user_id(),
-                    language=_current_language(),
-                    contents=contents,
-                    enrich=enrich,
-                    source_language=_source_language(),
-                    secrets=st.secrets if hasattr(st, "secrets") else None,
-                )
+            n_lines = vocab.count_import_lines(contents)
+            est = f" (~{n_lines * 2}–{n_lines * 4}s with enrichment)" if enrich and n_lines > 10 else ""
+            st.caption(f"{n_lines} words to import{est}.")
+
+        if uploaded is not None and st.button(
+            "Import file", key="vocab_bulk_btn", type="primary"
+        ):
+            progress_bar = st.progress(0, text="Importing…")
+
+            def _progress(done, total):
+                pct = done / total if total else 1
+                progress_bar.progress(pct, text=f"Importing… {done}/{total}")
+
+            summary = vocab.import_from_file_contents(
+                user_id=_user_id(),
+                language=_current_language(),
+                contents=contents,
+                enrich=enrich,
+                source_language=_source_language(),
+                secrets=st.secrets if hasattr(st, "secrets") else None,
+                progress_fn=_progress,
+            )
+            progress_bar.empty()
             st.success(
                 f"✅ Imported — {summary['added']} new, "
                 f"{summary['updated']} updated."

--- a/src/vocab.py
+++ b/src/vocab.py
@@ -286,6 +286,14 @@ def _parse_import_line(line: str) -> Optional[Dict[str, str]]:
     return {"word": word, "source": source, "context": context}
 
 
+def count_import_lines(contents: str) -> int:
+    """Count non-blank, non-comment lines in a pipe-delimited import file."""
+    return sum(
+        1 for raw in contents.splitlines()
+        if raw.strip() and not raw.strip().startswith("#")
+    )
+
+
 def import_from_file_contents(
     *,
     user_id: int,
@@ -294,46 +302,55 @@ def import_from_file_contents(
     enrich: bool = False,
     source_language: str = "English",
     secrets: Any = None,
+    progress_fn=None,
 ) -> Dict[str, Any]:
     """
     Parse a pipe-delimited dictionary file and capture each valid row.
     Returns a summary dict with `added`, `updated`, `skipped_not_single`,
     `skipped_other`, and a list of skipped rows for display.
+
+    progress_fn: optional callable(current, total) called after each line.
     """
     added = 0
     updated = 0
     skipped_not_single: List[str] = []
     skipped_other: List[Tuple[str, str]] = []
 
-    for lineno, raw in enumerate(contents.splitlines(), start=1):
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        parsed = _parse_import_line(line)
+    lines = [
+        (lineno, raw)
+        for lineno, raw in enumerate(contents.splitlines(), start=1)
+        if raw.strip() and not raw.strip().startswith("#")
+    ]
+    total = len(lines)
+
+    for done, (lineno, raw) in enumerate(lines, start=1):
+        parsed = _parse_import_line(raw.strip())
         if not parsed:
             skipped_other.append((f"line {lineno}", "unparseable"))
-            continue
-        result = capture_vocab_entry(
-            user_id=user_id,
-            language=language,
-            word=parsed["word"],
-            source_name=parsed["source"] or None,
-            context_line=parsed["context"],
-            enrich=enrich,
-            source_language=source_language,
-            secrets=secrets,
-        )
-        if not result["ok"]:
-            msg = result["message"]
-            if "single" in msg:
-                skipped_not_single.append(parsed["word"])
-            else:
-                skipped_other.append((parsed["word"], msg))
-            continue
-        if result["created"]:
-            added += 1
         else:
-            updated += 1
+            result = capture_vocab_entry(
+                user_id=user_id,
+                language=language,
+                word=parsed["word"],
+                source_name=parsed["source"] or None,
+                context_line=parsed["context"],
+                enrich=enrich,
+                source_language=source_language,
+                secrets=secrets,
+            )
+            if not result["ok"]:
+                msg = result["message"]
+                if "single" in msg:
+                    skipped_not_single.append(parsed["word"])
+                else:
+                    skipped_other.append((parsed["word"], msg))
+            elif result["created"]:
+                added += 1
+            else:
+                updated += 1
+
+        if progress_fn is not None:
+            progress_fn(done, total)
 
     return {
         "added": added,


### PR DESCRIPTION
## Summary

- Show word count and estimated time ("~N–Ns with enrichment") as soon as a file is uploaded, before the user clicks Import
- Replace the silent `st.spinner("Importing…")` with a live `st.progress` bar showing `N/total` words processed
- Added `count_import_lines()` helper in `vocab.py` and `progress_fn` callback parameter to `import_from_file_contents()`

## Test plan

- [ ] `pytest` → 100 passed
- [ ] Upload a small file (5 words) — count shown, progress bar advances and clears on completion
- [ ] Upload with enrichment unchecked — no estimated time shown (only shown when enrich=True and >10 words)

🤖 Generated with [Claude Code](https://claude.com/claude-code)