### PR TITLE
feat(admin): selective sync + connection diagnostics + diag scripts (admin v1.0.2-claude-dev)

### DIFF
--- a/ADMIN_CHANGELOG.md
+++ b/ADMIN_CHANGELOG.md
@@ -1,0 +1,24 @@
+# Miolingo Admin Changelog
+
+Changelog for the admin dashboard (`src/unified_admin.py` + `src/miolingo-admin.py`).
+Versions are independent from the main app's `APP_CHANGELOG.md` and tags use the
+`admin-v` prefix.
+
+## [Unreleased]
+
+## [1.0.2-claude-dev]
+
+### Added
+- Selective table sync (translation_cache, vocab_entries, user_settings) with skip/overwrite/merge-by-timestamp policies.
+- Connection diagnostics tab: SSH tunnel/connection/session views, pool-capacity snapshot, purge stale connection rows, mark dead tunnels.
+- Diagnostic CLI scripts moved to scripts/diag/ with README.
+
+## [1.0.1-claude-dev]
+
+### Added
+- Initial unified admin entrypoint (PR-2): users CRUD with reset-password / force-logout / soft+hard delete; DB Health tab (schema diff with version-cosmetic filter, row counts, per-user audit); Migration Runner with `schema_migrations` audit log.
+
+## [1.0.0]
+
+### Added
+- Initial admin dashboard.

--- a/scripts/diag/README.md
+++ b/scripts/diag/README.md
@@ -1,0 +1,25 @@
+# scripts/diag/
+
+Standalone read-only diagnostic CLI scripts. Each connects to local *or*
+remote (via `local_db.enabled` in `secrets.toml`) and prints results to
+stdout — none of them write. Most have been superseded by tabs in the
+unified admin app, but they remain useful when:
+
+- Streamlit is down and you need a quick sanity check from a terminal.
+- You want the *raw* / unfiltered view (e.g. version-cosmetic schema
+  noise) that the admin tab deliberately hides.
+
+Run with the venv python directly:
+
+```
+venv/bin/python3 scripts/diag/diag_schema_compare.py
+```
+
+| Script | Purpose | Admin-tab equivalent |
+|---|---|---|
+| `diag_vocab_keys.py` | Show the unique-key columns on `vocab_entries` plus per-user × language × source_language row counts. Was the smoking gun for the (fr,en)≠(pt,en) bug. | DB Health → row counts + Users → per-user audit |
+| `diag_user_auth.py` | List every user with role / active flag / argon2id hash prefix. Searches case-insensitively for "digby" and prints the full hash. | Users tab |
+| `diag_schema_compare.py` | Full schema dump of both DBs and the **unfiltered** column-by-column diff (every `int` vs `int(11)`, every `NULL` default, etc.). Useful for inspecting the cosmetic filter itself. | DB Health → schema diff (filtered) |
+
+Delete any of these if they go stale or unused — they hold no
+unique state.

--- a/scripts/diag/diag_schema_compare.py
+++ b/scripts/diag/diag_schema_compare.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Deep comparison of local vs remote DB schema.
+
+Reports: tables, columns (type/nullable/default), indexes, foreign keys,
+and any differences between the two databases.
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "src"))
+
+import tomllib
+secrets = tomllib.loads((ROOT / ".streamlit/secrets.toml").read_text())
+
+import mysql.connector
+
+# ── Connect to both ──────────────────────────────────────────────────────────
+local_cfg = secrets["local_db"]
+local = mysql.connector.connect(
+    unix_socket=local_cfg["unix_socket"],
+    database=local_cfg["database"],
+    user=local_cfg["user"],
+    password=local_cfg["password"],
+)
+print("LOCAL  connected")
+
+from sync_db import open_remote_connection
+tunnel, remote = open_remote_connection(secrets)
+print("REMOTE connected\n")
+
+def get_schema(conn, db_name):
+    """Return a nested dict describing every table in the database."""
+    c = conn.cursor(dictionary=True)
+    schema = {}
+
+    # Tables
+    c.execute(f"SELECT TABLE_NAME, TABLE_ROWS, ENGINE, TABLE_COMMENT "
+              f"FROM information_schema.TABLES "
+              f"WHERE TABLE_SCHEMA = '{db_name}' ORDER BY TABLE_NAME")
+    tables = {r["TABLE_NAME"]: r for r in c.fetchall()}
+
+    for tbl in sorted(tables):
+        schema[tbl] = {"columns": {}, "indexes": {}, "foreign_keys": {}}
+
+        # Columns
+        c.execute(
+            "SELECT COLUMN_NAME, ORDINAL_POSITION, COLUMN_DEFAULT, IS_NULLABLE, "
+            "COLUMN_TYPE, COLUMN_KEY, EXTRA, COLUMN_COMMENT "
+            "FROM information_schema.COLUMNS "
+            f"WHERE TABLE_SCHEMA='{db_name}' AND TABLE_NAME='{tbl}' "
+            "ORDER BY ORDINAL_POSITION"
+        )
+        for row in c.fetchall():
+            schema[tbl]["columns"][row["COLUMN_NAME"]] = {
+                "pos":      row["ORDINAL_POSITION"],
+                "type":     row["COLUMN_TYPE"],
+                "nullable": row["IS_NULLABLE"],
+                "default":  row["COLUMN_DEFAULT"],
+                "key":      row["COLUMN_KEY"],
+                "extra":    row["EXTRA"],
+            }
+
+        # Indexes
+        c.execute(
+            "SELECT INDEX_NAME, SEQ_IN_INDEX, COLUMN_NAME, NON_UNIQUE, NULLABLE "
+            "FROM information_schema.STATISTICS "
+            f"WHERE TABLE_SCHEMA='{db_name}' AND TABLE_NAME='{tbl}' "
+            "ORDER BY INDEX_NAME, SEQ_IN_INDEX"
+        )
+        idx = defaultdict(list)
+        for row in c.fetchall():
+            idx[row["INDEX_NAME"]].append({
+                "col": row["COLUMN_NAME"],
+                "seq": row["SEQ_IN_INDEX"],
+                "unique": row["NON_UNIQUE"] == 0,
+                "nullable": row["NULLABLE"],
+            })
+        schema[tbl]["indexes"] = dict(idx)
+
+        # Foreign keys
+        c.execute(
+            "SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, "
+            "REFERENCED_COLUMN_NAME "
+            "FROM information_schema.KEY_COLUMN_USAGE "
+            f"WHERE TABLE_SCHEMA='{db_name}' AND TABLE_NAME='{tbl}' "
+            "AND REFERENCED_TABLE_NAME IS NOT NULL "
+            "ORDER BY CONSTRAINT_NAME"
+        )
+        for row in c.fetchall():
+            schema[tbl]["foreign_keys"][row["CONSTRAINT_NAME"]] = {
+                "col": row["COLUMN_NAME"],
+                "ref_table": row["REFERENCED_TABLE_NAME"],
+                "ref_col": row["REFERENCED_COLUMN_NAME"],
+            }
+
+    return schema
+
+LOCAL_DB  = local_cfg["database"]
+REMOTE_DB = secrets["mysql"]["database"]
+
+print(f"Fetching LOCAL  schema  ({LOCAL_DB})…")
+local_schema = get_schema(local, LOCAL_DB)
+print(f"Fetching REMOTE schema  ({REMOTE_DB})…\n")
+remote_schema = get_schema(remote, REMOTE_DB)
+
+# ── Print full schemas ────────────────────────────────────────────────────────
+def print_schema(label, schema):
+    print(f"\n{'='*72}")
+    print(f"  {label}  —  {len(schema)} tables")
+    print(f"{'='*72}")
+    for tbl, info in sorted(schema.items()):
+        print(f"\n  TABLE: {tbl}")
+        print(f"    Columns:")
+        for col, d in info["columns"].items():
+            nullable = "NULL" if d["nullable"] == "YES" else "NOT NULL"
+            default  = f" DEFAULT {d['default']!r}" if d["default"] is not None else ""
+            extra    = f" {d['extra']}" if d["extra"] else ""
+            key      = f" [{d['key']}]" if d["key"] else ""
+            print(f"      {col:35s} {d['type']:30s} {nullable}{default}{extra}{key}")
+        print(f"    Indexes:")
+        for idx_name, cols in info["indexes"].items():
+            unique = "UNIQUE" if cols[0]["unique"] else "INDEX"
+            col_list = ", ".join(c["col"] for c in cols)
+            print(f"      {unique:8s} {idx_name:35s} ({col_list})")
+        if info["foreign_keys"]:
+            print(f"    Foreign keys:")
+            for fk_name, fk in info["foreign_keys"].items():
+                print(f"      {fk_name}: {fk['col']} → {fk['ref_table']}.{fk['ref_col']}")
+
+print_schema(f"LOCAL  ({LOCAL_DB})",  local_schema)
+print_schema(f"REMOTE ({REMOTE_DB})", remote_schema)
+
+# ── Diff ──────────────────────────────────────────────────────────────────────
+print(f"\n\n{'='*72}")
+print("  DIFF  (LOCAL vs REMOTE)")
+print(f"{'='*72}")
+
+all_tables = sorted(set(local_schema) | set(remote_schema))
+diffs_found = False
+
+for tbl in all_tables:
+    in_local  = tbl in local_schema
+    in_remote = tbl in remote_schema
+
+    if not in_local:
+        print(f"\n  [TABLE MISSING IN LOCAL]  {tbl}")
+        diffs_found = True
+        continue
+    if not in_remote:
+        print(f"\n  [TABLE MISSING IN REMOTE] {tbl}")
+        diffs_found = True
+        continue
+
+    L = local_schema[tbl]
+    R = remote_schema[tbl]
+    tbl_diffs = []
+
+    # Columns
+    all_cols = sorted(set(L["columns"]) | set(R["columns"]))
+    for col in all_cols:
+        if col not in L["columns"]:
+            tbl_diffs.append(f"    [COL MISSING IN LOCAL]  {col}")
+        elif col not in R["columns"]:
+            tbl_diffs.append(f"    [COL MISSING IN REMOTE] {col}")
+        else:
+            lc, rc = L["columns"][col], R["columns"][col]
+            for field in ("type", "nullable", "default", "extra"):
+                if lc[field] != rc[field]:
+                    tbl_diffs.append(f"    [COL DIFF] {col}.{field}: LOCAL={lc[field]!r}  REMOTE={rc[field]!r}")
+
+    # Indexes
+    all_idx = sorted(set(L["indexes"]) | set(R["indexes"]))
+    for idx in all_idx:
+        if idx not in L["indexes"]:
+            cols = ", ".join(c["col"] for c in R["indexes"][idx])
+            tbl_diffs.append(f"    [IDX MISSING IN LOCAL]  {idx} ({cols})")
+        elif idx not in R["indexes"]:
+            cols = ", ".join(c["col"] for c in L["indexes"][idx])
+            tbl_diffs.append(f"    [IDX MISSING IN REMOTE] {idx} ({cols})")
+        else:
+            l_cols = [c["col"] for c in L["indexes"][idx]]
+            r_cols = [c["col"] for c in R["indexes"][idx]]
+            if l_cols != r_cols:
+                tbl_diffs.append(f"    [IDX DIFF] {idx}: LOCAL=({', '.join(l_cols)})  REMOTE=({', '.join(r_cols)})")
+
+    if tbl_diffs:
+        print(f"\n  TABLE: {tbl}")
+        for d in tbl_diffs:
+            print(d)
+        diffs_found = True
+
+if not diffs_found:
+    print("\n  Schemas are identical.")
+
+# ── Row counts ────────────────────────────────────────────────────────────────
+print(f"\n\n{'='*72}")
+print("  ROW COUNTS")
+print(f"{'='*72}")
+print(f"  {'Table':35s}  {'Local':>10s}  {'Remote':>10s}")
+print(f"  {'-'*35}  {'-'*10}  {'-'*10}")
+lc2 = local.cursor()
+rc2 = remote.cursor()
+for tbl in sorted(set(local_schema) | set(remote_schema)):
+    try:
+        lc2.execute(f"SELECT COUNT(*) FROM `{tbl}`")
+        l_cnt = lc2.fetchone()[0]
+    except Exception:
+        l_cnt = "N/A"
+    try:
+        rc2.execute(f"SELECT COUNT(*) FROM `{tbl}`")
+        r_cnt = rc2.fetchone()[0]
+    except Exception:
+        r_cnt = "N/A"
+    marker = "  <<<" if l_cnt != r_cnt else ""
+    print(f"  {tbl:35s}  {str(l_cnt):>10s}  {str(r_cnt):>10s}{marker}")
+
+local.close()
+remote.close()
+tunnel.stop()
+print("\nDone.")

--- a/scripts/diag/diag_user_auth.py
+++ b/scripts/diag/diag_user_auth.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Diagnose a user account: existence, password hash, and auth algorithm."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "src"))
+
+import tomllib
+secrets = tomllib.loads((ROOT / ".streamlit/secrets.toml").read_text())
+
+import mysql.connector
+
+local_cfg = secrets.get("local_db", {})
+tunnel = None
+
+if local_cfg.get("enabled"):
+    print(">> Using LOCAL MySQL")
+    conn = mysql.connector.connect(
+        unix_socket=local_cfg["unix_socket"],
+        database=local_cfg["database"],
+        user=local_cfg["user"],
+        password=local_cfg["password"],
+    )
+else:
+    print(">> Using REMOTE MySQL via SSH tunnel")
+    from sync_db import open_remote_connection
+    tunnel, conn = open_remote_connection(secrets)
+
+cur = conn.cursor(dictionary=True)
+
+print("\n=== All users ===")
+cur.execute(
+    "SELECT user_id, username, email, password_hash, is_active, role "
+    "FROM users ORDER BY user_id"
+)
+for row in cur.fetchall():
+    print(f"  id={row['user_id']:3d}  username={row['username']!r:20s}  "
+          f"email={row['email']!r:35s}  active={row['is_active']}  role={row['role']!r}  "
+          f"hash_prefix={row['password_hash'][:30] if row['password_hash'] else 'NULL'}...")
+
+print("\n=== Looking for 'digby' (case-insensitive) ===")
+cur.execute(
+    "SELECT user_id, username, email, password_hash, is_active "
+    "FROM users "
+    "WHERE LOWER(username) LIKE '%digby%' OR LOWER(email) LIKE '%digby%'"
+)
+rows = cur.fetchall()
+if rows:
+    for row in rows:
+        print(f"  FOUND: id={row['user_id']}  username={row['username']!r}  "
+              f"email={row['email']!r}  active={row['is_active']}")
+        print(f"  full hash: {row['password_hash']}")
+else:
+    print("  (no match)")
+
+conn.close()
+if tunnel:
+    tunnel.stop()

--- a/scripts/diag/diag_vocab_keys.py
+++ b/scripts/diag/diag_vocab_keys.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Diagnostic: vocab_entries breakdown by user, language, source_language."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "src"))
+
+import tomllib
+secrets = tomllib.loads((ROOT / ".streamlit/secrets.toml").read_text())
+
+import mysql.connector
+
+local_cfg = secrets.get("local_db", {})
+tunnel = None
+
+if local_cfg.get("enabled"):
+    print(">> Using LOCAL MySQL via Unix socket")
+    conn = mysql.connector.connect(
+        unix_socket=local_cfg["unix_socket"],
+        database=local_cfg["database"],
+        user=local_cfg["user"],
+        password=local_cfg["password"],
+    )
+else:
+    print(">> Using REMOTE MySQL via SSH tunnel")
+    from sync_db import open_remote_connection
+    tunnel, conn = open_remote_connection(secrets)
+
+cur = conn.cursor()
+
+print("\n=== UNIQUE KEY ===")
+cur.execute("SHOW INDEX FROM vocab_entries WHERE Non_unique=0 AND Key_name != 'PRIMARY'")
+for row in cur.fetchall():
+    print(f"  {row[2]}: col={row[4]}, seq={row[3]}, nullable={row[9]}")
+
+print("\n=== Per-user breakdown: (user_id, language_code, source_language_code, count) ===")
+cur.execute(
+    "SELECT user_id, language_code, source_language_code, COUNT(*) as cnt "
+    "FROM vocab_entries "
+    "GROUP BY user_id, language_code, source_language_code "
+    "ORDER BY user_id, language_code, cnt DESC"
+)
+for row in cur.fetchall():
+    print(f"  user={row[0]:3d}  lang={row[1]!r:15s}  src={str(row[2]):6s}  count={row[3]}")
+
+print("\n=== Users table (id, username/email) ===")
+try:
+    cur.execute("SELECT id, username FROM users ORDER BY id")
+    for row in cur.fetchall():
+        print(f"  id={row[0]}  username={row[1]!r}")
+except Exception as e:
+    try:
+        cur.execute("SELECT id, email FROM users ORDER BY id")
+        for row in cur.fetchall():
+            print(f"  id={row[0]}  email={row[1]!r}")
+    except Exception as e2:
+        print(f"  (could not read users: {e2})")
+
+conn.close()
+if tunnel:
+    tunnel.stop()

--- a/scripts/migrate_local_users_to_remote.py
+++ b/scripts/migrate_local_users_to_remote.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Migrate users that exist in local DB but not in remote DB.
+
+Reads both DBs, finds users present locally but absent remotely (by user_id),
+and INSERTs them into remote preserving the original user_id. Safe to re-run
+(skips users already present on remote).
+"""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "src"))
+
+import tomllib
+secrets = tomllib.loads((ROOT / ".streamlit/secrets.toml").read_text())
+
+import mysql.connector
+
+local_cfg = secrets["local_db"]
+local = mysql.connector.connect(
+    unix_socket=local_cfg["unix_socket"],
+    database=local_cfg["database"],
+    user=local_cfg["user"],
+    password=local_cfg["password"],
+)
+
+from sync_db import open_remote_connection
+tunnel, remote = open_remote_connection(secrets)
+
+lc = local.cursor(dictionary=True)
+rc = remote.cursor(dictionary=True)
+
+# Fetch all user_ids already in remote
+rc.execute("SELECT user_id FROM users")
+remote_ids = {row["user_id"] for row in rc.fetchall()}
+
+# Fetch all users from local
+lc.execute(
+    "SELECT user_id, username, email, password_hash, created_at, last_login, "
+    "email_verified, is_active, role FROM users ORDER BY user_id"
+)
+local_users = lc.fetchall()
+
+missing = [u for u in local_users if u["user_id"] not in remote_ids]
+
+if not missing:
+    print("No missing users — remote is already up to date.")
+else:
+    print(f"Found {len(missing)} user(s) in local but not in remote:")
+    for u in missing:
+        print(f"  id={u['user_id']:3d}  {u['username']!r:25s}  {u['email']!r}")
+
+    confirm = input("\nInsert these into remote? [y/N] ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+    else:
+        rc2 = remote.cursor()
+        for u in missing:
+            rc2.execute(
+                """
+                INSERT INTO users
+                  (user_id, username, email, password_hash, created_at, last_login,
+                   email_verified, is_active, role)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON DUPLICATE KEY UPDATE user_id=user_id
+                """,
+                (
+                    u["user_id"], u["username"], u["email"], u["password_hash"],
+                    u["created_at"], u["last_login"],
+                    u["email_verified"], u["is_active"], u["role"],
+                ),
+            )
+            print(f"  Inserted user_id={u['user_id']} ({u['username']!r})")
+        remote.commit()
+        print(f"\nDone — {len(missing)} user(s) migrated to remote.")
+
+local.close()
+remote.close()
+tunnel.stop()

--- a/src/admin_connections.py
+++ b/src/admin_connections.py
@@ -1,0 +1,173 @@
+"""Admin connection diagnostics — surface what the SSH-tunnel pool is
+doing right now so admins can spot leaks, runaway sessions, or stale
+tunnels.
+
+Reads exclusively from ``connection_monitor`` / ``tunnel_monitor`` /
+``sessions`` on the **remote** DB — those tables only get populated when
+the app talks through an SSH tunnel, so they're meaningless when local
+mode is on (in which case the UI shows a "no diagnostics" message).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import admin_db_health
+import app_mysql
+
+
+# ----------------------------------------------------------------------------
+# Tunnels
+# ----------------------------------------------------------------------------
+
+def list_tunnels() -> List[Dict[str, Any]]:
+    """Return all rows from ``tunnel_monitor`` sorted newest-first, plus a
+    derived ``conn_count`` taken live from ``connection_monitor``."""
+    rows: List[Dict[str, Any]] = []
+    with admin_db_health._remote_connect() as conn:
+        cur = conn.cursor(dictionary=True)
+        cur.execute(
+            """
+            SELECT t.tunnel_id, t.pid, t.local_port, t.created_at,
+                   t.last_used, t.status,
+                   (SELECT COUNT(*) FROM connection_monitor cm
+                      WHERE cm.tunnel_id = t.tunnel_id
+                        AND cm.status = 'active') AS active_conns
+            FROM tunnel_monitor t
+            ORDER BY t.created_at DESC
+            """
+        )
+        rows = cur.fetchall()
+        cur.close()
+    return rows
+
+
+# ----------------------------------------------------------------------------
+# Connections
+# ----------------------------------------------------------------------------
+
+def list_active_connections() -> List[Dict[str, Any]]:
+    """Active rows in ``connection_monitor`` joined with usernames."""
+    rows: List[Dict[str, Any]] = []
+    with admin_db_health._remote_connect() as conn:
+        cur = conn.cursor(dictionary=True)
+        cur.execute(
+            """
+            SELECT cm.connection_id, cm.tunnel_id, cm.session_id,
+                   cm.username, cm.app_name, cm.created_at, cm.last_activity,
+                   cm.status
+            FROM connection_monitor cm
+            WHERE cm.status = 'active'
+            ORDER BY cm.last_activity DESC
+            """
+        )
+        rows = cur.fetchall()
+        cur.close()
+    return rows
+
+
+# ----------------------------------------------------------------------------
+# Sessions per user / app
+# ----------------------------------------------------------------------------
+
+def sessions_per_user() -> List[Dict[str, Any]]:
+    """``{username, app_name, active, expires_soon}`` per (user, app)."""
+    rows: List[Dict[str, Any]] = []
+    with admin_db_health._remote_connect() as conn:
+        cur = conn.cursor(dictionary=True)
+        cur.execute(
+            """
+            SELECT s.username, s.app_name,
+                   COUNT(*) AS active,
+                   SUM(CASE WHEN s.expires_at < DATE_ADD(NOW(), INTERVAL 1 DAY)
+                           THEN 1 ELSE 0 END) AS expires_within_24h
+            FROM sessions s
+            WHERE s.status = 'active' AND s.expires_at > NOW()
+            GROUP BY s.username, s.app_name
+            ORDER BY active DESC
+            """
+        )
+        rows = cur.fetchall()
+        cur.close()
+    return rows
+
+
+# ----------------------------------------------------------------------------
+# Pool capacity snapshot
+# ----------------------------------------------------------------------------
+
+def pool_capacity() -> Dict[str, Any]:
+    """One-shot summary: active connections / tunnels / soft-limit headroom."""
+    with admin_db_health._remote_connect() as conn:
+        cur = conn.cursor(dictionary=True)
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) AS active_connections,
+                COUNT(DISTINCT tunnel_id) AS active_tunnels,
+                COUNT(DISTINCT session_id) AS sessions_with_connections
+            FROM connection_monitor
+            WHERE status = 'active'
+            """
+        )
+        stats = cur.fetchone() or {}
+        cur.close()
+    MAX_TOTAL = 100
+    SOFT_LIMIT = 90
+    active = int(stats.get("active_connections") or 0)
+    return {
+        "active_connections":        active,
+        "active_tunnels":            int(stats.get("active_tunnels") or 0),
+        "sessions_with_connections": int(stats.get("sessions_with_connections") or 0),
+        "max_total":                 MAX_TOTAL,
+        "soft_limit":                SOFT_LIMIT,
+        "headroom":                  MAX_TOTAL - active,
+        "capacity_pct":              (active / MAX_TOTAL) * 100,
+        "over_soft_limit":           active >= SOFT_LIMIT,
+    }
+
+
+# ----------------------------------------------------------------------------
+# Cleanup
+# ----------------------------------------------------------------------------
+
+def cleanup_stale_connections(stale_hours: int = 12) -> int:
+    """Delete rows from ``connection_monitor`` that are closed or idle
+    for ``stale_hours`` hours. Surfaces the existing pool helper.
+    Returns the row count deleted."""
+    pool = app_mysql.get_connection_pool_instance()
+    return pool.cleanup_stale_connections(stale_hours=stale_hours)
+
+
+def kill_dead_tunnels() -> Dict[str, int]:
+    """Mark ``tunnel_monitor`` rows as ``dead`` for tunnels whose PID no
+    longer exists. Returns ``{checked, marked_dead}``. Best-effort —
+    skips rows where the PID is null. Does NOT touch live tunnels."""
+    import os
+
+    checked = 0
+    marked = 0
+    with admin_db_health._remote_connect() as conn:
+        cur = conn.cursor(dictionary=True)
+        cur.execute(
+            "SELECT tunnel_id, pid FROM tunnel_monitor "
+            "WHERE status IN ('active','idle') AND pid IS NOT NULL"
+        )
+        rows = cur.fetchall()
+
+        update_cur = conn.cursor()
+        for row in rows:
+            checked += 1
+            pid = int(row["pid"])
+            try:
+                os.kill(pid, 0)  # signal 0 = existence check
+            except OSError:
+                update_cur.execute(
+                    "UPDATE tunnel_monitor SET status='dead' "
+                    "WHERE tunnel_id=%s",
+                    (row["tunnel_id"],),
+                )
+                marked += 1
+        conn.commit()
+        update_cur.close()
+        cur.close()
+    return {"checked": checked, "marked_dead": marked}

--- a/src/admin_sync.py
+++ b/src/admin_sync.py
@@ -1,0 +1,297 @@
+"""Selective table sync between LOCAL and REMOTE DBs.
+
+Used by the admin Sync tab to copy rows from one DB to the other under
+one of three conflict policies:
+
+* ``skip`` — only insert rows whose unique key is missing on the target;
+  existing rows are left alone.
+* ``overwrite`` — upsert every source row; existing rows are replaced.
+* ``merge-by-timestamp`` — for each row, compare the source row's
+  freshness column against the target's; only apply rows where source
+  is newer (or target row is missing). Per-table freshness column is
+  declared in ``SYNCABLE_TABLES``.
+
+Only tables explicitly registered in ``SYNCABLE_TABLES`` are syncable —
+admin can't choose arbitrary tables. Each entry declares the unique
+columns (used to detect overlap) and an optional freshness column
+(required for merge-by-timestamp).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import admin_db_health
+
+
+# ----------------------------------------------------------------------------
+# Whitelist
+# ----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SyncSpec:
+    table:             str
+    unique_columns:    Tuple[str, ...]
+    freshness_column:  Optional[str]   # ``None`` => merge-by-timestamp not supported
+    description:       str
+
+
+SYNCABLE_TABLES: Dict[str, SyncSpec] = {
+    "translation_cache": SyncSpec(
+        table="translation_cache",
+        unique_columns=("provider", "source_lang", "target_lang", "source_text_hash"),
+        freshness_column="updated_at",
+        description="Cached translations. Cheap to merge — pure read cache.",
+    ),
+    "vocab_entries": SyncSpec(
+        table="vocab_entries",
+        unique_columns=("user_id", "language_code", "source_language_code", "word"),
+        freshness_column="last_seen_at",
+        description="Per-user vocab. Merge-by-timestamp picks the most "
+                    "recently practised row's translation/IPA/counters.",
+    ),
+    "user_settings": SyncSpec(
+        table="user_settings",
+        unique_columns=("user_id", "setting_key"),
+        freshness_column="updated_at",
+        description="Per-user settings. Already dual-written by the app; "
+                    "this is a recovery tool for drift.",
+    ),
+}
+
+VALID_POLICIES = ("skip", "overwrite", "merge-by-timestamp")
+
+
+# ----------------------------------------------------------------------------
+# Connection helpers — reuse what admin_db_health already exposes
+# ----------------------------------------------------------------------------
+
+def _open(target: str):
+    """Return an already-opened connection. Caller is responsible for
+    closing remote connections via the context manager pattern; for
+    consistency this returns a *closeable* object that callers must close.
+    """
+    if target == "local":
+        if not admin_db_health.local_enabled():
+            raise RuntimeError("Local DB is disabled in secrets.toml.")
+        return admin_db_health._local_connect()
+    if target == "remote":
+        # Open a fresh tunnel + conn; the caller must close it.
+        # admin_db_health._remote_connect is a contextmanager that owns
+        # the tunnel — for the manual close pattern we open via the pool
+        # directly so we can hold the connection across multiple statements.
+        import app_mysql
+        pool = app_mysql.get_connection_pool_instance()
+        # The pool's bootstrap is REMOTE-ONLY (post PR-1 docstring). Use
+        # the pool's create_ssh_tunnel + manual connect so we can keep the
+        # tunnel + conn alive for the duration of the sync.
+        tunnel = pool.create_ssh_tunnel()
+        import mysql.connector
+        conn = mysql.connector.connect(
+            host="127.0.0.1",
+            port=tunnel.local_bind_port,
+            database=pool.secrets["mysql"]["database"],
+            user=pool.secrets["mysql"]["user"],
+            password=pool.secrets["mysql"]["password"],
+            connect_timeout=10,
+        )
+        # Stash the tunnel on the connection so close() also stops it.
+        conn._sync_tunnel = tunnel  # type: ignore[attr-defined]
+        return conn
+    raise ValueError(f"Unknown target {target!r}")
+
+
+def _close(conn) -> None:
+    try:
+        conn.close()
+    except Exception:
+        pass
+    tunnel = getattr(conn, "_sync_tunnel", None)
+    if tunnel is not None:
+        try:
+            tunnel.stop()
+        except Exception:
+            pass
+
+
+# ----------------------------------------------------------------------------
+# Preview — count source / target / overlap before syncing
+# ----------------------------------------------------------------------------
+
+def preview(table: str, source: str, target: str) -> Dict[str, Any]:
+    """Return ``{source_count, target_count, overlap, source_only,
+    target_only}`` so admin can see what's about to happen."""
+    if table not in SYNCABLE_TABLES:
+        raise ValueError(f"Table {table!r} is not in the sync whitelist.")
+    if source == target:
+        raise ValueError("Source and target must differ.")
+
+    spec = SYNCABLE_TABLES[table]
+    src = _open(source)
+    tgt = _open(target)
+    try:
+        sc = src.cursor()
+        tc = tgt.cursor()
+        sc.execute(f"SELECT COUNT(*) FROM `{table}`")
+        source_count = int(sc.fetchone()[0])
+        tc.execute(f"SELECT COUNT(*) FROM `{table}`")
+        target_count = int(tc.fetchone()[0])
+
+        # Build the unique-key tuples on each side.
+        cols_csv = ", ".join(f"`{c}`" for c in spec.unique_columns)
+        sc.execute(f"SELECT {cols_csv} FROM `{table}`")
+        src_keys = {tuple(r) for r in sc.fetchall()}
+        tc.execute(f"SELECT {cols_csv} FROM `{table}`")
+        tgt_keys = {tuple(r) for r in tc.fetchall()}
+
+        overlap = src_keys & tgt_keys
+        source_only = src_keys - tgt_keys
+        target_only = tgt_keys - src_keys
+
+        sc.close()
+        tc.close()
+    finally:
+        _close(src)
+        _close(tgt)
+
+    return {
+        "source_count": source_count,
+        "target_count": target_count,
+        "overlap":      len(overlap),
+        "source_only":  len(source_only),
+        "target_only":  len(target_only),
+    }
+
+
+# ----------------------------------------------------------------------------
+# Sync
+# ----------------------------------------------------------------------------
+
+def _column_names(conn, table: str) -> List[str]:
+    cur = conn.cursor()
+    cur.execute(f"SELECT * FROM `{table}` LIMIT 0")
+    cols = [d[0] for d in cur.description]
+    cur.close()
+    return cols
+
+
+def _fetch_all(conn, table: str, columns: List[str]) -> List[Dict[str, Any]]:
+    cols_csv = ", ".join(f"`{c}`" for c in columns)
+    cur = conn.cursor(dictionary=True)
+    cur.execute(f"SELECT {cols_csv} FROM `{table}`")
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
+def _index_by_key(rows: List[Dict[str, Any]], spec: SyncSpec) -> Dict[Tuple, Dict[str, Any]]:
+    return {tuple(r[c] for c in spec.unique_columns): r for r in rows}
+
+
+def _executemany_upsert(
+    conn,
+    table: str,
+    columns: List[str],
+    rows: List[Dict[str, Any]],
+    chunk_size: int = 500,
+) -> None:
+    """``INSERT ... ON DUPLICATE KEY UPDATE col=VALUES(col)`` for every
+    column. Caller has already filtered ``rows`` to exactly those it
+    wants to apply, so a blanket "overwrite all non-key columns" is
+    correct here regardless of the original policy."""
+    if not rows:
+        return
+    cols_csv = ", ".join(f"`{c}`" for c in columns)
+    placeholders = ", ".join(["%s"] * len(columns))
+    update_csv = ", ".join(f"`{c}`=VALUES(`{c}`)" for c in columns)
+    sql = (
+        f"INSERT INTO `{table}` ({cols_csv}) VALUES ({placeholders}) "
+        f"ON DUPLICATE KEY UPDATE {update_csv}"
+    )
+    cur = conn.cursor()
+    try:
+        for i in range(0, len(rows), chunk_size):
+            chunk = rows[i : i + chunk_size]
+            params = [tuple(r[c] for c in columns) for r in chunk]
+            cur.executemany(sql, params)
+        conn.commit()
+    finally:
+        cur.close()
+
+
+def sync_table(
+    table: str,
+    *,
+    source: str,
+    target: str,
+    policy: str,
+) -> Dict[str, Any]:
+    """Apply rows from ``source`` to ``target`` under ``policy``.
+
+    Returns ``{table, source, target, policy, selected, applied, skipped}``.
+    ``selected`` is rows fetched from source; ``applied`` is rows actually
+    sent to target after policy filtering; ``skipped = selected - applied``.
+    """
+    if table not in SYNCABLE_TABLES:
+        raise ValueError(f"Table {table!r} is not in the sync whitelist.")
+    if policy not in VALID_POLICIES:
+        raise ValueError(f"policy must be one of {VALID_POLICIES}, got {policy!r}")
+    if source == target:
+        raise ValueError("Source and target must differ.")
+    spec = SYNCABLE_TABLES[table]
+    if policy == "merge-by-timestamp" and spec.freshness_column is None:
+        raise ValueError(
+            f"Table {table!r} has no freshness column; merge-by-timestamp "
+            "is not supported for it."
+        )
+
+    src = _open(source)
+    tgt = _open(target)
+    try:
+        # Same column set on both sides so the upsert SQL matches.
+        src_cols = _column_names(src, table)
+        tgt_cols = _column_names(tgt, table)
+        # Use the intersection so we don't break on schema drift.
+        common_cols = [c for c in src_cols if c in tgt_cols]
+        if any(c not in common_cols for c in spec.unique_columns):
+            raise RuntimeError(
+                f"Schema drift: unique columns {spec.unique_columns} not all "
+                "present on both sides. Run a schema diff first."
+            )
+
+        src_rows = _fetch_all(src, table, common_cols)
+
+        if policy == "overwrite":
+            to_apply = src_rows
+        else:
+            tgt_rows = _fetch_all(tgt, table, common_cols)
+            tgt_index = _index_by_key(tgt_rows, spec)
+            to_apply = []
+            for r in src_rows:
+                key = tuple(r[c] for c in spec.unique_columns)
+                existing = tgt_index.get(key)
+                if existing is None:
+                    to_apply.append(r)
+                elif policy == "merge-by-timestamp":
+                    fc = spec.freshness_column
+                    if fc and r[fc] is not None and (
+                        existing[fc] is None or r[fc] > existing[fc]
+                    ):
+                        to_apply.append(r)
+                # ``skip``: existing row → drop
+
+        _executemany_upsert(tgt, table, common_cols, to_apply)
+
+    finally:
+        _close(src)
+        _close(tgt)
+
+    return {
+        "table":    table,
+        "source":   source,
+        "target":   target,
+        "policy":   policy,
+        "selected": len(src_rows),
+        "applied":  len(to_apply),
+        "skipped":  len(src_rows) - len(to_apply),
+    }

--- a/src/miolingo-admin.py
+++ b/src/miolingo-admin.py
@@ -25,6 +25,8 @@ import app_mysql
 import admin_users
 import admin_db_health
 import admin_migrations
+import admin_sync
+import admin_connections
 from contextlib import contextmanager
 
 
@@ -186,7 +188,7 @@ if not HOSTED_BY_UNIFIED_ADMIN:
             st.rerun()
 
 # Navigation (tabs deprecated)
-_admin_pages = ["📊 Resource Usage", "👥 Users", "🗄️ DB Health", "🚦 Migrations", "📝 Logs", "📧 Email", "📢 Announcements", "⚙️ Settings"]
+_admin_pages = ["📊 Resource Usage", "👥 Users", "🗄️ DB Health", "🔁 Sync", "🚦 Migrations", "🔌 Connections", "📝 Logs", "📧 Email", "📢 Announcements", "⚙️ Settings"]
 if HOSTED_BY_UNIFIED_ADMIN:
     selected_page = st.session_state.get('ua_admin_page', _admin_pages[0])
     if selected_page not in _admin_pages:
@@ -1416,6 +1418,229 @@ if selected_page == "🚦 Migrations":
             st.dataframe(df_hist, hide_index=True, use_container_width=True)
         else:
             st.info("No migrations recorded yet on this target.")
+
+# TAB 6c: Sync
+if selected_page == "🔁 Sync":
+    st.header("🔁 Selective Table Sync")
+    st.caption(
+        "Copy rows between LOCAL and REMOTE for whitelisted tables only. "
+        "Three policies: **skip** (only insert missing rows), **overwrite** "
+        "(replace existing rows), **merge-by-timestamp** (apply only when "
+        "the source row's freshness column is newer)."
+    )
+
+    if not admin_db_health.local_enabled():
+        st.info(
+            "ℹ️ Local DB is disabled (`local_db.enabled = false` in secrets.toml). "
+            "Sync needs both DBs."
+        )
+    else:
+        # Pickers
+        sync_table_choice = st.selectbox(
+            "Table",
+            options=list(admin_sync.SYNCABLE_TABLES.keys()),
+            format_func=lambda t: f"{t} — {admin_sync.SYNCABLE_TABLES[t].description}",
+            key="sync_table",
+        )
+        sync_dir = st.radio(
+            "Direction",
+            options=["LOCAL → REMOTE", "REMOTE → LOCAL"],
+            horizontal=True,
+            key="sync_dir",
+        )
+        source = "local" if sync_dir.startswith("LOCAL") else "remote"
+        target = "remote" if source == "local" else "local"
+
+        spec = admin_sync.SYNCABLE_TABLES[sync_table_choice]
+        policy_options = ["skip", "overwrite"]
+        if spec.freshness_column:
+            policy_options.append("merge-by-timestamp")
+        sync_policy = st.radio(
+            "Conflict policy",
+            options=policy_options,
+            horizontal=True,
+            key="sync_policy",
+        )
+        if sync_policy == "merge-by-timestamp":
+            st.caption(f"Freshness column for `{sync_table_choice}`: "
+                       f"`{spec.freshness_column}`")
+
+        # Preview
+        if st.button("👀 Preview", key="sync_preview"):
+            with st.spinner("Counting rows + overlap..."):
+                try:
+                    p = admin_sync.preview(
+                        sync_table_choice,
+                        source=source, target=target,
+                    )
+                    st.session_state["sync_preview_data"] = p
+                except Exception as e:
+                    st.error(f"❌ Preview failed: {e}")
+
+        if "sync_preview_data" in st.session_state:
+            p = st.session_state["sync_preview_data"]
+            cols = st.columns(5)
+            cols[0].metric(f"{source.upper()} rows",  p["source_count"])
+            cols[1].metric(f"{target.upper()} rows",  p["target_count"])
+            cols[2].metric("Overlap (UK match)",     p["overlap"])
+            cols[3].metric(f"{source.upper()}-only", p["source_only"])
+            cols[4].metric(f"{target.upper()}-only", p["target_only"])
+
+        # Apply
+        with st.popover("🔁 Run sync"):
+            st.warning(
+                f"Sync `{sync_table_choice}` from **{source.upper()}** to "
+                f"**{target.upper()}** with policy **{sync_policy}**?"
+            )
+            sync_ack = st.checkbox(
+                "I've previewed the counts above and want to proceed",
+                key=f"sync_ack_{sync_table_choice}_{source}_{target}_{sync_policy}",
+            )
+            if st.button("Confirm sync", key="sync_confirm",
+                         type="primary",
+                         disabled=not sync_ack):
+                with st.spinner(f"Syncing {sync_table_choice}..."):
+                    try:
+                        result = admin_sync.sync_table(
+                            sync_table_choice,
+                            source=source, target=target,
+                            policy=sync_policy,
+                        )
+                        st.success(
+                            f"✅ {result['table']}: selected {result['selected']}, "
+                            f"applied {result['applied']}, skipped "
+                            f"{result['skipped']} ({result['policy']})."
+                        )
+                        # Clear stale preview
+                        if "sync_preview_data" in st.session_state:
+                            del st.session_state["sync_preview_data"]
+                    except Exception as e:
+                        st.error(f"❌ Sync failed: {e}")
+
+
+# TAB 6d: Connections
+if selected_page == "🔌 Connections":
+    st.header("🔌 Connection Diagnostics")
+    st.caption(
+        "Live view of SSH tunnels, MySQL connections, and active sessions. "
+        "Reads from `tunnel_monitor`, `connection_monitor`, `sessions` on "
+        "the **remote** DB."
+    )
+
+    if admin_db_health.local_enabled():
+        st.info(
+            "ℹ️ Local mode is on, so the app isn't using SSH tunnels for its "
+            "regular work. Diagnostics still query remote — what you see "
+            "here is whoever else (8501, other admins) is connected to remote."
+        )
+
+    # Pool capacity snapshot
+    if st.button("📊 Refresh pool snapshot", key="conn_refresh_pool"):
+        try:
+            st.session_state["conn_pool_snapshot"] = admin_connections.pool_capacity()
+        except Exception as e:
+            st.error(f"❌ Snapshot failed: {e}")
+
+    if "conn_pool_snapshot" in st.session_state:
+        s = st.session_state["conn_pool_snapshot"]
+        c1, c2, c3, c4 = st.columns(4)
+        c1.metric(
+            "Active connections",
+            f"{s['active_connections']}/{s['max_total']}",
+            delta=f"{s['capacity_pct']:.0f}% capacity",
+            delta_color="off" if s["capacity_pct"] < 75 else "normal",
+        )
+        c2.metric("Active tunnels", s["active_tunnels"])
+        c3.metric("Sessions w/ conns", s["sessions_with_connections"])
+        c4.metric(
+            "Status",
+            "⚠️ HIGH" if s["over_soft_limit"]
+            else ("⚡ BUSY" if s["capacity_pct"] > 75 else "✅ OK"),
+            delta=f"{s['headroom']} available",
+            delta_color="inverse" if s["over_soft_limit"] else "off",
+        )
+
+    # Tunnels
+    st.subheader("SSH tunnels")
+    if st.button("Refresh tunnels", key="conn_refresh_tunnels"):
+        try:
+            st.session_state["conn_tunnels"] = admin_connections.list_tunnels()
+        except Exception as e:
+            st.error(f"❌ Tunnel list failed: {e}")
+    if "conn_tunnels" in st.session_state:
+        tunnels = st.session_state["conn_tunnels"]
+        if tunnels:
+            st.dataframe(pd.DataFrame(tunnels), hide_index=True,
+                         use_container_width=True)
+        else:
+            st.info("No tunnels recorded.")
+
+    # Sessions per user/app
+    st.subheader("Active sessions per (user, app)")
+    if st.button("Refresh sessions", key="conn_refresh_sessions"):
+        try:
+            st.session_state["conn_sessions"] = admin_connections.sessions_per_user()
+        except Exception as e:
+            st.error(f"❌ Session list failed: {e}")
+    if "conn_sessions" in st.session_state:
+        sessions = st.session_state["conn_sessions"]
+        if sessions:
+            st.dataframe(pd.DataFrame(sessions), hide_index=True,
+                         use_container_width=True)
+        else:
+            st.info("No active sessions.")
+
+    # Live connections
+    with st.expander("All active MySQL connections (raw)", expanded=False):
+        if st.button("Refresh connections", key="conn_refresh_active"):
+            try:
+                st.session_state["conn_active"] = admin_connections.list_active_connections()
+            except Exception as e:
+                st.error(f"❌ Active connection list failed: {e}")
+        if "conn_active" in st.session_state:
+            active = st.session_state["conn_active"]
+            if active:
+                st.dataframe(pd.DataFrame(active), hide_index=True,
+                             use_container_width=True)
+            else:
+                st.info("No active connections.")
+
+    # Cleanup actions
+    st.subheader("Cleanup")
+    cleanup_col1, cleanup_col2 = st.columns(2)
+
+    with cleanup_col1:
+        with st.popover("🧹 Purge stale connection rows"):
+            st.warning(
+                "Delete rows from `connection_monitor` that are **closed** "
+                "or have been idle for the last 12 hours."
+            )
+            if st.button("Confirm purge", key="conn_purge_confirm",
+                         type="primary"):
+                try:
+                    n = admin_connections.cleanup_stale_connections(stale_hours=12)
+                    st.success(f"✅ Deleted {n} stale connection row(s).")
+                except Exception as e:
+                    st.error(f"❌ Purge failed: {e}")
+
+    with cleanup_col2:
+        with st.popover("⚰️ Mark dead tunnels"):
+            st.warning(
+                "Check every active/idle tunnel's PID; mark `tunnel_monitor` "
+                "rows whose process no longer exists as `dead`. Does NOT "
+                "touch live tunnels."
+            )
+            if st.button("Confirm scan", key="conn_dead_confirm",
+                         type="primary"):
+                try:
+                    r = admin_connections.kill_dead_tunnels()
+                    st.success(
+                        f"✅ Checked {r['checked']} tunnel(s); "
+                        f"marked {r['marked_dead']} as dead."
+                    )
+                except Exception as e:
+                    st.error(f"❌ Scan failed: {e}")
+
 
 # TAB 6: Settings
 if selected_page == "⚙️ Settings":

--- a/src/unified_admin.py
+++ b/src/unified_admin.py
@@ -22,7 +22,7 @@ import streamlit as st
 
 import app_mysql
 
-__version__ = "1.0.1-claude-dev"
+__version__ = "1.0.2-claude-dev"
 
 
 REFRESH_INTERVAL_MINUTES = 5
@@ -162,7 +162,7 @@ with st.sidebar:
 
     # Per-tool navigation lives here (hosted tools read from session state)
     if tool == "Admin Dashboard":
-        admin_pages = ["📊 Resource Usage", "👥 Users", "🗄️ DB Health", "🚦 Migrations", "📝 Logs", "📧 Email", "📢 Announcements", "⚙️ Settings"]
+        admin_pages = ["📊 Resource Usage", "👥 Users", "🗄️ DB Health", "🔁 Sync", "🚦 Migrations", "🔌 Connections", "📝 Logs", "📧 Email", "📢 Announcements", "⚙️ Settings"]
         st.session_state.ua_admin_page = st.radio(
             "Admin Pages",
             admin_pages,


### PR DESCRIPTION
## Summary

PR-3 of the admin overhaul. **B4 + B5** from the agreed plan, plus housekeeping for the diagnostic CLI scripts that grew out of recent debugging.

## What's new

### 🔁 Sync tab
Selective table sync between LOCAL and REMOTE.

- **Whitelist** of tables (admin can't sync arbitrary tables):
  - ``translation_cache`` — pure cache, low-risk merge
  - ``vocab_entries`` — per-user vocab; merge-by-timestamp uses ``last_seen_at``
  - ``user_settings`` — already dual-written by app; this is the recovery tool for drift
- **Direction**: LOCAL → REMOTE or REMOTE → LOCAL
- **Conflict policies**:
  - ``skip`` — only insert rows whose unique key is missing on target
  - ``overwrite`` — upsert every source row
  - ``merge-by-timestamp`` — apply only when source's freshness column is newer (offered only for tables with a freshness column declared)
- **Preview** counts source / target / overlap / source-only / target-only before any work
- Apply gated behind ``st.popover`` + checkbox acknowledgement

### 🔌 Connections tab
Live diagnostics for the SSH-tunnel + connection pool.

- **Pool capacity snapshot** — active connections / tunnels / sessions, % capacity, soft-limit headroom
- **SSH tunnel list** — joined live with active connection count per tunnel
- **Sessions per (user, app)** — active count + ``expires_within_24h`` flag
- **Active MySQL connections** (raw, collapsed)
- **Cleanup actions** (popover-gated):
  - Purge stale ``connection_monitor`` rows (closed / 12h idle) — surfaces the existing pool helper
  - Mark dead tunnels via PID existence check (signal 0); does NOT touch live tunnels

### 🧹 Diagnostic scripts (housekeeping commit)
Four read-only / one-shot CLI scripts that grew out of the recent (fr,en)≠(pt,en) and Digby debugging sessions, now properly committed:

- ``scripts/diag/diag_vocab_keys.py`` — vocab unique-key + per-user breakdown
- ``scripts/diag/diag_user_auth.py`` — list users + argon2id hash prefixes
- ``scripts/diag/diag_schema_compare.py`` — full unfiltered schema dump + diff (companion to admin DB Health, which filters version cosmetics)
- ``scripts/migrate_local_users_to_remote.py`` — idempotent backfill of users from local to remote (recovery tool from before PR-1's dual-write)
- ``scripts/diag/README.md`` — describes each, points at admin-tab equivalent

All are standalone CLI tools, not imported by app code. Easy to delete later if they go stale.

### Other
- Created ``ADMIN_CHANGELOG.md`` so future ``bump_version.py admin`` runs have a changelog target instead of warning that it's missing.
- This is the **first admin-versioned PR**: bumped ``unified_admin.__version__`` from ``1.0.1-claude-dev`` to ``1.0.2-claude-dev``. App version (``src/config.py``) is **untouched**.

## Files

**New**
- ``src/admin_sync.py`` — sync whitelist, preview, policy-aware apply
- ``src/admin_connections.py`` — diagnostics queries + cleanup
- ``ADMIN_CHANGELOG.md``
- ``scripts/diag/README.md``
- ``scripts/diag/diag_*.py`` (3 files, moved from ``scripts/``)
- ``scripts/migrate_local_users_to_remote.py``

**Modified**
- ``src/miolingo-admin.py`` — Sync + Connections pages; new imports
- ``src/unified_admin.py`` — register new pages; ``__version__`` bumped

## Verification
- ✅ pytest 224/224 pass
- ✅ Syntax-check on all modified files
- ✅ Admin version-bump script ran cleanly with the new ``ADMIN_CHANGELOG.md``

## Test plan

- [ ] Open admin (``streamlit run src/unified_admin.py --server.port 8507``) → log in
- [ ] **🔁 Sync** with ``local_db.enabled=true`` and a real translation_cache row count drift: pick ``translation_cache``, REMOTE→LOCAL, **skip** policy, preview, apply, confirm count goes up on local
- [ ] Try **merge-by-timestamp** on ``vocab_entries`` (with at least one row updated more recently on one side) and confirm only the newer rows propagate
- [ ] **🔌 Connections** → refresh pool snapshot, tunnels, sessions, raw connections — all four should populate from remote
- [ ] Click "Purge stale connection rows" → expect a non-negative count
- [ ] Click "Mark dead tunnels" → expect a count of tunnels checked (most likely 0 marked dead in a healthy system)
- [ ] Toggle ``local_db.enabled = false`` and restart admin: 🔁 Sync should show the "local disabled" info banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)