### PR TITLE
fix(materials): header line no longer appears as practice phrase (v7.9.3-claude-dev)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,13 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.9.3-claude-dev] - 2026-04-25
+
+### Fixed
+
+- Language-pair header line (e.g. (pt, en)) no longer appears as a practice phrase when loading built-in or uploaded phrase files
+
+
 ## [7.9.1] - 2026-04-25
 
 ### Changed

--- a/scripts/pr-config.env
+++ b/scripts/pr-config.env
@@ -1,3 +1,3 @@
 # PR target branch configuration.
 # Update this when the target changes (e.g. after claude/dev-swept is merged into claude/dev).
-CLAUDE_BRANCH_TARGET=claude/dev-swept
+CLAUDE_BRANCH_TARGET=claude/dev-minimal-pairs

--- a/src/app_language_materials.py
+++ b/src/app_language_materials.py
@@ -431,11 +431,13 @@ def load_phrase_file(file_path_str: str) -> List[Dict]:
     
     phrases = []
     for line in content.split('\n'):
-        line = line.strip()
-        
-        # Skip comments and empty lines
-        if not line or line.startswith('#'):
+        stripped = line.strip()
+
+        # Skip comments, empty lines, and the (source, target) language-pair
+        # header — it is metadata, not a practice phrase.
+        if not stripped or stripped.startswith('#') or is_header_line(stripped):
             continue
+        line = stripped
         
         # Parse format: "phrase | translation | [ipa]"
         if '|' in line:

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.9.2"
+__version__ = "7.9.3-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"

--- a/src/ui/quick_practice_tab.py
+++ b/src/ui/quick_practice_tab.py
@@ -20,6 +20,7 @@ from scoring.phonemes import format_ipa, get_ipa_from_espeak
 from translation import get_translation_from_llm
 from translation import enrich_material_file
 from config import get_language_code
+from import_header import is_header_line
 from ui.practice_tab import render_practice_interface, render_practice_results
 from ui.sidebar import is_debug
 
@@ -475,7 +476,10 @@ def _render_upload_materials(format_language_name):
         else:
             content = st.session_state[upload_key]
 
-        raw_lines = [line.strip() for line in content.split('\n') if line.strip() and not line.strip().startswith('#')]
+        raw_lines = [
+            s for line in content.split('\n')
+            if (s := line.strip()) and not s.startswith('#') and not is_header_line(s)
+        ]
 
         if len(raw_lines) > MAX_UPLOAD_LINES:
             st.error(f"❌ File too large: {len(raw_lines)} lines (max {MAX_UPLOAD_LINES})")


### PR DESCRIPTION
## Summary

- bd3b6ec v7.9.3-claude-dev: version bump
- 6900858 fix(materials): skip language-pair header line when loading phrases for practice

## Test plan
- [x] App starts without import errors
- [x] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)