### PR TITLE
Fix oversized font in Items/Translations/IPA stat row (Quick Practice)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,13 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.8.4-claude-dev] - 2026-04-22
+
+### Changed
+
+- Replace st.metric() with st.caption() for Items/Translations/IPA stat row in Quick Practice — metric rendered values in oversized heading font, wasting screen space
+
+
 ## [7.8.3-claude-dev] - 2026-04-22
 
 ### Changed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.8.3-claude-dev"
+__version__ = "7.8.4-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/quick_practice_tab.py
+++ b/src/ui/quick_practice_tab.py
@@ -161,11 +161,11 @@ def _render_builtin_materials(get_available_languages, get_language_structure,
 
     col1, col2, col3 = st.columns(3)
     with col1:
-        st.metric("Items", metadata.get('line_count', 0))
+        st.caption(f"**Items:** {metadata.get('line_count', 0)}")
     with col2:
-        st.metric("Translations", "✓" if metadata.get('has_translations') else "✗")
+        st.caption(f"**Translations:** {'✓' if metadata.get('has_translations') else '✗'}")
     with col3:
-        st.metric("IPA", "✓" if metadata.get('has_ipa') else "✗")
+        st.caption(f"**IPA:** {'✓' if metadata.get('has_ipa') else '✗'}")
 
     if metadata.get('preview'):
         with st.expander("Preview first 3 items"):
@@ -341,11 +341,11 @@ def _render_upload_materials(format_language_name):
 
         col1, col2, col3 = st.columns(3)
         with col1:
-            st.metric("Phrases", len(phrases))
+            st.caption(f"**Phrases:** {len(phrases)}")
         with col2:
-            st.metric("Translations", "✓" if has_translations else "✗")
+            st.caption(f"**Translations:** {'✓' if has_translations else '✗'}")
         with col3:
-            st.metric("IPA", "✓" if has_ipa else "✗")
+            st.caption(f"**IPA:** {'✓' if has_ipa else '✗'}")
 
         if st.session_state.get(f"{upload_key}_saved"):
             st.success("💾 Saved to server - showing saved version")


### PR DESCRIPTION
## Summary

- Replace `st.metric()` with `st.caption()` in Quick Practice tab for the Items / Translations / IPA metadata row
- `st.metric` rendered values in a large heading-style font, wasting vertical screen space
- `st.caption` gives compact, label-appropriate sizing consistent with the surrounding UI
- Applied in both the **Built-in Library** section and the **Upload File** section

## Test plan

- [x] Quick Practice → Built-in Library: select any file — Items / Translations / IPA row shows in compact caption font, not large heading font
- [x] Quick Practice → Upload File: upload a pipe-delimited file — Phrases / Translations / IPA row shows in compact caption font
- [x] Bold labels (`**Items:**` etc.) render correctly within caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)