### PR TITLE
fix(vocab): 5-field positional import format + additive enrichment (v7.6.6)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.6.6] - 2026-04-20
+
+### Changed
+
+- Vocabulary bulk import: new 5-field positional format `word | translation | ipa | source | url` (context field removed — impractical in plain text). Use `||` to skip a field while keeping later ones in the correct position (e.g. `word || [atˈɛ] | src`). IPA `[]` brackets stripped automatically.
+- Enrichment is now additive: LLM/eSpeak only fills fields missing from the file — pre-enriched files import instantly with no redundant API calls.
+- "Auto-fetch translation + IPA" checkbox relabelled to "Auto-fetch **missing** translation + IPA" to reflect the above.
+
 ## [7.6.5] - 2026-04-19
 
 ### Changed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.5"
+__version__ = "7.6.6"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -109,8 +109,10 @@ def _render_paste_capture():
 def _render_bulk_upload():
     with st.expander("📥 Upload a dictionary file", expanded=False):
         st.caption(
-            "Pipe-delimited `.txt`: `word | source | context | url` — one entry per line. "
-            "url is optional; lines starting with `#` are ignored; multi-word entries are skipped."
+            "Pipe-delimited `.txt`: `word | translation | ipa | source | url` — one entry per line. "
+            "Only word is required. Use `||` to skip a field while keeping later ones in position "
+            "(e.g. `word || [atˈɛ] | src`). IPA brackets `[]` are stripped automatically. "
+            "Lines starting with `#` are ignored; multi-word entries are skipped."
         )
         uploaded = st.file_uploader(
             "Upload .txt",
@@ -118,10 +120,10 @@ def _render_bulk_upload():
             key="vocab_bulk_upload",
         )
         enrich = st.checkbox(
-            "Auto-fetch translation + IPA on import",
+            "Auto-fetch missing translation + IPA on import",
             value=True,
             key="vocab_bulk_enrich",
-            help="Slower but more useful. Uncheck for a raw import you'll enrich later.",
+            help="Fills any blank translation/IPA via LLM + eSpeak. Skipped if the file already has those fields.",
         )
         if uploaded is not None:
             try:
@@ -130,7 +132,7 @@ def _render_bulk_upload():
                 st.error("File is not UTF-8 encoded.")
                 return
             n_lines = vocab.count_import_lines(contents)
-            est = f" (~{n_lines * 2}–{n_lines * 4}s with enrichment)" if enrich and n_lines > 10 else ""
+            est = f" (~{n_lines * 2}–{n_lines * 4}s if enrichment needed)" if enrich and n_lines > 10 else ""
             st.caption(f"{n_lines} words to import{est}.")
 
         if uploaded is not None and st.button(

--- a/src/vocab.py
+++ b/src/vocab.py
@@ -113,6 +113,8 @@ def capture_vocab_entry(
     context_line: str = "",
     context_after: str = "",
     url: Optional[str] = None,
+    translation: Optional[str] = None,
+    ipa: Optional[str] = None,
     enrich: bool = False,
     source_language: str = "English",
     secrets: Any = None,
@@ -129,10 +131,12 @@ def capture_vocab_entry(
     except VocabCaptureError as e:
         return {"ok": False, "vocab_id": None, "created": False, "message": str(e)}
 
-    translation: Optional[str] = None
-    ipa: Optional[str] = None
-    if enrich:
-        translation, ipa = _enrich(display, language, source_language, secrets)
+    if enrich and (not translation or not ipa):
+        enrich_t, enrich_i = _enrich(display, language, source_language, secrets)
+        if not translation:
+            translation = enrich_t
+        if not ipa:
+            ipa = enrich_i
 
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     conn = app_mysql.get_connection()
@@ -276,17 +280,27 @@ def update_vocab_notes(*, user_id: int, vocab_id: int, notes: str) -> bool:
 
 
 def _parse_import_line(line: str) -> Optional[Dict[str, str]]:
-    """Pipe-delimited: `word | source | context | url`. Only word is required; rest may be empty."""
+    """Pipe-delimited: `word | translation | ipa | source | url` (5 positional fields).
+
+    Only word is required.  Use `||` to leave a field blank while keeping
+    later fields in the correct position — e.g. `word || [atˈɛ] | src` sets
+    ipa but leaves translation empty.  IPA may be wrapped in `[]`; brackets
+    are stripped.  Trailing fields may be omitted.
+    """
     parts = [p.strip() for p in line.split("|")]
-    if len(parts) < 1:
+    if not parts:
         return None
     word = parts[0]
     if not word:
         return None
-    source = parts[1] if len(parts) >= 2 else ""
-    context = parts[2] if len(parts) >= 3 else ""
-    url = parts[3] if len(parts) >= 4 else ""
-    return {"word": word, "source": source, "context": context, "url": url}
+    translation = parts[1] if len(parts) >= 2 else ""
+    ipa         = parts[2] if len(parts) >= 3 else ""
+    source      = parts[3] if len(parts) >= 4 else ""
+    url         = parts[4] if len(parts) >= 5 else ""
+    if ipa.startswith("[") and ipa.endswith("]"):
+        ipa = ipa[1:-1]
+    return {"word": word, "translation": translation, "ipa": ipa,
+            "source": source, "url": url}
 
 
 def count_import_lines(contents: str) -> int:
@@ -336,8 +350,9 @@ def import_from_file_contents(
                 language=language,
                 word=parsed["word"],
                 source_name=parsed["source"] or None,
-                context_line=parsed["context"],
                 url=parsed.get("url") or None,
+                translation=parsed.get("translation") or None,
+                ipa=parsed.get("ipa") or None,
                 enrich=enrich,
                 source_language=source_language,
                 secrets=secrets,


### PR DESCRIPTION
## Summary

- **New import format**: `word | translation | ipa | source | url` (5 positional fields). Context field is removed — multi-line context is impractical in plain-text files.
- **`||` skips a field positionally**: `word || [atˈɛ] | src` sets IPA but leaves translation blank; later fields stay in the correct column.
- **IPA `[]` brackets stripped automatically**.
- **Additive enrichment**: LLM/eSpeak only fills fields *absent* from the file. Pre-enriched word lists (e.g. `até | until | [atˈɛ]`) import instantly with no API calls and no double-translation display.
- UI caption and checkbox label updated to reflect the new format.

## Root cause of the double-translation bug

Old format put translation in the `source_name` column (field 2 = source). Enrichment then fetched the same translation via LLM and stored it in `translation`. Both showed up in the entry summary line.

## Test plan

- [ ] Import `words-004.txt` (format: `word | translation | ipa`) — entries show translation + IPA from file, source is blank, no enrichment API calls fired even with checkbox on
- [ ] Import a plain word-only file with enrichment on — LLM + eSpeak still fire for missing fields
- [ ] Import `word || [atˈɛ] | words-004` — IPA set, translation blank
- [ ] Import `word | until || words-004` — translation set, IPA blank
- [ ] `pytest -m integration tests/integration/test_vocab.py` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)