### PR TITLE
fix(vocab): remove semicolon-in-comment that broke amend_db.py parser

### DIFF
--- a/scripts/add_vocab_url.sql
+++ b/scripts/add_vocab_url.sql
@@ -1,6 +1,2 @@
--- Add optional url column to vocab_entries.
--- Run with: python scripts/amend_db.py --file scripts/add_vocab_url.sql
--- Apply --execute flag to commit; default is dry-run.
-
 ALTER TABLE `vocab_entries`
   ADD COLUMN `url` VARCHAR(2048) NULL AFTER `notes`;


### PR DESCRIPTION
## Summary

`scripts/add_vocab_url.sql` had a `--` comment containing a semicolon, which caused `amend_db.py`'s `split(';')` parser to split inside the comment and prepend `default is dry-run.` to the ALTER TABLE statement, producing a syntax error.

Fix: remove all comments from the SQL file, leaving only the bare ALTER TABLE statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)