### PR TITLE
feat(vocab): controls-first layout + optional URL field (v7.6.5)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.5] - 2026-04-19
+
+### Changed
+
+- Vocabulary tab: paste/upload controls now appear above the entry list (no more scrolling past entries to add a word).
+- Vocabulary tab: optional URL field on paste capture and bulk import (`word | source | context | url`); clickable 🔗 Source link shown in expanded entry rows; URL column in CSV export.
+- Migration: run `python scripts/amend_db.py --file scripts/add_vocab_url.sql --execute` against local and remote MySQL.
+
 ## [7.6.4] - 2026-04-19
 
 ### Fixed

--- a/scripts/add_vocab_url.sql
+++ b/scripts/add_vocab_url.sql
@@ -1,0 +1,6 @@
+-- Add optional url column to vocab_entries.
+-- Run with: python scripts/amend_db.py --file scripts/add_vocab_url.sql
+-- Apply --execute flag to commit; default is dry-run.
+
+ALTER TABLE `vocab_entries`
+  ADD COLUMN `url` VARCHAR(2048) NULL AFTER `notes`;

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.4"
+__version__ = "7.6.5"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -3,7 +3,7 @@ Vocabulary tab — per-user, per-language personal dictionary (F2).
 
 Capture routes wired in this tab:
   - Paste a passage, then type a word to capture from it (source = label)
-  - Bulk upload a pipe-delimited dictionary file (word | source | context)
+  - Bulk upload a pipe-delimited dictionary file (word | source | context | url)
 Capture from Story Reader and Quick Practice hooks into `vocab.capture_vocab_entry`
 directly; this tab is the view layer + paste/upload routes + export.
 """
@@ -42,10 +42,9 @@ def _user_id() -> int:
     return st.session_state["user"]["user_id"]
 
 
-def _capture_from_passage(passage: str, word: str, source_label: str) -> dict:
+def _capture_from_passage(passage: str, word: str, source_label: str, url: str = "") -> dict:
     """Capture a single word from a pasted passage, pulling ±2 lines of context."""
     lines = [ln for ln in passage.splitlines() if ln.strip()]
-    # Find the first line containing the word (case-insensitive).
     lower_word = word.strip().lower()
     idx = next(
         (i for i, ln in enumerate(lines) if lower_word in ln.lower()),
@@ -65,6 +64,7 @@ def _capture_from_passage(passage: str, word: str, source_label: str) -> dict:
         context_before=context_before,
         context_line=context_line,
         context_after=context_after,
+        url=url or None,
         enrich=True,
         source_language=_source_language(),
         secrets=st.secrets if hasattr(st, "secrets") else None,
@@ -87,11 +87,16 @@ def _render_paste_capture():
                 key="vocab_paste_source",
                 placeholder="(pasted)",
             )
+        url = st.text_input(
+            "Source URL (optional)",
+            key="vocab_paste_url",
+            placeholder="https://…",
+        )
         if st.button("➕ Add from passage", key="vocab_paste_btn", type="primary"):
             if not word.strip():
                 st.warning("Type a word to add.")
             else:
-                r = _capture_from_passage(passage, word, source_label)
+                r = _capture_from_passage(passage, word, source_label, url)
                 if r["ok"]:
                     st.success(
                         f"✅ {r['message'].capitalize()}: **{word}** "
@@ -104,8 +109,8 @@ def _render_paste_capture():
 def _render_bulk_upload():
     with st.expander("📥 Upload a dictionary file", expanded=False):
         st.caption(
-            "Pipe-delimited `.txt`: `word | source | context` — one entry per line. "
-            "Lines starting with `#` are ignored. Multi-word entries are skipped."
+            "Pipe-delimited `.txt`: `word | source | context | url` — one entry per line. "
+            "url is optional; lines starting with `#` are ignored; multi-word entries are skipped."
         )
         uploaded = st.file_uploader(
             "Upload .txt",
@@ -168,7 +173,7 @@ def _render_export_csv(rows: List[dict]):
     writer.writerow([
         "word", "translation", "ipa", "source",
         "context_before", "context_line", "context_after",
-        "times_seen", "first_seen_at", "last_seen_at", "notes",
+        "times_seen", "first_seen_at", "last_seen_at", "notes", "url",
     ])
     for r in rows:
         writer.writerow([
@@ -183,6 +188,7 @@ def _render_export_csv(rows: List[dict]):
             r.get("first_seen_at") or "",
             r.get("last_seen_at") or "",
             r.get("notes") or "",
+            r.get("url") or "",
         ])
     st.download_button(
         "⬇️ Export CSV",
@@ -211,6 +217,9 @@ def _render_entry_row(row: dict):
                 st.markdown(f"> {row['context_line']}")
             if row.get("context_after"):
                 st.caption(row["context_after"])
+
+        if row.get("url"):
+            st.markdown(f"[🔗 Source]({row['url']})")
 
         notes = st.text_area(
             "Notes",
@@ -274,6 +283,11 @@ def render_vocabulary_tab():
             placeholder="type to filter…",
         )
 
+    st.markdown("---")
+    _render_paste_capture()
+    _render_bulk_upload()
+    st.markdown("---")
+
     rows = vocab.list_vocab(
         user_id=_user_id(), language=language, sort=sort, search=search
     )
@@ -294,7 +308,3 @@ def render_vocabulary_tab():
     else:
         for row in rows:
             _render_entry_row(row)
-
-    st.markdown("---")
-    _render_paste_capture()
-    _render_bulk_upload()

--- a/src/vocab.py
+++ b/src/vocab.py
@@ -112,6 +112,7 @@ def capture_vocab_entry(
     context_before: str = "",
     context_line: str = "",
     context_after: str = "",
+    url: Optional[str] = None,
     enrich: bool = False,
     source_language: str = "English",
     secrets: Any = None,
@@ -145,8 +146,8 @@ def capture_vocab_entry(
             user_id, language_code, word, display_word,
             translation, ipa, source_name,
             context_before, context_line, context_after,
-            times_seen, first_seen_at, last_seen_at
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 1, %s, %s)
+            url, times_seen, first_seen_at, last_seen_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 1, %s, %s)
         ON DUPLICATE KEY UPDATE
             times_seen = times_seen + 1,
             last_seen_at = VALUES(last_seen_at),
@@ -155,13 +156,14 @@ def capture_vocab_entry(
             source_name   = COALESCE(source_name, VALUES(source_name)),
             context_before= COALESCE(NULLIF(context_before,''), VALUES(context_before)),
             context_line  = COALESCE(NULLIF(context_line,''),   VALUES(context_line)),
-            context_after = COALESCE(NULLIF(context_after,''),  VALUES(context_after))
+            context_after = COALESCE(NULLIF(context_after,''),  VALUES(context_after)),
+            url           = COALESCE(NULLIF(url,''), VALUES(url))
         """,
         (
             user_id, language, key, display,
             translation, ipa, source_name,
             context_before or None, context_line or None, context_after or None,
-            now, now,
+            url or None, now, now,
         ),
     )
     conn.commit()
@@ -274,16 +276,17 @@ def update_vocab_notes(*, user_id: int, vocab_id: int, notes: str) -> bool:
 
 
 def _parse_import_line(line: str) -> Optional[Dict[str, str]]:
-    """Pipe-delimited: `word | source | context`. All three required; context may be empty."""
+    """Pipe-delimited: `word | source | context | url`. Only word is required; rest may be empty."""
     parts = [p.strip() for p in line.split("|")]
-    if len(parts) < 2:
+    if len(parts) < 1:
         return None
     word = parts[0]
-    source = parts[1] if len(parts) >= 2 else ""
-    context = parts[2] if len(parts) >= 3 else ""
     if not word:
         return None
-    return {"word": word, "source": source, "context": context}
+    source = parts[1] if len(parts) >= 2 else ""
+    context = parts[2] if len(parts) >= 3 else ""
+    url = parts[3] if len(parts) >= 4 else ""
+    return {"word": word, "source": source, "context": context, "url": url}
 
 
 def count_import_lines(contents: str) -> int:
@@ -334,6 +337,7 @@ def import_from_file_contents(
                 word=parsed["word"],
                 source_name=parsed["source"] or None,
                 context_line=parsed["context"],
+                url=parsed.get("url") or None,
                 enrich=enrich,
                 source_language=source_language,
                 secrets=secrets,

--- a/tests/integration/schema.sql
+++ b/tests/integration/schema.sql
@@ -161,6 +161,7 @@ CREATE TABLE `vocab_entries` (
   `first_seen_at` datetime NOT NULL,
   `last_seen_at` datetime NOT NULL,
   `notes` text COLLATE utf8mb4_unicode_ci,
+  `url` varchar(2048) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`vocab_id`),
   UNIQUE KEY `uq_user_lang_word` (`user_id`,`language_code`,`word`),
   KEY `idx_user_lang_last_seen` (`user_id`,`language_code`,`last_seen_at`),


### PR DESCRIPTION
## Summary

- **Layout**: paste/upload expanders now appear above the entry list — no scrolling past entries to add a word
- **URL field**: optional URL on paste capture and bulk import (`word | source | context | url`); clickable 🔗 Source link in expanded rows; URL column in CSV export
- **Migration**: `scripts/add_vocab_url.sql` — run against local and remote MySQL before deploying:
  ```bash
  source venv/bin/activate && python scripts/amend_db.py --file scripts/add_vocab_url.sql --execute
  ```

## Test plan

- [ ] `pytest` → 100 passed
- [ ] Apply migration locally and remotely
- [ ] Vocabulary tab: paste/upload expanders visible without scrolling
- [ ] Add a word with a URL → 🔗 Source link appears in expanded row
- [ ] Add a word without a URL → no link, no error
- [ ] Bulk import 4-field file (`word|source|context|url`) → url stored and displayed
- [ ] Bulk import 3-field file → still works
- [ ] Export CSV → url column present

🤖 Generated with [Claude Code](https://claude.com/claude-code)