### PR TITLE
feat(vocab): post-capture edit + auto-fill (v7.7.0-claude-dev)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.7.0-claude-dev] - 2026-04-21
+
+### Changed
+
+- Version bump
+
+
 ## [7.6.9-claude-dev] - 2026-04-20
 
 ### Changed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.6.9-claude-dev"
+__version__ = "7.7.0-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -209,6 +209,136 @@ def _render_export_csv(rows: List[dict]):
     )
 
 
+_EDIT_FIELDS = (
+    "display_word", "translation", "ipa", "source_name", "url",
+    "context_before", "context_line", "context_after",
+)
+
+
+def _clear_edit_state(vocab_id: int) -> None:
+    """Drop the editing flag + all per-field widget keys for one entry."""
+    st.session_state.pop(f"vocab_editing_{vocab_id}", None)
+    for field in _EDIT_FIELDS:
+        st.session_state.pop(f"vocab_edit_{field}_{vocab_id}", None)
+
+
+def _prune_stale_session_keys(rows: list) -> None:
+    """Drop vocab_editing_* / vocab_notes_* / vocab_edit_*_<id> keys whose
+    vocab_id is no longer in the current result set. Prevents a slow leak
+    of orphan widget state after deletes, and cross-user leaks after logout.
+    """
+    live_ids = {str(r["vocab_id"]) for r in rows}
+    stale: list = []
+    for key in st.session_state.keys():
+        for prefix in ("vocab_editing_", "vocab_notes_", "vocab_save_"):
+            if key.startswith(prefix):
+                if key[len(prefix):] not in live_ids:
+                    stale.append(key)
+                break
+        else:
+            if key.startswith("vocab_edit_"):
+                # key form: vocab_edit_<field>_<vocab_id>
+                vid = key.rsplit("_", 1)[-1]
+                if vid.isdigit() and vid not in live_ids:
+                    stale.append(key)
+    for key in stale:
+        st.session_state.pop(key, None)
+
+
+def _render_entry_edit_form(row: dict) -> None:
+    """Inline edit form — seven editable text fields + Save / Cancel."""
+    vocab_id = row["vocab_id"]
+
+    st.markdown("**Edit entry**")
+    c1, c2 = st.columns(2)
+    with c1:
+        display_word = st.text_input(
+            "Word (casing only — lookup key is immutable)",
+            value=row.get("display_word") or "",
+            key=f"vocab_edit_display_word_{vocab_id}",
+        )
+        translation = st.text_input(
+            "Translation",
+            value=row.get("translation") or "",
+            key=f"vocab_edit_translation_{vocab_id}",
+        )
+    with c2:
+        ipa = st.text_input(
+            "IPA",
+            value=row.get("ipa") or "",
+            key=f"vocab_edit_ipa_{vocab_id}",
+        )
+        source_name = st.text_input(
+            "Source",
+            value=row.get("source_name") or "",
+            key=f"vocab_edit_source_name_{vocab_id}",
+        )
+
+    url = st.text_input(
+        "URL",
+        value=row.get("url") or "",
+        key=f"vocab_edit_url_{vocab_id}",
+        placeholder="https://…",
+    )
+    context_before = st.text_area(
+        "Context before",
+        value=row.get("context_before") or "",
+        key=f"vocab_edit_context_before_{vocab_id}",
+        height=60,
+    )
+    context_line = st.text_area(
+        "Context line",
+        value=row.get("context_line") or "",
+        key=f"vocab_edit_context_line_{vocab_id}",
+        height=60,
+    )
+    context_after = st.text_area(
+        "Context after",
+        value=row.get("context_after") or "",
+        key=f"vocab_edit_context_after_{vocab_id}",
+        height=60,
+    )
+
+    bcol1, bcol2, _ = st.columns([1, 1, 4])
+    with bcol1:
+        save_clicked = st.button(
+            "💾 Save", key=f"vocab_edit_save_{vocab_id}", type="primary"
+        )
+    with bcol2:
+        cancel_clicked = st.button(
+            "✖ Cancel", key=f"vocab_edit_cancel_{vocab_id}"
+        )
+
+    if cancel_clicked:
+        _clear_edit_state(vocab_id)
+        st.rerun()
+
+    if save_clicked:
+        fields = {
+            "display_word":   display_word,
+            "translation":    translation,
+            "ipa":            ipa,
+            "source_name":    source_name,
+            "url":            url,
+            "context_before": context_before,
+            "context_line":   context_line,
+            "context_after":  context_after,
+        }
+        try:
+            ok = vocab.update_vocab_entry(
+                user_id=_user_id(), vocab_id=vocab_id, **fields
+            )
+        except ValueError as e:
+            st.error(f"⚠️ {e}")
+            return
+        if ok:
+            _clear_edit_state(vocab_id)
+            st.success("Saved.")
+            st.rerun()
+        else:
+            st.error("Could not save — entry no longer exists.")
+
+
 def _render_entry_row(row: dict):
     # Summary line: word · translation · IPA · source · date
     summary_bits = [f"**{row['display_word']}**"]
@@ -218,7 +348,15 @@ def _render_entry_row(row: dict):
         summary_bits.append(f"`{row['ipa']}`")
     summary_bits.append(f"· {row.get('source_name') or '—'}")
     summary_bits.append(f"· {str(row.get('last_seen_at') or '')[:16]}")
-    with st.expander(" ".join(summary_bits), expanded=False):
+
+    vocab_id = row["vocab_id"]
+    editing = st.session_state.get(f"vocab_editing_{vocab_id}", False)
+
+    with st.expander(" ".join(summary_bits), expanded=editing):
+        if editing:
+            _render_entry_edit_form(row)
+            return
+
         if row.get("context_before") or row.get("context_line") or row.get("context_after"):
             st.markdown("**Context:**")
             if row.get("context_before"):
@@ -234,21 +372,21 @@ def _render_entry_row(row: dict):
         notes = st.text_area(
             "Notes",
             value=row.get("notes") or "",
-            key=f"vocab_notes_{row['vocab_id']}",
+            key=f"vocab_notes_{vocab_id}",
             height=60,
         )
         col1, col2, col3 = st.columns(3)
         with col1:
-            if st.button("💾 Save notes", key=f"vocab_save_{row['vocab_id']}"):
+            if st.button("💾 Save notes", key=f"vocab_save_{vocab_id}"):
                 if vocab.update_vocab_notes(
                     user_id=_user_id(),
-                    vocab_id=row["vocab_id"],
+                    vocab_id=vocab_id,
                     notes=notes,
                 ):
                     st.success("Notes saved.")
                     st.rerun()
         with col2:
-            if st.button("🔊 Play", key=f"vocab_tts_{row['vocab_id']}"):
+            if st.button("🔊 Play", key=f"vocab_tts_{vocab_id}"):
                 try:
                     audio_bytes, fmt = generate_target_audio(
                         row["display_word"], st.session_state.settings
@@ -257,12 +395,40 @@ def _render_entry_row(row: dict):
                 except Exception as e:
                     st.warning(f"TTS failed: {e}")
         with col3:
-            if st.button("🗑️ Delete", key=f"vocab_del_{row['vocab_id']}"):
+            if st.button("🗑️ Delete", key=f"vocab_del_{vocab_id}"):
                 vocab.delete_vocab_entry(
-                    user_id=_user_id(), vocab_id=row["vocab_id"]
+                    user_id=_user_id(), vocab_id=vocab_id
                 )
                 st.success("Deleted.")
                 st.rerun()
+
+        # Secondary action row: Edit + Auto-fill (auto-fill only when needed).
+        need_autofill = not (row.get("translation") or "").strip() \
+                        or not (row.get("ipa") or "").strip()
+        acol1, acol2, _ = st.columns([1, 1, 4])
+        with acol1:
+            if st.button("✏️ Edit", key=f"vocab_edit_btn_{vocab_id}"):
+                st.session_state[f"vocab_editing_{vocab_id}"] = True
+                st.rerun()
+        with acol2:
+            if need_autofill and st.button(
+                "✨ Auto-fill", key=f"vocab_autofill_{vocab_id}",
+                help="Fill missing translation / IPA via LLM + eSpeak.",
+            ):
+                with st.spinner("Auto-filling…"):
+                    result = vocab.autofill_vocab_entry(
+                        user_id=_user_id(),
+                        vocab_id=vocab_id,
+                        language=_current_language(),
+                        source_language=_source_language(),
+                        secrets=st.secrets if hasattr(st, "secrets") else None,
+                    )
+                filled = result.get("filled", {})
+                if filled:
+                    st.toast(f"Filled: {', '.join(filled.keys())}")
+                    st.rerun()
+                else:
+                    st.info("Nothing to fill — enrichment didn't return a value.")
 
 
 def render_vocabulary_tab():
@@ -301,6 +467,7 @@ def render_vocabulary_tab():
     rows = vocab.list_vocab(
         user_id=_user_id(), language=language, sort=sort, search=search
     )
+    _prune_stale_session_keys(rows)
 
     st.caption(f"**{len(rows)}** entr{'y' if len(rows) == 1 else 'ies'}")
 

--- a/src/vocab.py
+++ b/src/vocab.py
@@ -279,6 +279,132 @@ def update_vocab_notes(*, user_id: int, vocab_id: int, notes: str) -> bool:
     return affected > 0
 
 
+# Fields that the post-capture edit form may modify. `word` (the lookup key)
+# is intentionally excluded — changing it would require re-deduplication.
+# `notes` has its own dedicated save flow. `times_seen` / `first_seen_at` /
+# `last_seen_at` are capture-side counters, not user-editable.
+_EDITABLE_FIELDS = (
+    "display_word",
+    "translation",
+    "ipa",
+    "source_name",
+    "url",
+    "context_before",
+    "context_line",
+    "context_after",
+)
+
+
+def update_vocab_entry(*, user_id: int, vocab_id: int, **fields: Any) -> bool:
+    """Update a subset of editable fields on an entry owned by ``user_id``.
+
+    - Rejects keys outside ``_EDITABLE_FIELDS`` with ``ValueError``.
+    - For ``display_word``: the new value must round-trip to the same lookup
+      key (``_normalise(new)[1] == row["word"]``); otherwise ``ValueError``.
+      This allows casing fixes but preserves the unique (user_id, language,
+      word) key.
+    - Each value is normalised with ``(x or "").strip()``; an empty string
+      is persisted as ``NULL``.
+    - A delta against the current row is computed; if nothing changed, no
+      SQL runs and ``True`` is returned.
+    - Returns ``True`` if the row exists and belongs to ``user_id``;
+      ``False`` otherwise.
+    """
+    unknown = set(fields) - set(_EDITABLE_FIELDS)
+    if unknown:
+        raise ValueError(
+            f"Unknown editable field(s): {sorted(unknown)}. "
+            f"Allowed: {list(_EDITABLE_FIELDS)}"
+        )
+
+    row = get_vocab_entry(user_id=user_id, vocab_id=vocab_id)
+    if row is None:
+        return False
+
+    # Validate display_word preserves the lookup key.
+    if "display_word" in fields:
+        new_display = (fields["display_word"] or "").strip()
+        if not new_display:
+            raise ValueError("display_word cannot be empty")
+        _, new_key = _normalise(new_display)
+        if new_key != row["word"]:
+            raise ValueError(
+                f"display_word {new_display!r} would change lookup key "
+                f"from {row['word']!r} to {new_key!r}; "
+                "editing the lookup key is not supported"
+            )
+
+    # Build delta: only columns whose normalised value differs from current.
+    delta: Dict[str, Optional[str]] = {}
+    for col, raw in fields.items():
+        new_val: Optional[str] = (raw or "").strip() or None
+        cur_val = row.get(col)
+        cur_norm: Optional[str] = (cur_val or "").strip() or None if isinstance(cur_val, str) else cur_val
+        if new_val != cur_norm:
+            delta[col] = new_val
+
+    if not delta:
+        return True  # no-op; row exists and is owned.
+
+    set_clause = ", ".join(f"{col}=%s" for col in delta)
+    params = list(delta.values()) + [vocab_id, user_id]
+
+    conn = app_mysql.get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        f"UPDATE vocab_entries SET {set_clause} "
+        "WHERE vocab_id=%s AND user_id=%s",
+        params,
+    )
+    conn.commit()
+    cur.close()
+    # Row existed and was owned (checked above); a 0 rowcount from MySQL
+    # just means the driver saw no byte-level change, not a failure.
+    return True
+
+
+def autofill_vocab_entry(
+    *,
+    user_id: int,
+    vocab_id: int,
+    language: str,
+    source_language: str,
+    secrets: Any,
+) -> Dict[str, Dict[str, str]]:
+    """Fill missing ``translation`` / ``ipa`` on an entry via ``_enrich``.
+
+    Only fields that are currently empty are candidates; existing values are
+    never overwritten. Returns ``{"filled": {field: value, ...}}`` describing
+    what was written. Returns ``{"filled": {}}`` when the entry is already
+    complete, when the user does not own the row, or when ``_enrich`` could
+    not produce the missing field(s).
+    """
+    row = get_vocab_entry(user_id=user_id, vocab_id=vocab_id)
+    if row is None:
+        return {"filled": {}}
+
+    need_translation = not (row.get("translation") or "").strip()
+    need_ipa = not (row.get("ipa") or "").strip()
+    if not (need_translation or need_ipa):
+        return {"filled": {}}
+
+    translation, ipa = _enrich(
+        row["display_word"], language, source_language, secrets
+    )
+
+    to_write: Dict[str, str] = {}
+    if need_translation and translation:
+        to_write["translation"] = translation
+    if need_ipa and ipa:
+        to_write["ipa"] = ipa
+
+    if not to_write:
+        return {"filled": {}}
+
+    update_vocab_entry(user_id=user_id, vocab_id=vocab_id, **to_write)
+    return {"filled": to_write}
+
+
 def _parse_import_line(line: str) -> Optional[Dict[str, str]]:
     """Pipe-delimited: `word | translation | ipa | source | url` (5 positional fields).
 

--- a/tests/integration/test_vocab.py
+++ b/tests/integration/test_vocab.py
@@ -202,6 +202,155 @@ def test_bulk_import(db_conn, make_user):
     assert lua["source_name"] == "Cancao da Lua"
 
 
+# ── update_vocab_entry / autofill_vocab_entry (Task 2) ─────────────────────
+
+def _capture_simple(user_id, word="saudade", language="Portuguese", **kw):
+    import vocab
+    r = vocab.capture_vocab_entry(
+        user_id=user_id, language=language, word=word, **kw
+    )
+    assert r["ok"] and r["vocab_id"]
+    return r["vocab_id"]
+
+
+def test_update_vocab_entry_partial(db_conn, make_user):
+    import vocab
+    u = make_user(username="vocab_upd_partial")
+    vid = _capture_simple(
+        u["user_id"], translation="longing", ipa="sawˈdad.ʒi",
+        source_name="Pessoa",
+    )
+    assert vocab.update_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid, translation="nostalgia"
+    )
+    row = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert row["translation"] == "nostalgia"
+    assert row["ipa"] == "sawˈdad.ʒi"
+    assert row["source_name"] == "Pessoa"
+
+
+def test_update_vocab_entry_cross_user_isolation(db_conn, make_user):
+    import vocab
+    u1 = make_user(username="vocab_upd_owner")
+    u2 = make_user(username="vocab_upd_intruder")
+    vid = _capture_simple(u1["user_id"], translation="orig")
+    assert vocab.update_vocab_entry(
+        user_id=u2["user_id"], vocab_id=vid, translation="hacked"
+    ) is False
+    row = vocab.get_vocab_entry(user_id=u1["user_id"], vocab_id=vid)
+    assert row["translation"] == "orig"
+
+
+def test_update_vocab_entry_clears_field_with_empty_string(db_conn, make_user):
+    import vocab
+    u = make_user(username="vocab_upd_clear")
+    vid = _capture_simple(u["user_id"], url="https://example.com")
+    assert vocab.update_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid, url=""
+    )
+    row = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert row["url"] is None
+
+
+def test_update_vocab_entry_display_word_casing_accepted(db_conn, make_user):
+    import vocab
+    u = make_user(username="vocab_upd_casing")
+    vid = _capture_simple(u["user_id"], word="saudade")
+    assert vocab.update_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid, display_word="Saudade"
+    )
+    row = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert row["display_word"] == "Saudade"
+    assert row["word"] == "saudade"  # lookup key unchanged
+
+
+def test_update_vocab_entry_display_word_rejects_key_change(db_conn, make_user):
+    import vocab
+    u = make_user(username="vocab_upd_keychange")
+    vid = _capture_simple(u["user_id"], word="saudade")
+    with pytest.raises(ValueError, match="lookup key"):
+        vocab.update_vocab_entry(
+            user_id=u["user_id"], vocab_id=vid, display_word="saudades"
+        )
+
+
+def test_update_vocab_entry_rejects_unknown_field(db_conn, make_user):
+    import vocab
+    u = make_user(username="vocab_upd_unknown")
+    vid = _capture_simple(u["user_id"])
+    with pytest.raises(ValueError, match="Unknown"):
+        vocab.update_vocab_entry(
+            user_id=u["user_id"], vocab_id=vid, times_seen=999
+        )
+
+
+def test_update_vocab_entry_noop_when_unchanged(db_conn, make_user):
+    import vocab
+    u = make_user(username="vocab_upd_noop")
+    vid = _capture_simple(u["user_id"], translation="x")
+    before = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert vocab.update_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid, translation="x"
+    ) is True
+    after = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert before["times_seen"] == after["times_seen"]
+    assert before["translation"] == after["translation"]
+
+
+def test_autofill_only_fills_missing(db_conn, make_user, monkeypatch):
+    import vocab
+    u = make_user(username="vocab_autofill_partial")
+    vid = _capture_simple(u["user_id"], translation="already-set")
+
+    monkeypatch.setattr(vocab, "_enrich",
+                        lambda *a, **kw: ("SHOULD-NOT-OVERWRITE", "ˈstub"))
+
+    result = vocab.autofill_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid,
+        language="Portuguese", source_language="English", secrets=None,
+    )
+    assert result == {"filled": {"ipa": "ˈstub"}}
+    row = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert row["translation"] == "already-set"
+    assert row["ipa"] == "ˈstub"
+
+
+def test_autofill_noop_when_complete(db_conn, make_user, monkeypatch):
+    import vocab
+    u = make_user(username="vocab_autofill_complete")
+    vid = _capture_simple(u["user_id"], translation="t", ipa="i")
+
+    called = {"n": 0}
+    def _stub(*a, **kw):
+        called["n"] += 1
+        return ("X", "Y")
+    monkeypatch.setattr(vocab, "_enrich", _stub)
+
+    result = vocab.autofill_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid,
+        language="Portuguese", source_language="English", secrets=None,
+    )
+    assert result == {"filled": {}}
+    assert called["n"] == 0  # short-circuits before calling _enrich
+
+
+def test_autofill_noop_when_enrich_returns_none(db_conn, make_user, monkeypatch):
+    import vocab
+    u = make_user(username="vocab_autofill_empty")
+    vid = _capture_simple(u["user_id"])
+
+    monkeypatch.setattr(vocab, "_enrich", lambda *a, **kw: (None, None))
+
+    result = vocab.autofill_vocab_entry(
+        user_id=u["user_id"], vocab_id=vid,
+        language="Portuguese", source_language="English", secrets=None,
+    )
+    assert result == {"filled": {}}
+    row = vocab.get_vocab_entry(user_id=u["user_id"], vocab_id=vid)
+    assert row["translation"] is None
+    assert row["ipa"] is None
+
+
 def test_vocab_as_practice_phrases_shape(db_conn, make_user):
     import vocab
 


### PR DESCRIPTION
## Summary

- a4ed0d5 v7.7.0-claude-dev: version bump
- e851a30 feat(vocab): post-capture edit form + auto-fill action

## Test plan
- [x] App starts without import errors
- [x] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)