### PR TITLE
feat(vocab): search mini-language (v7.8.0-claude-dev)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -2,31 +2,41 @@
 
 All notable changes to the Miolingo pronunciation trainer application will be documented in this file.
 
-only this broke: only the version changes are logged here
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries are written by `scripts/bump_version.py`; the `--notes` flag is
+required for any non-tooling bump so the log captures *what* changed, not
+just that something changed.
 
 
 ## [7.7.0-claude-dev] - 2026-04-21
 
+### Added
+
+- Post-capture edit form on every vocabulary entry: ✏️ Edit opens an inline form covering display_word (casing only), translation, IPA, source_name, url, and the three context fields. Empty strings clear to NULL; lookup key stays immutable. (PR #87)
+- ✨ Auto-fill action — visible only when translation or IPA is missing — fills gaps via the existing LLM + eSpeak enrichment and never overwrites existing values.
+
 ### Changed
 
-- Version bump
+- Per-entry Streamlit session keys are pruned after deletes and logout/re-login to prevent orphan widget state.
 
 
 ## [7.6.9-claude-dev] - 2026-04-20
 
 ### Changed
 
-- Version bump
+- `scripts/create-pr.sh` version check now compares HEAD against `origin/$BASE_BRANCH:src/config.py` instead of `git describe`; the old check gave false positives because `bump_version.py --tag` places the new tag at HEAD. (PR #86)
+- `scripts/create-pr.sh` push uses explicit `HEAD:refs/heads/<branch>` form so it stays safe regardless of inherited upstream tracking, and sets the upstream cleanly so subsequent tag pushes don't trip the PreToolUse hook.
+- New authoritative workflow doc at `docs/dev-docs/SCRIPTS_WORKFLOW.md` + CLAUDE.md preamble pointing at it, so fresh sessions stop rediscovering the release workflow from scratch.
 
 
 ## [7.6.8-claude-dev] - 2026-04-20
 
-### Changed
+### Fixed
 
-- Version bump
+- Personal vocabulary sync: `vocab_entries` table was missing from `scripts/sync_db.py`'s `SYNC_TABLES`, so local captures never replicated to the remote MySQL. Added the table with an idempotent merge strategy (GREATEST/COALESCE/NULLIF) that preserves per-row history across both sides. (PR #85)
+- New `scripts/test_vocab_sync.py` round-trip harness (17 assertions) proves L→R, R→L, counter-merge, NULL-fill, and idempotency.
 
 
 ## [7.6.7] - 2026-04-20

--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,15 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.7.1-claude-dev] - 2026-04-21
+
+### Changed
+
+- bump_version.py now requires --notes "TEXT" for any real bump; --kind selects section heading; --no-notes for emergency re-tags only.
+- APP_CHANGELOG.md backfilled for 7.6.8 / 7.6.9 / 7.7.0 from their PR bodies.
+- SCRIPTS_WORKFLOW.md golden path updated to reflect the new --notes requirement.
+
+
 ## [7.7.0-claude-dev] - 2026-04-21
 
 ### Added

--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,16 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.8.0-claude-dev] - 2026-04-21
+
+### Added
+
+- Vocabulary search mini-language: plain text still works; new operators are ^prefix, suffix$, [bracket-class-regex], field:value (word/translation/ipa/source/url/note/context), has:FIELD and none:FIELD. All AND-combined, any order.
+- Regex triggers conservatively (^ at start, unescaped $ at end, or [...] present) so natural punctuation like 'saudade?' or 'e.g.' still searches as plain text.
+- Whitespace around ':' is collapsed outside quotes; only the first ':' splits field from value so URLs work.
+- Invalid queries surface as non-fatal warnings in the UI rather than crashing.
+
+
 ## [7.7.1-claude-dev] - 2026-04-21
 
 ### Changed

--- a/docs/dev-docs/SCRIPTS_WORKFLOW.md
+++ b/docs/dev-docs/SCRIPTS_WORKFLOW.md
@@ -29,8 +29,13 @@ git add <files>
 git commit -m "fix(scope): concise subject"
 
 # 4. Bump version + tag.  Do NOT pass --push here.
-python scripts/bump_version.py patch --suffix claude-dev --tag
-# For admin changes: python scripts/bump_version.py admin patch --suffix claude-dev --tag
+#    --notes is REQUIRED — it's what appears in APP_CHANGELOG.md.
+python scripts/bump_version.py patch --suffix claude-dev --tag \
+  --notes "One-line summary of what this PR actually changes."
+#    --kind added|changed|fixed|removed|deprecated|security (default: changed)
+#    Repeat --notes, or use '\n' in one value, for multiple bullets.
+#    --no-notes is reserved for emergency bumps only.
+# For admin changes: python scripts/bump_version.py admin patch --suffix claude-dev --tag --notes "..."
 
 # 5. Create the PR.  Script handles branch push + PR creation.
 bash scripts/create-pr.sh --title "fix(scope): concise subject (vX.Y.Z-claude-dev)"
@@ -111,6 +116,9 @@ All scripts live in `scripts/`. Paths shown are relative to the repo root.
 - command: `show | major | minor | patch | set X.Y.Z`
 - `--suffix LABEL` — appends `-LABEL` (use `claude-dev` for dev PRs)
 - `--tag` — commits the bump and creates a local annotated tag
+- `--notes "TEXT"` — **REQUIRED** for any real bump; one line per bullet. Repeatable. Accepts `\n` inside a single value. Lifted verbatim into `APP_CHANGELOG.md`; do not prefix with `-`.
+- `--kind added|changed|fixed|removed|deprecated|security` — changelog heading (default: `changed`).
+- `--no-notes` — opt out of the notes requirement. Reserved for emergency / tooling-only re-tags. **Do not use for feature or fix PRs** — the whole point of the requirement is that "Version bump" entries are useless.
 - `--push` — **avoid in normal workflow**. Runs `git push origin HEAD` which follows upstream. Use only when you know the branch upstream matches its remote name.
 
 ### Dev server

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -44,6 +44,17 @@ Usage
     --suffix LABEL        Append -LABEL to the version  (e.g. claude-dev-phase3)
     --tag                 Create annotated git tag after commit
     --push                Push commits and tags to remote (implies commit)
+    --notes "TEXT"        One-line summary written to the changelog.
+                          REQUIRED unless --no-notes is given. May be passed
+                          multiple times (each becomes a bullet).  Also accepts
+                          a single string with '\\n' — each line becomes a
+                          bullet. Bullets copy verbatim; don't prefix with '-'.
+    --kind KIND           Changelog section for the bullets.
+                          One of: added | changed | fixed | removed | deprecated
+                          | security. Default: changed.
+    --no-notes            Skip the --notes requirement. Reserved for emergency
+                          bumps / tooling-only re-tags — DO NOT use for
+                          feature/fix/refactor PRs.
 
 Examples
 --------
@@ -142,7 +153,22 @@ def write_version(target_cfg: dict, new_version: str) -> None:
     path.write_text(new_content)
 
 
-def update_changelog(target_cfg: dict, new_version: str) -> bool:
+_KIND_HEADINGS = {
+    "added": "Added",
+    "changed": "Changed",
+    "fixed": "Fixed",
+    "removed": "Removed",
+    "deprecated": "Deprecated",
+    "security": "Security",
+}
+
+
+def update_changelog(
+    target_cfg: dict,
+    new_version: str,
+    notes: list[str] | None = None,
+    kind: str = "changed",
+) -> bool:
     """Prepend a new section to the changelog. Returns True if file was updated."""
     path = target_cfg["changelog_file"]
     if not path.exists():
@@ -150,7 +176,12 @@ def update_changelog(target_cfg: dict, new_version: str) -> bool:
         return False
 
     today = date.today().isoformat()
-    entry = f"## [{new_version}] - {today}\n\n### Changed\n\n- Version bump\n\n\n"
+    heading = _KIND_HEADINGS.get(kind.lower(), "Changed")
+    if notes:
+        bullets = "\n".join(f"- {line}" for line in notes)
+    else:
+        bullets = "- Version bump"
+    entry = f"## [{new_version}] - {today}\n\n### {heading}\n\n{bullets}\n\n\n"
 
     content = path.read_text()
     # Insert before the first existing ## [ entry
@@ -187,25 +218,50 @@ def git_push() -> None:
 
 def parse_args(argv):
     """
-    Returns (target, command, set_version, suffix, do_tag, do_push).
+    Returns (target, command, set_version, suffix, do_tag, do_push,
+             notes, kind, no_notes).
     """
     args = list(argv[1:])
 
-    # Extract flags
+    # Extract boolean flags
     do_tag = "--tag" in args
     do_push = "--push" in args
-    for flag in ("--tag", "--push"):
-        if flag in args:
+    no_notes = "--no-notes" in args
+    for flag in ("--tag", "--push", "--no-notes"):
+        while flag in args:
             args.remove(flag)
 
-    suffix = ""
-    if "--suffix" in args:
-        idx = args.index("--suffix")
+    def _take_value(flag: str) -> str | None:
+        nonlocal args
+        if flag not in args:
+            return None
+        idx = args.index(flag)
         if idx + 1 >= len(args):
-            print("Error: --suffix requires a value", file=sys.stderr)
+            print(f"Error: {flag} requires a value", file=sys.stderr)
             sys.exit(1)
-        suffix = args[idx + 1]
+        val = args[idx + 1]
         args = args[:idx] + args[idx + 2:]
+        return val
+
+    suffix = _take_value("--suffix") or ""
+    kind = (_take_value("--kind") or "changed").lower()
+    if kind not in _KIND_HEADINGS:
+        print(
+            f"Error: --kind must be one of {sorted(_KIND_HEADINGS)}, got {kind!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Collect all --notes values (repeatable).
+    notes: list[str] = []
+    while "--notes" in args:
+        val = _take_value("--notes")
+        if val:
+            # A single --notes may carry '\n' or real newlines; split either.
+            for line in val.replace("\\n", "\n").splitlines():
+                line = line.strip().lstrip("-").strip()
+                if line:
+                    notes.append(line)
 
     if not args:
         print(__doc__)
@@ -235,7 +291,8 @@ def parse_args(argv):
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
 
-    return target, command, set_version, suffix, do_tag, do_push
+    return (target, command, set_version, suffix, do_tag, do_push,
+            notes, kind, no_notes)
 
 
 # ---------------------------------------------------------------------------
@@ -243,7 +300,24 @@ def parse_args(argv):
 # ---------------------------------------------------------------------------
 
 def main():
-    target_name, command, set_version, suffix, do_tag, do_push = parse_args(sys.argv)
+    (target_name, command, set_version, suffix, do_tag, do_push,
+     notes, kind, no_notes) = parse_args(sys.argv)
+
+    # Enforce --notes for any real bump (not `show`). --no-notes opts out.
+    if command != "show" and not notes and not no_notes:
+        print(
+            "Error: --notes \"summary\" is required.\n"
+            "  A changelog entry that just says 'Version bump' is useless —\n"
+            "  summarise what changed so future readers (and you) know why.\n\n"
+            "  Examples:\n"
+            "    --notes \"Post-capture edit form for vocab entries.\"\n"
+            "    --notes \"Fix: auto-fill no longer overwrites translations.\" --kind fixed\n"
+            "    --notes \"line one\" --notes \"line two\"         # two bullets\n"
+            "    --notes \"line one\\nline two\"                   # same, one arg\n\n"
+            "  For emergency bumps / tooling-only re-tags only, pass --no-notes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     cfg = TARGETS[target_name]
 
@@ -283,7 +357,7 @@ def main():
     print(f"  ✅  {cfg['version_file'].relative_to(PROJECT_ROOT)}")
 
     # Update changelog
-    changelog_updated = update_changelog(cfg, new_full)
+    changelog_updated = update_changelog(cfg, new_full, notes=notes, kind=kind)
     if changelog_updated:
         print(f"  ✅  {cfg['changelog_file'].relative_to(PROJECT_ROOT)}")
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.7.0-claude-dev"
+__version__ = "7.7.1-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.7.1-claude-dev"
+__version__ = "7.8.0-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/vocabulary_tab.py
+++ b/src/ui/vocabulary_tab.py
@@ -456,7 +456,20 @@ def render_vocabulary_tab():
         search = st.text_input(
             "Search (word or translation)",
             key="vocab_search",
-            placeholder="type to filter…",
+            placeholder="type to filter…   try: ^a    ção$    source:Pessoa    none:ipa",
+            help=(
+                "Plain text searches word + translation.\n\n"
+                "Operators (all AND, any order):\n"
+                "- `^a` → word starts with \"a\" or \"A\"\n"
+                "- `ção$` → word ends with \"ção\"\n"
+                "- `[a-c]+ão.*` → regex on word (advanced)\n"
+                "- `source:foo` → only in that field\n"
+                "- `source:\"Foo Bar\"` → quote values with spaces\n"
+                "- `has:url` / `none:ipa` → presence tests\n\n"
+                "Fields: word, translation, ipa, source, url, note, context.\n"
+                "Whitespace around `:` is fine (`has : url` works).\n"
+                "Only the first colon splits field from value, so URLs are safe."
+            ),
         )
 
     st.markdown("---")
@@ -464,9 +477,14 @@ def render_vocabulary_tab():
     _render_bulk_upload()
     st.markdown("---")
 
-    rows = vocab.list_vocab(
-        user_id=_user_id(), language=language, sort=sort, search=search
-    )
+    import vocab_search
+    try:
+        rows = vocab.list_vocab(
+            user_id=_user_id(), language=language, sort=sort, search=search
+        )
+    except vocab_search.QueryError as e:
+        st.warning(f"🔎 {e}")
+        rows = []
     _prune_stale_session_keys(rows)
 
     st.caption(f"**{len(rows)}** entr{'y' if len(rows) == 1 else 'ies'}")

--- a/src/vocab.py
+++ b/src/vocab.py
@@ -204,7 +204,9 @@ def list_vocab(
 
     sort: 'alpha' (default, by lookup key), 'recent' (last_seen_at DESC),
           'oldest' (first_seen_at ASC).
-    search: case-insensitive substring match over word OR translation.
+    search: mini-language query — plain text still means substring on word
+            OR translation. See src/vocab_search.py for the grammar.
+            Unknown fields, unterminated quotes, etc. raise QueryError.
     """
     order = {
         "alpha": "word ASC",
@@ -212,30 +214,29 @@ def list_vocab(
         "oldest": "first_seen_at ASC",
     }.get(sort, "word ASC")
 
+    # Build optional WHERE fragment from the query mini-language.
+    extra_sql = ""
+    extra_params: List[Any] = []
+    if search:
+        import vocab_search
+        clauses = vocab_search.parse_query(search)
+        if clauses:
+            where_sql, extra_params = vocab_search.build_where(clauses)
+            if where_sql:
+                extra_sql = " AND " + where_sql
+
     conn = app_mysql.get_connection()
     cur = conn.cursor(dictionary=True)
-    if search:
-        like = f"%{search.lower()}%"
-        cur.execute(
-            f"""
-            SELECT * FROM vocab_entries
-            WHERE user_id=%s AND language_code=%s
-              AND (LOWER(word) LIKE %s OR LOWER(COALESCE(translation,'')) LIKE %s)
-            ORDER BY {order}
-            LIMIT %s
-            """,
-            (user_id, language, like, like, limit),
-        )
-    else:
-        cur.execute(
-            f"""
-            SELECT * FROM vocab_entries
-            WHERE user_id=%s AND language_code=%s
-            ORDER BY {order}
-            LIMIT %s
-            """,
-            (user_id, language, limit),
-        )
+    cur.execute(
+        f"""
+        SELECT * FROM vocab_entries
+        WHERE user_id=%s AND language_code=%s
+          {extra_sql}
+        ORDER BY {order}
+        LIMIT %s
+        """,
+        [user_id, language, *extra_params, limit],
+    )
     rows = cur.fetchall()
     cur.close()
     return rows

--- a/src/vocab_search.py
+++ b/src/vocab_search.py
@@ -1,0 +1,298 @@
+"""
+Vocab search mini-language parser (v7.8.0+).
+
+A tiny query language for the personal vocabulary tracker. Plain text keeps
+doing what it has always done; operators are opt-in sugar.
+
+Grammar (informal)
+------------------
+    query       := clause ( WHITESPACE clause )*
+    clause      := present | field_clause | regex_clause | text_clause
+    present     := ("has" | "none") ":" field_name
+    field_clause:= field_name ":" value
+    regex_clause:= value-that-triggers-regex  (against `word`)
+    text_clause := value                       (substring on word + translation)
+
+Whitespace around `:` is collapsed so `has : url`, `has: url`, `has :url`
+all parse identically. Only the FIRST colon in a token separates field
+from value — the rest is part of the value (URLs keep working).
+Values may be double-quoted to include whitespace or operator chars.
+
+Regex trigger (conservative — ordinary punctuation never triggers):
+  - clause starts with `^`           → regex
+  - clause ends with unescaped `$`   → regex
+  - clause contains a `[...]` pair   → regex
+Anything else is plain substring.
+
+Valid fields: word / translation / ipa / source / url / note / context.
+For `has:` and `none:`, `word` is not allowed (always present). `context`
+matches any of the three context columns OR'd.
+
+All clauses AND together; clause order is irrelevant.
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional, Tuple
+
+
+# Public column aliases used in the query language and in UI messages.
+FIELDS = ("word", "translation", "ipa", "source", "url", "note", "context")
+# Subset that allows `has:` / `none:` — `word` is always present.
+PRESENCE_FIELDS = ("translation", "ipa", "source", "url", "note", "context")
+
+# Map user-facing field names to DB columns. `context` is special
+# (fans out to three columns); the SQL builder handles that.
+_FIELD_TO_COL: Dict[str, str] = {
+    "word": "word",
+    "translation": "translation",
+    "ipa": "ipa",
+    "source": "source_name",
+    "url": "url",
+    "note": "notes",
+    # "context" handled specially in SQL builder
+}
+
+# Regex-trigger characters — see module docstring.
+_REGEX_META = set("^$[]*+?|()\\")
+
+
+class QueryError(ValueError):
+    """Raised when the query string is malformed (bad field, bad quoting, ...)."""
+
+
+# ── tokenisation ────────────────────────────────────────────────────────────
+
+def _collapse_colon_whitespace(q: str) -> str:
+    """
+    Replace `\\s+:\\s*` or `\\s*:\\s+` with `:` — but only outside quotes.
+    Leaves zero-whitespace colons (URLs, timestamps) completely alone.
+    """
+    out: List[str] = []
+    i, n = 0, len(q)
+    in_quote = False
+    buf: List[str] = []
+    while i < n:
+        ch = q[i]
+        if ch == '"':
+            in_quote = not in_quote
+            buf.append(ch)
+            i += 1
+            continue
+        if in_quote:
+            buf.append(ch)
+            i += 1
+            continue
+        # Try to match `\s+:\s*` or `\s*:\s+` starting at i.
+        m = re.match(r"(\s+:\s*|\s*:\s+)", q[i:])
+        if m:
+            buf.append(":")
+            i += m.end()
+            continue
+        buf.append(ch)
+        i += 1
+    if in_quote:
+        raise QueryError("Unterminated quote in query")
+    out.append("".join(buf))
+    return "".join(out)
+
+
+def _split_tokens(q: str) -> List[str]:
+    """Whitespace-split, honouring double-quoted segments.
+
+    Inside quotes, whitespace is preserved. A quote that closes a token
+    strips the surrounding quotes. Unterminated quotes raise.
+    """
+    tokens: List[str] = []
+    buf: List[str] = []
+    in_quote = False
+    had_quote = False  # token contained quoted content (preserves empty tokens)
+
+    def flush():
+        if buf or had_quote:
+            tokens.append("".join(buf))
+        buf.clear()
+
+    i, n = 0, len(q)
+    while i < n:
+        ch = q[i]
+        if ch == '"':
+            in_quote = not in_quote
+            had_quote = True
+            i += 1
+            continue
+        if ch.isspace() and not in_quote:
+            flush()
+            had_quote = False
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    if in_quote:
+        raise QueryError("Unterminated quote in query")
+    flush()
+    return tokens
+
+
+# ── regex-trigger detection ─────────────────────────────────────────────────
+
+def _looks_like_regex(s: str) -> bool:
+    """Conservative: `^` at start, unescaped `$` at end, or `[...]` present."""
+    if not s:
+        return False
+    if s[0] == "^":
+        return True
+    # Unescaped `$` at end: preceding char (if any) is not a backslash,
+    # or is an even number of backslashes.
+    if s[-1] == "$":
+        # Count trailing backslashes before the final `$`.
+        j = len(s) - 2
+        backs = 0
+        while j >= 0 and s[j] == "\\":
+            backs += 1
+            j -= 1
+        if backs % 2 == 0:
+            return True
+    # `[...]` pair present (non-empty, in order). Use simple regex — a
+    # hand-written scan would flag `[` alone, which isn't what we want.
+    if re.search(r"\[[^\]]*\]", s):
+        return True
+    return False
+
+
+# ── clause parsing ──────────────────────────────────────────────────────────
+
+def _parse_clause(tok: str) -> Dict[str, object]:
+    """
+    Returns a dict of one of these shapes:
+      {"kind": "has",    "field": <field>}
+      {"kind": "none",   "field": <field>}
+      {"kind": "field",  "field": <field>, "value": <str>, "is_regex": bool}
+      {"kind": "word",   "value": <str>, "is_regex": True}       # ^foo / foo$ / [ab]
+      {"kind": "text",   "value": <str>}                          # plain
+    """
+    # First colon split (if any). Field name must be non-empty and match known
+    # operator / field names; otherwise treat the whole token as a value.
+    if ":" in tok:
+        head, _, rest = tok.partition(":")
+        head_lc = head.lower()
+        if head_lc in ("has", "none"):
+            field = rest.lower()
+            if not field:
+                raise QueryError(f"'{head_lc}:' requires a field name")
+            if field not in PRESENCE_FIELDS:
+                raise QueryError(
+                    f"'{head_lc}:{field}' — unknown field. "
+                    f"Try: {', '.join(PRESENCE_FIELDS)}"
+                )
+            return {"kind": head_lc, "field": field}
+        if head_lc in FIELDS:
+            if not rest:
+                raise QueryError(f"'{head_lc}:' requires a value")
+            return {
+                "kind": "field",
+                "field": head_lc,
+                "value": rest,
+                "is_regex": _looks_like_regex(rest),
+            }
+        # Unknown prefix with `:` — be strict so typos surface.
+        raise QueryError(
+            f"Unknown field '{head}'. "
+            f"Known: {', '.join(FIELDS)} | has:<field> | none:<field>"
+        )
+
+    # No colon. Plain text unless it triggers regex mode.
+    if _looks_like_regex(tok):
+        return {"kind": "word", "value": tok, "is_regex": True}
+    return {"kind": "text", "value": tok}
+
+
+def parse_query(q: str) -> List[Dict[str, object]]:
+    """Parse a query string into a list of AND-combined clauses.
+
+    Empty / whitespace-only input returns []. Raises QueryError on
+    syntactic issues (unknown field, unterminated quote, empty value).
+    """
+    if not q or not q.strip():
+        return []
+    normalised = _collapse_colon_whitespace(q.strip())
+    tokens = _split_tokens(normalised)
+    return [_parse_clause(tok) for tok in tokens if tok]
+
+
+# ── SQL builder ─────────────────────────────────────────────────────────────
+
+# Context fans out to these three columns.
+_CONTEXT_COLS = ("context_before", "context_line", "context_after")
+
+
+def build_where(clauses: List[Dict[str, object]]) -> Tuple[str, List[object]]:
+    """Convert parsed clauses into a `(where_sql, params)` pair.
+
+    Always AND-combined; returns ``("", [])`` for an empty clause list.
+    All column references are whitelisted (no interpolation of user data
+    into SQL); all values go through parameters.
+    """
+    if not clauses:
+        return "", []
+    parts: List[str] = []
+    params: List[object] = []
+
+    def _col(field: str) -> str:
+        # Only reached after validation in parse_query, so KeyError is a bug.
+        return _FIELD_TO_COL[field]
+
+    def _fanout_has_not_null(field: str, negate: bool = False) -> str:
+        """Build a (NOT) NULL+empty test across one or many columns."""
+        if field == "context":
+            cols = _CONTEXT_COLS
+        else:
+            cols = (_col(field),)
+        # "has" means ANY col is non-empty; "none" means ALL cols empty.
+        joiner = " OR " if not negate else " AND "
+        per_col = []
+        for c in cols:
+            if negate:
+                per_col.append(f"(NULLIF({c}, '') IS NULL)")
+            else:
+                per_col.append(f"(NULLIF({c}, '') IS NOT NULL)")
+        return "(" + joiner.join(per_col) + ")"
+
+    def _fanout_match(field: str, value: str, is_regex: bool) -> Tuple[str, List[object]]:
+        """Match `value` against one or (for context) three columns."""
+        cols = _CONTEXT_COLS if field == "context" else (_col(field),)
+        per_col: List[str] = []
+        pp: List[object] = []
+        for c in cols:
+            if is_regex:
+                per_col.append(f"(COALESCE({c}, '') REGEXP %s)")
+                pp.append(value)
+            else:
+                per_col.append(f"(LOWER(COALESCE({c}, '')) LIKE %s)")
+                pp.append(f"%{value.lower()}%")
+        return "(" + " OR ".join(per_col) + ")", pp
+
+    for cl in clauses:
+        kind = cl["kind"]
+        if kind == "has":
+            parts.append(_fanout_has_not_null(cl["field"]))         # type: ignore[arg-type]
+        elif kind == "none":
+            parts.append(_fanout_has_not_null(cl["field"], negate=True))  # type: ignore[arg-type]
+        elif kind == "field":
+            sql, pp = _fanout_match(cl["field"], cl["value"], cl["is_regex"])  # type: ignore[arg-type]
+            parts.append(sql)
+            params.extend(pp)
+        elif kind == "word":
+            parts.append("(word REGEXP %s)")
+            params.append(cl["value"])
+        elif kind == "text":
+            # Back-compat behaviour: substring match across word + translation.
+            parts.append(
+                "(LOWER(word) LIKE %s OR LOWER(COALESCE(translation,'')) LIKE %s)"
+            )
+            like = f"%{str(cl['value']).lower()}%"
+            params.extend([like, like])
+        else:  # pragma: no cover — defensive
+            raise QueryError(f"Internal: unhandled clause kind {kind!r}")
+
+    return " AND ".join(parts), params

--- a/tests/integration/test_vocab.py
+++ b/tests/integration/test_vocab.py
@@ -351,6 +351,132 @@ def test_autofill_noop_when_enrich_returns_none(db_conn, make_user, monkeypatch)
     assert row["ipa"] is None
 
 
+# ── search mini-language (v7.8.0) ──────────────────────────────────────────
+
+def _capture(user_id, word, language="Portuguese", **kw):
+    import vocab
+    r = vocab.capture_vocab_entry(
+        user_id=user_id, language=language, word=word, **kw
+    )
+    assert r["ok"], r
+    return r["vocab_id"]
+
+
+@pytest.fixture
+def vocab_corpus(db_conn, make_user):
+    """Seed a user with a small, diverse corpus for search tests."""
+    import vocab
+    u = make_user(username="vocab_search_user")
+    uid = u["user_id"]
+    _capture(uid, "abelha", translation="bee", ipa="aˈβe.ʎɐ",
+             source_name="Apiology 101")
+    _capture(uid, "ação", translation="action", ipa="aˈsɐ̃w",
+             source_name="Notícias")
+    _capture(uid, "canção", translation="song",
+             source_name="Pessoa: Canção")
+    _capture(uid, "mar", translation="sea", ipa="ˈmaɾ",
+             url="https://example.com/mar")  # no source
+    _capture(uid, "sol", translation="sun",
+             source_name="Lesson 1")  # no ipa, no url
+    _capture(uid, "zebra", source_name="Zoo")  # no translation, no ipa
+    return u
+
+
+def test_search_prefix_anchor(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese", search="^a")}
+    assert hits == {"abelha", "ação"}
+
+
+def test_search_suffix_anchor(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese", search="ção$")}
+    assert hits == {"ação", "canção"}
+
+
+def test_search_bracket_regex(vocab_corpus):
+    import vocab
+    # [aeiou]ção → vowel immediately before 'ção'.
+    # ação matches (a+ção); canção does NOT (n+ção) — exactly what a class is for.
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="[aeiou]ção")}
+    assert hits == {"ação"}
+
+    # And a broader class to prove the operator itself works over multiple words.
+    hits2 = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="^[az]")}
+    assert hits2 == {"abelha", "ação", "zebra"}
+
+
+def test_search_field_substring(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="source:Pessoa")}
+    assert hits == {"canção"}
+
+
+def test_search_field_regex(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="source:^Lesson")}
+    assert hits == {"sol"}
+
+
+def test_search_has_url(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="has:url")}
+    assert hits == {"mar"}
+
+
+def test_search_none_ipa(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="none:ipa")}
+    assert hits == {"sol", "zebra", "canção"}
+
+
+def test_search_combined_AND(vocab_corpus):
+    import vocab
+    # ^a AND has:ipa → abelha, ação
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="^a has:ipa")}
+    assert hits == {"abelha", "ação"}
+
+
+def test_search_plain_text_backcompat(vocab_corpus):
+    import vocab
+    # Plain text still matches word OR translation substring.
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese", search="sea")}
+    assert hits == {"mar"}  # 'sea' is mar's translation
+
+
+def test_search_whitespace_around_colon(vocab_corpus):
+    import vocab
+    hits = {r["word"] for r in vocab.list_vocab(
+        user_id=vocab_corpus["user_id"], language="Portuguese",
+        search="has : url")}
+    assert hits == {"mar"}
+
+
+def test_search_unknown_field_raises(vocab_corpus):
+    import vocab, vocab_search
+    with pytest.raises(vocab_search.QueryError):
+        vocab.list_vocab(
+            user_id=vocab_corpus["user_id"], language="Portuguese",
+            search="bogus:x")
+
+
 def test_vocab_as_practice_phrases_shape(db_conn, make_user):
     import vocab
 

--- a/tests/test_vocab_search.py
+++ b/tests/test_vocab_search.py
@@ -1,0 +1,272 @@
+"""
+Unit tests for the vocab search mini-language parser (src/vocab_search.py).
+
+No DB here — the SQL builder is exercised in integration tests. These tests
+cover tokenisation, clause parsing, regex-trigger detection, whitespace-
+around-colon, quoting, and error cases.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vocab_search import (
+    QueryError,
+    _collapse_colon_whitespace,
+    _looks_like_regex,
+    _split_tokens,
+    build_where,
+    parse_query,
+)
+
+
+# ── regex trigger detection ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("s, expected", [
+    ("sea",        False),  # plain
+    ("saudade?",   False),  # trailing ? alone doesn't trigger
+    ("see (it)",   False),  # () alone doesn't trigger
+    ("foo*bar",    False),  # * alone doesn't trigger
+    ("price $5",   False),  # $ not at end
+    ("e.g.",       False),  # . alone doesn't trigger
+    ("l'amour",    False),
+    ("well-being", False),
+    ("^a",         True),   # prefix anchor
+    ("ção$",       True),   # suffix anchor
+    (r"foo\$",     False),  # escaped $ at end
+    (r"foo\\$",    True),   # even backslashes → $ is unescaped
+    ("[aeiou]",    True),   # bracket class
+    ("[a-c]+ão.*", True),   # mixed: bracket present → regex mode
+    ("^[aeiou].*r$", True), # all three triggers
+])
+def test_looks_like_regex(s, expected):
+    assert _looks_like_regex(s) is expected
+
+
+# ── tokenisation & quote handling ──────────────────────────────────────────
+
+def test_split_tokens_plain():
+    assert _split_tokens("one two three") == ["one", "two", "three"]
+
+
+def test_split_tokens_quoted_preserves_space():
+    assert _split_tokens('a "b c" d') == ["a", "b c", "d"]
+
+
+def test_split_tokens_quoted_with_operator_char():
+    assert _split_tokens('source:"Pessoa: Auto"') == ['source:Pessoa: Auto']
+
+
+def test_split_tokens_unterminated_raises():
+    with pytest.raises(QueryError, match="Unterminated"):
+        _split_tokens('"still open')
+
+
+def test_collapse_colon_whitespace_forms():
+    # All four user-listed forms collapse to the same.
+    for variant in ["has:context", "has : context", "has: context", "has :context"]:
+        assert _collapse_colon_whitespace(variant) == "has:context"
+
+
+def test_collapse_ignores_zero_space_colons():
+    # URLs and timestamps — no whitespace around `:` — stay intact.
+    assert _collapse_colon_whitespace("url:https://ex.com/a:b") == "url:https://ex.com/a:b"
+
+
+def test_collapse_respects_quotes():
+    # A colon between spaces inside a quoted string is NOT collapsed.
+    q = 'source:"Pessoa : Autopsicografia"'
+    assert _collapse_colon_whitespace(q) == q
+
+
+# ── parse_query — happy paths ──────────────────────────────────────────────
+
+def test_empty_query_yields_no_clauses():
+    assert parse_query("") == []
+    assert parse_query("   ") == []
+
+
+def test_plain_text_clause():
+    assert parse_query("sea") == [{"kind": "text", "value": "sea"}]
+
+
+def test_prefix_and_suffix_anchors_are_word_regex():
+    assert parse_query("^a") == [
+        {"kind": "word", "value": "^a", "is_regex": True}
+    ]
+    assert parse_query("ção$") == [
+        {"kind": "word", "value": "ção$", "is_regex": True}
+    ]
+
+
+def test_bracket_class_is_word_regex():
+    assert parse_query("[a-c]+ão.*") == [
+        {"kind": "word", "value": "[a-c]+ão.*", "is_regex": True}
+    ]
+
+
+def test_field_clause_plain_value():
+    assert parse_query("source:Pessoa") == [{
+        "kind": "field", "field": "source", "value": "Pessoa", "is_regex": False,
+    }]
+
+
+def test_field_clause_regex_value():
+    assert parse_query("source:^Pess") == [{
+        "kind": "field", "field": "source", "value": "^Pess", "is_regex": True,
+    }]
+
+
+def test_field_clause_only_first_colon_splits():
+    # URL value contains further colons — they must stay in the value.
+    assert parse_query("url:https://ex.com/a:b") == [{
+        "kind": "field", "field": "url",
+        "value": "https://ex.com/a:b", "is_regex": False,
+    }]
+
+
+def test_has_and_none():
+    assert parse_query("has:url none:ipa") == [
+        {"kind": "has", "field": "url"},
+        {"kind": "none", "field": "ipa"},
+    ]
+
+
+def test_whitespace_around_colon_all_four_forms():
+    for q in ["has:url", "has : url", "has: url", "has :url"]:
+        assert parse_query(q) == [{"kind": "has", "field": "url"}]
+
+
+def test_combination_any_order():
+    # All three examples the user asked about.
+    a = parse_query("^s o$")
+    b = parse_query("has:url ^b")
+    c = parse_query("source:^a")
+    assert len(a) == 2 and all(cl["kind"] == "word" for cl in a)
+    assert b == [
+        {"kind": "has", "field": "url"},
+        {"kind": "word", "value": "^b", "is_regex": True},
+    ]
+    assert c == [{
+        "kind": "field", "field": "source", "value": "^a", "is_regex": True,
+    }]
+
+
+def test_quoted_value_preserves_spaces():
+    assert parse_query('source:"Pessoa: Auto"') == [{
+        "kind": "field", "field": "source",
+        "value": "Pessoa: Auto", "is_regex": False,
+    }]
+
+
+# ── parse_query — error paths ──────────────────────────────────────────────
+
+def test_unknown_field_raises():
+    with pytest.raises(QueryError, match="Unknown field"):
+        parse_query("bogus:x")
+
+
+def test_has_unknown_field_raises():
+    with pytest.raises(QueryError, match="unknown field"):
+        parse_query("has:bogus")
+
+
+def test_has_without_field_raises():
+    with pytest.raises(QueryError, match="requires a field name"):
+        parse_query("has:")
+
+
+def test_field_without_value_raises():
+    with pytest.raises(QueryError, match="requires a value"):
+        parse_query("source:")
+
+
+def test_unterminated_quote_raises():
+    with pytest.raises(QueryError, match="Unterminated"):
+        parse_query('source:"still open')
+
+
+# ── SQL builder (structural only — no DB) ──────────────────────────────────
+
+def test_build_where_empty():
+    assert build_where([]) == ("", [])
+
+
+def test_build_where_plain_text_uses_like_on_word_and_translation():
+    clauses = parse_query("sea")
+    sql, params = build_where(clauses)
+    assert "word) LIKE" in sql and "translation" in sql
+    assert params == ["%sea%", "%sea%"]
+
+
+def test_build_where_word_regex_uses_regexp():
+    clauses = parse_query("^a")
+    sql, params = build_where(clauses)
+    assert "word REGEXP" in sql
+    assert params == ["^a"]
+
+
+def test_build_where_field_substring_uses_like_on_correct_col():
+    clauses = parse_query("source:Pessoa")
+    sql, params = build_where(clauses)
+    assert "source_name" in sql and "LIKE" in sql
+    assert params == ["%pessoa%"]
+
+
+def test_build_where_field_regex_uses_regexp_on_correct_col():
+    clauses = parse_query("source:^Pess")
+    sql, params = build_where(clauses)
+    assert "source_name" in sql and "REGEXP" in sql
+    assert params == ["^Pess"]
+
+
+def test_build_where_context_fans_out_to_three_cols():
+    clauses = parse_query("context:foo")
+    sql, params = build_where(clauses)
+    assert "context_before" in sql
+    assert "context_line" in sql
+    assert "context_after" in sql
+    # OR'd together
+    assert sql.count("OR") >= 2
+    assert params == ["%foo%", "%foo%", "%foo%"]
+
+
+def test_build_where_has_uses_nullif_not_null():
+    clauses = parse_query("has:url")
+    sql, _ = build_where(clauses)
+    assert "NULLIF(url, '') IS NOT NULL" in sql
+
+
+def test_build_where_none_uses_nullif_is_null():
+    clauses = parse_query("none:ipa")
+    sql, _ = build_where(clauses)
+    assert "NULLIF(ipa, '') IS NULL" in sql
+
+
+def test_build_where_and_joins_clauses():
+    clauses = parse_query("^a has:url source:Pessoa")
+    sql, params = build_where(clauses)
+    # All three fragments present, AND-joined.
+    assert sql.count(" AND ") == 2
+    assert "word REGEXP" in sql
+    assert "url" in sql
+    assert "source_name" in sql
+    # Regex params are not %-wrapped; substring params are.
+    assert "^a" in params
+    assert "%pessoa%" in params
+
+
+# ── Design-level note (executable documentation) ───────────────────────────
+
+def test_presence_plus_field_match_equivalence_notes():
+    """
+    The user observed:
+      - `has:X X:foo`  ≡  `X:foo`        (any match implies non-empty)
+      - `none:X X:foo` ≡  ∅              (can't both be empty and match)
+    We still accept both forms — the parser doesn't collapse them, so the
+    "obvious" query works, and the pathological one just costs an extra
+    ANDed predicate. Left documented so a future reader doesn't 'optimise'
+    the parser and break user expectations.
+    """
+    # These just need to parse cleanly — no structural assertion.
+    parse_query("has:source source:Pessoa")
+    parse_query("none:source source:Pessoa")


### PR DESCRIPTION
## Summary

- a35d944 v7.8.0-claude-dev: version bump
- db9b9fa feat(vocab): search mini-language — prefix/suffix/regex/field/presence
- 7d49963 v7.7.1-claude-dev: version bump
- 089cf29 chore(scripts): require --notes for bump_version.py + backfill recent entries

## Test plan
- [x] App starts without import errors
- [x] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)