### PR TITLE
fix(launch): use dev_server.sh for 8701 to auto-kill stale process on restart

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,12 +3,8 @@
   "configurations": [
     {
       "name": "miolingo (main app)",
-      "runtimeExecutable": "/Users/matthew/Software/working/miolingo/venv/bin/streamlit",
-      "runtimeArgs": [
-        "run", "src/app.py",
-        "--server.headless", "true",
-        "--server.port", "8701"
-      ],
+      "runtimeExecutable": "scripts/dev_server.sh",
+      "runtimeArgs": ["8701"],
       "cwd": "${workspaceFolder}",
       "port": 8701,
       "autoPort": false


### PR DESCRIPTION
## Problem

The Claude Code side panel's stop button only kills the wrapper process, leaving the Python/Streamlit process orphaned and still bound to port 8701. Clicking start then silently no-ops because the port is taken, so the old version keeps serving.

## Fix

Point `launch.json` for the `miolingo (main app)` entry at `scripts/dev_server.sh 8701` instead of calling streamlit directly. `dev_server.sh` already has a robust `kill_port` function (SIGTERM → wait 3s → SIGKILL) that runs before starting streamlit. Every side-panel restart now automatically clears any stale process first.

## Test plan

- [ ] Merge, pull, click stop then start in side panel — new version loads without needing a manual `pkill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)