### PR TITLE
fix(materials): correct en/words dictionary headers (pt, en) (v7.9.5-claude-dev)

### DIFF
--- a/APP_CHANGELOG.md
+++ b/APP_CHANGELOG.md
@@ -10,6 +10,13 @@ required for any non-tooling bump so the log captures *what* changed, not
 just that something changed.
 
 
+## [7.9.5-claude-dev] - 2026-04-25
+
+### Fixed
+
+- English dictionary files (en/words): corrected header from (en, pt) to (pt, en) — source/target were swapped
+
+
 ## [7.9.4-claude-dev] - 2026-04-25
 
 ### Added

--- a/language_materials/en/words/dictionary1.txt
+++ b/language_materials/en/words/dictionary1.txt
@@ -1,4 +1,4 @@
-(en, pt)
+(pt, en)
 a | uma | [ˈeɪ]
 abandoned | abandonada | [ɐbˈandənd]
 about | cerca | [ɐbˈaʊt]

--- a/language_materials/en/words/dictionary2.txt
+++ b/language_materials/en/words/dictionary2.txt
@@ -1,4 +1,4 @@
-(en, pt)
+(pt, en)
 erased | apagadas | [ɪɹˈeɪzd]
 escape | fugir | [ɛskˈeɪp]
 essential | essencial | [ɪsˈɛnʃəl]

--- a/language_materials/en/words/dictionary3.txt
+++ b/language_materials/en/words/dictionary3.txt
@@ -1,4 +1,4 @@
-(en, pt)
+(pt, en)
 mountainous | montanhosa | [mˈaʊntɪnəs]
 mountains | montanhas | [mˈaʊntɪnz]
 much | muita | [mˈʌtʃ]

--- a/language_materials/en/words/dictionary4.txt
+++ b/language_materials/en/words/dictionary4.txt
@@ -1,4 +1,4 @@
-(en, pt)
+(pt, en)
 story | história | [stˈɔːɹɪ]
 straighten | endireita | [stɹˈeɪtən]
 strange | estranha | [stɹˈeɪndʒ]

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ from typing import Dict
 # Version metadata
 # ---------------------------------------------------------------------------
 
-__version__ = "7.9.4-claude-dev"
+__version__ = "7.9.5-claude-dev"
 __app_name__ = "Pronunciation Trainer"
 __author__ = "Matthew Fairtlough & Contributors"
 __license__ = "GPL-3.0"


### PR DESCRIPTION
## Summary

- eca4d2d v7.9.5-claude-dev: version bump
- dda19e7 fix(materials): correct dictionary header from (en, pt) to (pt, en)

## Test plan
- [ ] App starts without import errors
- [ ] Changed functionality verified in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)