### PR TITLE
docs: audience banners + cross-doc links in GOLDEN and SCRIPTS_WORKFLOW (v7.8.3-claude-dev)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,13 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.8.3-claude-dev] - 2026-04-22
+
+### Changed
+
+- docs: strengthen GOLDEN.md audience banner and cross-doc links; add SCRIPTS_WORKFLOW.md back-link to GOLDEN
+
+
 ## [7.8.2-claude-dev] - 2026-04-22
 
 ### Changed

--- a/docs/dev-docs/GOLDEN.md
+++ b/docs/dev-docs/GOLDEN.md
@@ -1,10 +1,13 @@
 # GOLDEN.md — How Matthew and Claude Work Together
 
-**Audience:** Matthew (after a pause) and any future Claude session picking up
-the project. This is the human-readable contract; `SCRIPTS_WORKFLOW.md` is the
-mechanical recipe.
+**Audience: Matthew.** This is the human-readable overview of how we work
+together. Claude: read this for context if you want, but **do not edit it** —
+your operational docs are [`CLAUDE.md`](../../CLAUDE.md) (git recipe, venv,
+testing protocol) and [`AGENTS.md`](../../AGENTS.md) (project architecture,
+module map, DB rules). The mechanical script recipe is in
+[`SCRIPTS_WORKFLOW.md`](SCRIPTS_WORKFLOW.md).
 
-Last revised: 2026-04-21 (end of v7.8.0 session).
+Last revised: 2026-04-22 (v7.8.2 docs-refactor session).
 
 ---
 
@@ -53,7 +56,7 @@ Everything lands via a PR that Matthew merges.
 
 ## The golden path — every change, start to finish
 
-Canonical mechanics live in `SCRIPTS_WORKFLOW.md`. Summary:
+Canonical mechanics live in [`SCRIPTS_WORKFLOW.md`](SCRIPTS_WORKFLOW.md). Summary:
 
 1. **Branch** from `origin/claude/dev-swept` inside a fresh linked worktree.
 2. **Code + tests**, using `venv/bin/python` directly (the main clone's venv;
@@ -169,9 +172,16 @@ delete.
 ## Out of scope for this document
 
 - Product roadmap and feature priorities — those live in
-  `docs/dev-docs/ROADMAP.md` and the various `project_*.md` memory entries.
-- How to actually use the app as an end user — `docs/app-docs/USER_GUIDE.md`.
-- Detailed script flag reference — `docs/dev-docs/SCRIPTS_WORKFLOW.md`.
+  [`docs/dev-docs/ROADMAP2026.md`](ROADMAP2026.md) and the various
+  `project_*.md` memory entries.
+- How to actually use the app as an end user —
+  [`docs/app-docs/USER_GUIDE.md`](../app-docs/USER_GUIDE.md).
+- Detailed script flag reference —
+  [`docs/dev-docs/SCRIPTS_WORKFLOW.md`](SCRIPTS_WORKFLOW.md).
+- Project architecture, module map, DB rules —
+  [`AGENTS.md`](../../AGENTS.md).
+- Claude's git/venv/testing rules —
+  [`CLAUDE.md`](../../CLAUDE.md).
 
 ---
 

--- a/docs/dev-docs/SCRIPTS_WORKFLOW.md
+++ b/docs/dev-docs/SCRIPTS_WORKFLOW.md
@@ -2,7 +2,9 @@
 
 Single source of truth for the Miolingo dev scripts and the end-to-end workflow for landing changes. **Follow this exactly** — deviations have cost multiple sessions' worth of confusion. If you find the scripts don't match this document, the scripts are wrong: fix them and update this page.
 
-Audience: AI assistants (Claude Code, other models) and humans continuing work between sessions.
+**Audience: Claude (and humans continuing work between sessions).** For the
+human-readable overview of the Matthew↔Claude collaboration contract, see
+[`GOLDEN.md`](GOLDEN.md).
 
 Last verified: 2026-04-20 with `scripts/create-pr.sh` v2 (post-bug-fix commit).
 
@@ -197,7 +199,8 @@ Port convention (memorise):
 
 ## Pointers to related docs
 
-- `CLAUDE.md` — project-root file, the entry point for any AI assistant. Contains the Git-Workflow rules that should match this document. If they diverge, update both.
-- `AGENTS.md` — canonical module map and architecture notes.
-- `docs/TESTING_CHECKLIST.md` — structured manual UI test.
+- [`CLAUDE.md`](../../CLAUDE.md) — Claude's operational rules: git recipe, venv, testing protocol. Contains the Git-Workflow rules that should match this document. If they diverge, update both.
+- [`AGENTS.md`](../../AGENTS.md) — canonical project reference: module map, architecture, DB rules, known issues.
+- [`GOLDEN.md`](GOLDEN.md) — human-readable collaboration contract (Matthew's doc; read-only for Claude).
+- [`docs/TESTING_CHECKLIST.md`](../TESTING_CHECKLIST.md) — structured manual UI test checklist.
 - `~/.claude/projects/<project>/memory/MEMORY.md` — cross-session memory index. This document should be linked there (entry: `scripts_workflow.md`).

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.8.2-claude-dev"
+__version__ = "7.8.3-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Summary

- 48bc5af v7.8.3-claude-dev: version bump
- 695b04d docs: add audience banners and explicit cross-doc links to GOLDEN + SCRIPTS_WORKFLOW

## Test plan
- [x] App starts without import errors
- [x] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)