### PR TITLE
docs: AGENTS.md canonical, CLAUDE.md operational-only (v7.8.2-claude-dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ language_materials/
 
 ---
 
-## Key Configuration
+## Key Configuration & Reference Files
 
 | File | Purpose |
 |------|---------|
@@ -169,6 +169,9 @@ language_materials/
 | `config/.miolingo.config` | App-specific configuration |
 | `requirements.txt` | Python dependencies |
 | `docker-compose.yml` | Container deployment (port 8601) |
+| `docs/TESTING_CHECKLIST.md` | Structured manual UI test checklist (used during testing sessions) |
+| `.github/ISSUE_TEMPLATE/bug_report.md` | GitHub issue template for bug reports |
+| `APP_CHANGELOG.md` | Version history — updated by `scripts/bump_version.py` |
 
 ---
 

--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,13 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.8.2-claude-dev] - 2026-04-22
+
+### Changed
+
+- docs: make AGENTS.md the canonical project reference; slim CLAUDE.md to Claude-operational content only (git recipe, venv, testing protocol)
+
+
 ## [7.8.1-claude-dev] - 2026-04-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # Miolingo — Claude Code Instructions
 
+> **Project architecture, DB rules, module map, known issues, debug mode, and
+> app layout are in [`AGENTS.md`](AGENTS.md) — read that first.**
+> `AGENTS.md` is the canonical project reference; if `CLAUDE.md` and `AGENTS.md`
+> ever conflict, `AGENTS.md` wins.
+
 > **Before doing anything that touches scripts, versioning, or PRs:**
 > read **[docs/dev-docs/SCRIPTS_WORKFLOW.md](docs/dev-docs/SCRIPTS_WORKFLOW.md)**.
 > It is the single source of truth for the end-to-end workflow and a reference
@@ -7,6 +12,8 @@
 > document first — the scripts used to have bugs that forced workarounds, and
 > new agents have repeatedly relearned the workflow from scratch. Don't be the
 > next one: read the doc, and if you fix a script, update the doc.
+
+---
 
 ## Git Workflow — PR Branches (read before any `git push`)
 
@@ -61,41 +68,20 @@ The venv holds all installed packages — running outside it means those package
 
 ---
 
-## Project Overview
-Streamlit pronunciation trainer for Portuguese, French, Dutch, Flemish and other languages.
-- **Main app:** `src/app.py` (~4000 lines), runs at `localhost:8501`
-- **Admin:** `localhost:8505`
-- **Stack:** Streamlit 1.39+, OpenAI Whisper (ASR), Google Cloud TTS / eSpeak NG / gTTS, MySQL over SSH tunnel, Argon2 auth
-
-## CRITICAL: Database Connection Rule
-**Never create new DB tunnels or connections.** Always reuse the session connection via `app_mysql.get_connection()`. Creating new tunnels exhausts server resources (past production outage). One tunnel per session, always.
-
-```python
-# ✅ CORRECT
-conn = app_mysql.get_connection()
-
-# ❌ WRONG — never do this
-new_conn = mysql.connector.connect(...)
-new_tunnel = SSHTunnelForwarder(...)
-```
-
 ## Current Debug Mode
+
 The app is running in active debug mode. The following are **intentional** — do not report as new bugs:
 - `Missing cookie_password in st.secrets` warning banner
 - State-change banners (e.g. "State changed: story_mode: None → Scene by Scene")
 - Connection Info panel showing tunnel details, SQL connection string, MySQL ID — this is for developer/tester use
 
-## Known Issues (already tracked — do not duplicate)
-- Statistics tab: charts/breakdowns not yet implemented (missing feature, not regression)
-- Scene title encoding: accented characters stripped in dropdown/heading (Streamlit limitation under investigation)
-- Scoring/ASR accuracy: needs full refactor, not a simple fix
-- Input red border: default Streamlit behaviour on touched fields, may be configurable
-
 ---
 
 ## Testing Protocol
 
-When asked to test the app, follow this standard approach:
+When asked to test the app, follow this standard approach.
+
+Use `docs/TESTING_CHECKLIST.md` as a structured guide.
 
 ### Classification
 Every issue must have **both**:
@@ -136,45 +122,7 @@ Cover **all** of the following before writing up:
 - Sidebar: language settings, TTS engine, slow speech, Scoring Algorithm, Audio Processing, CCS Testing, Connection Info
 - Within each tab: every expander, every sub-mode, at least one complete primary action
 
-**Widget State Rule:** For every interactive widget encountered (toggle, checkbox, radio button, dropdown, selector), test **all** states — not just the default. Binary widgets: test both on and off. Multi-value selectors: test at least one non-default value. An untested state is an untested feature. This is the browser-test equivalent of ISTQB State Transition Testing, and is what the CCS framework's port matching is built to catch.
+**Widget State Rule:** For every interactive widget encountered (toggle, checkbox, radio button, dropdown, selector), test **all** states — not just the default. Binary widgets: test both on and off. Multi-value selectors: test at least one non-default value. An untested state is an untested feature.
 
 ### Interleaving
 Claude may (and should) pause to ask the user to log in, record audio, or perform any action requiring human input. This is expected and collaborative — not an error.
-
-Use `docs/TESTING_CHECKLIST.md` as a structured guide.
-
----
-
-## app.py Layout (line ranges)
-
-See `AGENTS.md` for the full module map. Quick reference for the main file:
-
-```
-  1–130     Imports (config, scoring, audio, translation modules), PATH fix, lib preload
-131–550     Settings wrappers, translation/IPA utilities, material enrichment
-551–1050    Announcements, authentication, login, role checks
-1050–1220   History, session state init
-1220–1280   Extracted-module comments + practice_word_from_audio wrapper
-1280–1700   Practice flow, UI rendering (interface + results)
-1700–2050   Story practice and story reader
-2050–2808   main(): sidebar, tab routing, entry point
-```
-
-Extracted modules (Phase 1 + Phase 2):
-- `src/config.py` — constants, LANGUAGE_CONFIG, settings
-- `src/scoring/comparison.py` — Levenshtein, phoneme comparison
-- `src/scoring/phonemes.py` — IPA/phoneme extraction via espeak
-- `src/scoring/practice.py` — practice pipeline: silence trim, ASR, scoring
-- `src/audio/tts.py` — TTS engines (eSpeak, Google Cloud, gTTS) + fallback
-- `src/audio/asr.py` — ASR (Whisper, Wav2Vec2) + model loaders
-- `src/translation.py` — translation providers + LLM translation
-
-## Key Files
-- `AGENTS.md` — canonical project reference for all AI assistants
-- `src/app.py` — main Streamlit app
-- `src/app_mysql.py` — MySQL DB module (use `get_connection()`)
-- `src/ccs_test_framework.py` — CCS dual-agent test framework (available for structured testing)
-- `docs/TESTING_CHECKLIST.md` — structured UI test checklist
-- `.github/ISSUE_TEMPLATE/bug_report.md` — GitHub issue template
-- `.streamlit/config.toml` — Streamlit theme and server config
-- `APP_CHANGELOG.md` — version history

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.8.1-claude-dev"
+__version__ = "7.8.2-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Summary

- 219b8c2 v7.8.2-claude-dev: version bump
- b1058c4 docs: make AGENTS.md canonical; slim CLAUDE.md to operational content

## Test plan
- [ ] App starts without import errors
- [ ] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)