### PR TITLE
feat(ipa): 'About IPA' sidebar expander (v7.8.19-claude-dev)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,13 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.8.19-claude-dev] - 2026-04-25
+
+### Added
+
+- Sidebar Help & Docs: 'About IPA' expander renders the user-facing IPA primer (docs/app-docs/IPA_PRIMER.md) inline — first integration step of the IPA-learning rollout.
+
+
 ## [7.8.18-claude-dev] - 2026-04-25
 
 ### Changed

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.8.18-claude-dev"
+__version__ = "7.8.19-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -446,6 +446,10 @@ def render_settings_panel():
         # ── Help & Docs ──────────────────────────────────────────────────────
         st.markdown("---")
         st.header("📚 Help & Docs")
+
+        with st.expander("📖 About IPA — read the brackets next to every word", expanded=False):
+            _render_ipa_primer()
+
         st.markdown("""
         **📖 Guides:**
         - [User Guide](https://github.com/fairflow/miolingo/blob/feature/admin-fusion/docs/app-docs/USER_GUIDE.md) - How to use the app
@@ -463,6 +467,31 @@ def render_settings_panel():
         - Email: io@miolingo.io
         - Discord: [Coming soon]
         """)
+
+
+def _render_ipa_primer():
+    """Render the local IPA primer inside the sidebar expander.
+
+    Reads ``docs/app-docs/IPA_PRIMER.md`` and shows it via
+    ``st.markdown``. The primer is the canonical user-facing
+    explanation of the bracketed transcriptions shown across the app
+    (Quick Practice, Story Reader, vocabulary). Falling back to a
+    short message if the file is missing keeps the expander useful
+    in stripped-down deployments.
+    """
+    from pathlib import Path
+
+    primer_path = Path(__file__).resolve().parent.parent.parent / "docs" / "app-docs" / "IPA_PRIMER.md"
+    try:
+        text = primer_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        st.info(
+            "IPA primer not found in this deployment. See "
+            "[`docs/app-docs/IPA_PRIMER.md`](https://github.com/fairflow/miolingo/blob/feature/admin-fusion/docs/app-docs/IPA_PRIMER.md) "
+            "in the repo."
+        )
+        return
+    st.markdown(text)
 
 
 def _render_story_link(lang_code: str):


### PR DESCRIPTION
## Summary
- IPA rollout **step 3** (per `docs/dev-docs/IPA_LEARNING_DESIGN.md` §6).
- Adds an `📖 About IPA` expander at the top of the sidebar **Help & Docs** section that renders `docs/app-docs/IPA_PRIMER.md` inline. Default-collapsed, no clutter.
- Falls back to a GitHub link if the primer file is missing (stripped-down deployments).
- ~30 LOC; no new deps, no DB changes.

## Stack
Branched off **PR #105 (Stage 2 sidebar-ownership hardening)** — base is `claude/sidebar-ownership-stage1`. GitHub will auto-retarget at `claude/dev-swept` when #105 merges.

## Test plan
- [ ] Sidebar shows the expander under Help & Docs
- [ ] Expanding it renders the primer (target-language tables visible)
- [ ] No regression in `pytest tests/ --ignore=tests/integration -q` (224 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)