### PR TITLE
docs(desktop): Phase 0 migration plan for native macOS port

### DIFF
--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -1,0 +1,178 @@
+# Miolingo Desktop — Agent Instructions (Phase 1: Autonomous Migration)
+
+This file governs the **native desktop port** of Miolingo. It is the operating
+manual for the autonomous Phase 1 agent. Read it fully before doing anything.
+
+> The desktop app lives entirely under `desktop/`. The existing Streamlit app
+> (repo root, `src/`) is the **reference implementation** — read it, port from
+> it, but **do not modify it** during this migration.
+
+---
+
+## 0. What you are building
+
+A native **macOS** desktop app (PySide6/Qt, packaged with PyInstaller) that
+replaces the Streamlit pronunciation trainer. It reuses the existing Python
+business logic (ASR, scoring, TTS, materials) and replaces only the Streamlit
+UI shell and the remote-MySQL storage layer.
+
+Read these before coding, in order:
+1. `desktop/SPEC.md` — the PRD: requirements, chosen stack, acceptance criteria.
+2. `desktop/MIGRATION_PLAN.md` — the milestone/PR sequence to execute.
+3. `desktop/DECISIONS.md` — decisions already made (don't re-litigate these).
+4. `desktop/QUESTIONS.md` — open questions for Matthew (don't block on them).
+5. Repo root `AGENTS.md` — architecture of the source app you're porting from.
+
+---
+
+## 1. HARD GUARDRAILS (never violate)
+
+These are absolute. Violating them is a failure regardless of outcome.
+
+- **NEVER push to `main`.** Never push to `claude/dev`, `claude/dev-swept`, or
+  `claude/dev-minimal-pairs` either. Those are integration branches.
+- **Always work on a feature branch.** One branch per milestone/PR.
+- **Always open a PR** for every shippable chunk. Never land work without a PR.
+- **Run the test suite before opening any PR.** A PR may not be opened if tests
+  fail. See §4.
+- **Never modify the existing Streamlit app** (`src/`, root `app.py`, root
+  `CLAUDE.md`, `AGENTS.md`). Port *from* it; leave it working.
+- **Never commit secrets.** No API keys, DB creds, Apple certs, or
+  `secrets.toml` content. Use `.gitignore` and environment/keychain.
+- **Never create remote DB tunnels or connections.** The desktop app is
+  local-first (SQLite). There is no SSH tunnel in this app.
+
+---
+
+## 2. Autonomy convention (how to make progress without Matthew)
+
+Phase 1 runs unattended. Matthew is unavailable. Therefore:
+
+> **When you hit a decision point, choose the most reasonable option, record it
+> in `desktop/DECISIONS.md` (with reasoning + alternatives considered), and
+> continue. Never block waiting for input. Put anything you'd want Matthew's
+> ruling on into `desktop/QUESTIONS.md` and keep working.**
+
+Rules of thumb for the autonomy convention:
+- Prefer the option that (a) preserves offline-first behaviour, (b) keeps the
+  Python core reusable, (c) is simplest to test headlessly, (d) is reversible.
+- If a choice is cheap and reversible, just make it and note it in DECISIONS.md.
+- If a choice is expensive/irreversible (e.g. a schema you'll build a lot on top
+  of, a dependency that's hard to remove), pick the conservative option, build
+  behind it, and log the trade-off in both DECISIONS.md and QUESTIONS.md.
+- If blocked by something you genuinely cannot decide or fake (e.g. an Apple
+  signing certificate you don't have), stub/skip that step, document it in
+  QUESTIONS.md, and continue with everything else. Do not stall the whole plan.
+
+Keep DECISIONS.md and QUESTIONS.md append-only and dated.
+
+---
+
+## 3. Project layout (target)
+
+```
+desktop/
+├── CLAUDE.md            # this file
+├── SPEC.md              # PRD
+├── MIGRATION_PLAN.md    # milestone/PR sequence
+├── DECISIONS.md         # decision log (append-only)
+├── QUESTIONS.md         # open questions for Matthew (append-only)
+├── pyproject.toml       # desktop app deps + tooling (created in M1)
+├── miolingo_desktop/    # the app package
+│   ├── __init__.py
+│   ├── main.py          # PySide6 entry point
+│   ├── core/            # ported, UI-free business logic (asr, tts, scoring, ...)
+│   ├── data/            # SQLite storage layer + migrations
+│   ├── ui/              # Qt widgets/views (Practice, Vocabulary, History, Stats)
+│   └── resources/       # bundled models/voices/content references
+├── tests/               # pytest suite for the desktop app
+└── packaging/           # PyInstaller spec, .dmg build, notarization scripts
+```
+
+The ported business logic in `miolingo_desktop/core/` must be **UI-framework
+free** — no `import streamlit`, no `import PySide6`. It takes plain args and
+returns plain values, so it stays testable headlessly. (The source modules
+`src/scoring/`, `src/audio/asr.py`, `src/audio/tts.py`, `src/config.py`,
+`src/app_language_materials.py` are already close to this — strip the
+`st.session_state`/`@st.cache_data`/`st.spinner` coupling when porting.)
+
+---
+
+## 4. Build / test / run commands
+
+All commands run from `desktop/` unless noted. Use the repo venv at
+`/Users/matthew/Software/working/miolingo/venv` (created in Phase 0) or a
+dedicated `desktop/.venv`; record which in DECISIONS.md.
+
+```bash
+# Activate environment (decide & document which venv in M1):
+source /Users/matthew/Software/working/miolingo/venv/bin/activate
+
+# Install desktop deps (after pyproject.toml exists):
+pip install -e ".[dev]"
+
+# Run the app (dev):
+python -m miolingo_desktop.main
+
+# Run the FULL test suite — REQUIRED green before any PR:
+pytest -q
+
+# Run only fast/headless unit tests:
+pytest tests/unit -q
+
+# Lint / type-check (configure in M1; treat failures as blocking):
+ruff check .
+mypy miolingo_desktop
+
+# Build the macOS app + .dmg (after packaging exists):
+python packaging/build_macos.py
+```
+
+Qt GUI tests must run headlessly in CI/cloud. Use `pytest-qt` with the
+`offscreen` platform: `QT_QPA_PLATFORM=offscreen pytest -q`. Any test that
+needs a display, a microphone, or network must be marked
+`@pytest.mark.manual` and excluded from the required pre-PR run.
+
+---
+
+## 5. Git workflow (per PR)
+
+```bash
+git fetch origin
+git switch -c claude/desktop-<milestone-slug> origin/claude/dev-minimal-pairs
+
+# ... do the work, keep core/ UI-free, add tests ...
+
+pytest -q                      # MUST be green
+git add desktop/<changed files>
+git commit -m "feat(desktop): <what and why>"
+
+# First push — explicit refspec (avoids inheriting the base branch upstream):
+git push -u origin HEAD:refs/heads/claude/desktop-<milestone-slug>
+
+gh pr create --base claude/dev-minimal-pairs \
+  --title "desktop(Mn): <title>" --body "<summary + test plan>"
+```
+
+- PRs target **`claude/dev-minimal-pairs`** (the repo's integration branch),
+  never `main`.
+- One PR per milestone in MIGRATION_PLAN.md. Each PR must be independently
+  reviewable and leave the desktop app in a working (if incomplete) state.
+- Before the first push on a branch, verify upstream matches the local name
+  (`git rev-parse --abbrev-ref @{u}`); if not, use the `HEAD:refs/heads/<name>`
+  refspec form.
+
+---
+
+## 6. Definition of done (every PR)
+
+A PR is done only when **all** hold:
+- [ ] Code for the milestone's acceptance criteria (see SPEC.md) is implemented.
+- [ ] `pytest -q` is green (headless), including new tests for the new behaviour.
+- [ ] `ruff` and `mypy` pass (or new violations are documented and justified).
+- [ ] No `import streamlit` anywhere under `desktop/`.
+- [ ] No secrets committed.
+- [ ] DECISIONS.md updated for any non-trivial choice made in the PR.
+- [ ] The app still launches (`python -m miolingo_desktop.main`) and the
+      milestone's vertical slice works.
+- [ ] PR description lists what changed and a test plan.

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -76,6 +76,35 @@ Phase 1 a clean, self-contained working directory; avoids clobbering the
 critical Streamlit/DB rules in the root `CLAUDE.md`.
 **Made by planning agent (Phase 0).**
 
+### 2026-05-23 (rev) — Whisper default = `medium`, downloaded on first run
+**Decision:** Default Whisper model is **`medium`** (not `base`). Not bundled
+(~1.5 GB); downloaded on first run with progress and cached locally so the app
+is offline thereafter. Model size adjustable in settings (down to `base`).
+**Reasoning:** Matthew uses `medium` — `base` accuracy is not good enough, and
+an inaccurate transcript compromises the whole practice/scoring cycle. Accuracy
+beats size/speed here. Bundling 1.5 GB would bloat the `.dmg`, so
+download-on-first-run is the better trade. Use Apple-Silicon accel where
+possible to offset the slower model.
+**Alternatives:** bundle `medium` (huge `.dmg`); keep `base` (rejected on
+accuracy). **Supersedes the earlier `base` decision; chosen by Matthew.**
+
+### 2026-05-23 (rev) — Cloud sync target = Matthew's own DB, end-of-session push
+**Decision:** Sync (a fast-follow, not core v1) pushes local data to Matthew's
+own existing remote DB as a **batch at the end of a session**, not live. v1
+keeps the schema sync-ready and may stub a session-end export.
+**Reasoning:** Matthew confirmed syncing to his own DB at session end is
+feasible — resolves the "no custom backend" concern (he already has the DB).
+Batch-at-session-end is simpler and avoids per-write coupling.
+**Alternatives:** live sync (more complex); BaaS/WordPress endpoint (unneeded —
+he has his own DB). **Chosen by Matthew.**
+
+### 2026-05-23 (rev) — Apple Developer ID expected to be available
+**Decision:** Plan for a signed/notarized `.dmg`; build scripts assume an Apple
+Developer ID is provided. Keep an unsigned-build fallback + documented signing
+steps if the cert isn't present at build time.
+**Reasoning:** Matthew says he can likely obtain a signed Apple ID.
+**Chosen by Matthew (tentative — "possibly").**
+
 ### 2026-05-23 — Story Reader deferred to post-v1
 **Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
 it in only if cheap after M3, else post-v1.

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -1,0 +1,84 @@
+# Decision Log — Miolingo Desktop
+
+Append-only. Newest at the bottom. Each entry: date, decision, reasoning,
+alternatives considered. Phase 1 adds to this whenever it makes a non-trivial
+choice (see the autonomy convention in `CLAUDE.md`).
+
+---
+
+### 2026-05-23 — Target stack: PySide6/Qt + PyInstaller
+**Decision:** Build the native app with PySide6 and package with PyInstaller.
+**Reasoning:** The business logic (Whisper ASR, scoring, TTS, materials) is
+already Python and largely decoupled from Streamlit, so this keeps the entire
+core and rewrites only the UI shell + storage. Fully offline, headlessly
+testable, one codebase ports to Win/Linux later.
+**Alternatives:** pywebview+web UI (frontend rewrite + bridge), Tauri+Python
+sidecar (Rust + most moving parts), Flutter (full Dart rewrite, loses Python
+core), BeeWare/Toga (immature for torch/whisper). **Chosen by Matthew in Phase 0.**
+
+### 2026-05-23 — Storage: local SQLite, local-first, sync-ready
+**Decision:** All user data in a local SQLite DB under
+`~/Library/Application Support/Miolingo/`. Schema uses UUID PKs,
+`created_at`/`updated_at`, soft-delete — sync-ready but no sync built in v1.
+**Reasoning:** Matthew can't host custom backends; desktop app must be offline
+and self-contained. Sync-ready schema avoids a painful migration later.
+**Alternatives:** keep remote MySQL+SSH (retains the latency/hosting coupling
+we're escaping); build sync now (mechanism unresolved — see QUESTIONS).
+**Chosen by Matthew (local-first + optional later sync).**
+
+### 2026-05-23 — No auth in v1 (single local user)
+**Decision:** Drop Argon2 login / multi-user. One implicit local user.
+**Reasoning:** A distributed single-user desktop app doesn't need server-side
+auth; removing it cuts large surface area (`app_mysql` auth, sessions, cookies).
+**Alternatives:** keep accounts (only needed if multi-user/sync, both deferred).
+**Implied by Matthew's data-model choice.**
+
+### 2026-05-23 — Default offline TTS: Piper; espeak demoted
+**Decision:** Bundle Piper neural voices as the default offline TTS; Google
+Cloud TTS optional/online; espeak last-resort fallback only.
+**Reasoning:** Matthew: espeak quality is "unspeakably bad." Piper is local,
+fast, good quality, MIT-licensed, covers the target languages. Keeps offline.
+**Alternatives:** online-only TTS (no offline audio); keep espeak (rejected on
+quality). **Chosen by Matthew.**
+
+### 2026-05-23 — ASR: Whisper local (`base`), wav2vec2 dropped
+**Decision:** Whisper running locally, default model `base`, ffmpeg bundled.
+Drop wav2vec2.
+**Reasoning:** Whisper covers all languages and already works; wav2vec2 is
+Portuguese-only and heavy. Local = offline.
+**Alternatives:** keep wav2vec2 (Portuguese-only, not worth the footprint).
+
+### 2026-05-23 — Platform: macOS only for v1
+**Decision:** Ship macOS first; keep code cross-platform-clean. Win/Linux are
+non-goals for v1.
+**Reasoning:** Focus polish; PyInstaller makes later Win/Linux cheap.
+**Chosen by Matthew.**
+
+### 2026-05-23 — Performance bar: snappy UI, scoring best-effort
+**Decision:** UI < 100 ms / no full reruns / never freezes (work off-thread);
+transcription latency best-effort with progress + cancel.
+**Reasoning:** The Streamlit pain is the full-script rerun, not raw model speed.
+Fixing responsiveness is the win; Whisper latency is inherent.
+**Chosen by Matthew.**
+
+### 2026-05-23 — Distribution: signed/notarized .dmg, manual updates
+**Decision:** Direct-download notarized `.dmg`; no auto-update, no App Store.
+Signing gated on Apple Developer ID availability (see QUESTIONS).
+**Reasoning:** Simplest credible distribution for v1; Sparkle/Store are later.
+**Chosen by Matthew.**
+
+### 2026-05-23 — Docs & app live under `desktop/`; source app untouched
+**Decision:** All migration docs and the new app live under `desktop/`. The
+existing Streamlit app (`src/`, root `CLAUDE.md`, `AGENTS.md`) is read-only
+reference during migration.
+**Reasoning:** Keeps the working app intact as a reference/fallback; gives
+Phase 1 a clean, self-contained working directory; avoids clobbering the
+critical Streamlit/DB rules in the root `CLAUDE.md`.
+**Made by planning agent (Phase 0).**
+
+### 2026-05-23 — Story Reader deferred to post-v1
+**Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
+it in only if cheap after M3, else post-v1.
+**Reasoning:** Matthew's must-keep selection in Phase 0 was Quick Practice,
+Vocabulary, History+Statistics — Story Reader was not selected.
+**Flagged for confirmation in QUESTIONS.md.**

--- a/desktop/MIGRATION_PLAN.md
+++ b/desktop/MIGRATION_PLAN.md
@@ -61,9 +61,10 @@ SQLite persistence, sync-ready schema. No UI yet.
 The proof-of-concept PR. One language, the full loop, real audio, persisted.
 
 - `ui/practice_view.py`: select language + phrase, play target audio (Piper —
-  bundle at least one voice now, M5 completes coverage), record mic input,
-  run Whisper transcription **off the UI thread**, show score + edit feedback,
-  save the attempt to SQLite.
+  bundle at least one voice now, M7 completes coverage), record mic input,
+  run Whisper transcription (default model **`medium`**, downloaded on first
+  run with progress) **off the UI thread**, show score + edit feedback, save
+  the attempt to SQLite.
 - Wire `core/` + `data/` together behind a small app controller.
 - Threading: `QThreadPool`/worker for transcription + TTS; progress + cancel.
 - **Tests:** Qt smoke test of the view (offscreen); an integration test that
@@ -118,9 +119,11 @@ Build what Streamlit never finished.
 
 - `packaging/build_macos.py` + PyInstaller spec. Bundle Python, Qt, Whisper
   `base` model, ffmpeg, Piper voices, and `language_materials/`.
-- Signing/notarization scripted but **gated on Apple Developer ID**: if absent,
-  produce an unsigned `.app`/`.dmg` and document the exact signing/notarize
-  steps in `packaging/SIGNING.md` + QUESTIONS.md.
+- Whisper `medium` is **not** bundled (~1.5 GB); it downloads on first run with
+  a progress UI and caches locally. Bundle ffmpeg, Qt, Piper voices, content.
+- Signing/notarization scripted; Matthew expects to provide an Apple Developer
+  ID. If absent at build time, produce an unsigned `.app`/`.dmg` and document
+  the exact signing/notarize steps in `packaging/SIGNING.md` + QUESTIONS.md.
 - **Tests:** a build smoke check that the produced bundle launches and the DB
   initializes (best-effort in cloud; document if it must be verified on a Mac).
 - **Acceptance:** `python packaging/build_macos.py` yields a launchable bundle;
@@ -134,7 +137,9 @@ Build what Streamlit never finished.
   scaffolding makes it cheap; otherwise post-v1. Confirm with Matthew.
 - **Online premium TTS** (Google Cloud) beyond the fallback hook in M7.
 - **LLM/DeepL translation** aid.
-- **Cloud sync** — schema is sync-ready (M2); mechanism unresolved (QUESTIONS).
+- **Cloud sync (fast-follow)** — schema is sync-ready (M2); target is Matthew's
+  own remote DB via an **end-of-session batch push**. v1 may stub a session-end
+  export; full push needs the endpoint/credentials (QUESTIONS).
 - **Auto-update (Sparkle)**, **Windows/Linux builds**.
 
 ## Sequencing rationale

--- a/desktop/MIGRATION_PLAN.md
+++ b/desktop/MIGRATION_PLAN.md
@@ -1,0 +1,146 @@
+# Miolingo Desktop — Migration Plan
+
+Execution plan for Phase 1 (autonomous). Each milestone = **one PR** targeting
+`claude/dev-minimal-pairs`, independently reviewable, leaving the app working.
+Sequenced so the **vertical slice** (a real practice attempt, end to end) is
+proven early — before breadth.
+
+Conventions: see `desktop/CLAUDE.md`. Don't start a milestone until the prior
+PR's acceptance checks pass. Record decisions in `DECISIONS.md` as you go.
+
+---
+
+## Milestone 0 — Scaffold & toolchain  → PR `desktop-m0-scaffold`
+
+Stand up an empty-but-runnable PySide6 app and the test/lint/CI plumbing.
+
+- `desktop/pyproject.toml` with deps (PySide6, openai-whisper, piper-tts,
+  numpy, soundfile) and `[dev]` extras (pytest, pytest-qt, ruff, mypy).
+- `miolingo_desktop/main.py`: opens an empty `QMainWindow` titled "Miolingo".
+- `tests/unit/test_smoke.py`: imports the package; a `pytest-qt` test that the
+  main window constructs under `QT_QPA_PLATFORM=offscreen`.
+- Decide & document the venv (shared repo venv vs `desktop/.venv`).
+- **Acceptance:** `python -m miolingo_desktop.main` shows a window; `pytest -q`
+  green headless; `ruff`/`mypy` pass.
+
+## Milestone 1 — Port the UI-free core  → PR `desktop-m1-core`
+
+Move business logic into `miolingo_desktop/core/`, stripped of Streamlit.
+
+- Port `config.py`, `scoring/` (comparison + phonemes), `audio/asr.py`,
+  `audio/tts.py`, `app_language_materials.py`, `pronunciation_trainer.py`,
+  `translation*.py` into `core/`. Remove `import streamlit`,
+  `@st.cache_data`, `st.spinner`, `st.session_state` — replace caching with
+  plain in-process caches/lru_cache; replace `st.*` callbacks with injected
+  callables or return values.
+- Model/voice loaders become plain functions (no session_state).
+- **Tests:** unit tests for scoring against fixed (reference, hypothesis)
+  inputs; a **regression fixture** capturing the source app's score for a known
+  (audio, reference) pair so parity is provable. Materials-loading tests.
+- **Acceptance:** `core/` has zero UI imports; scoring parity test passes;
+  `pytest -q` green.
+
+## Milestone 2 — Local storage layer  → PR `desktop-m2-storage`
+
+SQLite persistence, sync-ready schema. No UI yet.
+
+- `miolingo_desktop/data/`: SQLite at
+  `~/Library/Application Support/Miolingo/miolingo.db`; schema migrations
+  (e.g. simple versioned SQL or `yoyo`/`alembic` — pick one, document).
+- Tables: `settings`, `practice_attempts`, `vocabulary`, (+ `progress` if
+  needed). UUID PKs, `created_at`/`updated_at`, `deleted_at` soft-delete.
+- Repository classes with typed methods (save attempt, list history, CRUD
+  vocab, get/set settings). Mirror the data shapes used by the source
+  `app_mysql.py` so ported logic fits.
+- **Tests:** CRUD round-trips against a temp-file SQLite DB; migration applies
+  cleanly to an empty DB; soft-delete hides rows.
+- **Acceptance:** repo tests green; DB created on first run.
+
+## Milestone 3 — VERTICAL SLICE: Quick Practice end-to-end  → PR `desktop-m3-practice`
+
+The proof-of-concept PR. One language, the full loop, real audio, persisted.
+
+- `ui/practice_view.py`: select language + phrase, play target audio (Piper —
+  bundle at least one voice now, M5 completes coverage), record mic input,
+  run Whisper transcription **off the UI thread**, show score + edit feedback,
+  save the attempt to SQLite.
+- Wire `core/` + `data/` together behind a small app controller.
+- Threading: `QThreadPool`/worker for transcription + TTS; progress + cancel.
+- **Tests:** Qt smoke test of the view (offscreen); an integration test that
+  drives controller `record→transcribe(stub)→score→save` and asserts a row in
+  SQLite; a test asserting transcription runs off the GUI thread.
+- **Acceptance (this is the milestone that proves the whole approach):** on
+  macOS, a human can pick a phrase, hear Piper audio, record, and get a score
+  that persists to History — **with the UI staying responsive**. Offline.
+
+## Milestone 4 — History + Settings  → PR `desktop-m4-history-settings`
+
+- `ui/history_view.py`: list past attempts (score, phrase, language, date)
+  from SQLite; restart-persistent.
+- `ui/settings_view.py` + persistence: language, voice, Whisper model size,
+  scoring algorithm, TTS engine. Restored on relaunch.
+- **Tests:** history renders seeded rows; settings round-trip persist/restore.
+- **Acceptance:** attempts from M3 show in History across restarts; settings
+  persist.
+
+## Milestone 5 — Vocabulary  → PR `desktop-m5-vocabulary`
+
+- `ui/vocabulary_view.py`: per-language word list — add, edit, delete (soft),
+  source context, autofill, **CSV export**, and "practice from vocab" (feeds a
+  word into the M3 practice flow).
+- **Tests:** CRUD via UI controller; CSV export content; practice-from-vocab
+  hands a word to the practice controller.
+- **Acceptance:** vocab CRUD + CSV export + practice-from-vocab work and persist.
+
+## Milestone 6 — Statistics  → PR `desktop-m6-statistics`
+
+Build what Streamlit never finished.
+
+- `ui/statistics_view.py`: attempts count + accuracy-over-time trend, per
+  language, computed from SQLite. Use Qt charts (`QtCharts`) or a matplotlib
+  canvas — pick one, document.
+- **Tests:** stat aggregation functions over seeded data (pure, headless);
+  view smoke test.
+- **Acceptance:** Statistics renders real charts from local data, offline.
+
+## Milestone 7 — Full Piper voice coverage + TTS fallback  → PR `desktop-m7-tts`
+
+- Bundle a vetted Piper voice for **every** supported language (pt, fr, de, es,
+  it, nl, en). Implement the dispatcher: Piper → Google Cloud (optional/online)
+  → espeak (last resort).
+- Generate sample clips per language into `packaging/` artifacts for Matthew to
+  spot-check quality (note in QUESTIONS.md if any voice is weak).
+- **Tests:** dispatcher selection logic; each bundled voice synthesizes a clip
+  offline.
+- **Acceptance:** every language has offline Piper audio; fallback order works.
+
+## Milestone 8 — macOS packaging  → PR `desktop-m8-packaging`
+
+- `packaging/build_macos.py` + PyInstaller spec. Bundle Python, Qt, Whisper
+  `base` model, ffmpeg, Piper voices, and `language_materials/`.
+- Signing/notarization scripted but **gated on Apple Developer ID**: if absent,
+  produce an unsigned `.app`/`.dmg` and document the exact signing/notarize
+  steps in `packaging/SIGNING.md` + QUESTIONS.md.
+- **Tests:** a build smoke check that the produced bundle launches and the DB
+  initializes (best-effort in cloud; document if it must be verified on a Mac).
+- **Acceptance:** `python packaging/build_macos.py` yields a launchable bundle;
+  full offline core loop works from the packaged app.
+
+---
+
+## Deferred / fast-follow (not in v1 unless cheap)
+
+- **Story Reader** (full + scene-by-scene) — slot after M3 if the rendering
+  scaffolding makes it cheap; otherwise post-v1. Confirm with Matthew.
+- **Online premium TTS** (Google Cloud) beyond the fallback hook in M7.
+- **LLM/DeepL translation** aid.
+- **Cloud sync** — schema is sync-ready (M2); mechanism unresolved (QUESTIONS).
+- **Auto-update (Sparkle)**, **Windows/Linux builds**.
+
+## Sequencing rationale
+
+M0–M2 build the skeleton (UI shell, core, storage) with no user-visible
+feature. **M3 is deliberately the first feature and is a full vertical slice** —
+it exercises every layer (UI thread-safety, Piper, Whisper, scoring, SQLite) and
+de-risks the entire approach before investing in breadth (M4–M7). Packaging is
+last so it bundles a known-working app.

--- a/desktop/QUESTIONS.md
+++ b/desktop/QUESTIONS.md
@@ -9,23 +9,19 @@ proceeding under.
 
 ---
 
-### 2026-05-23 — How should optional cloud sync work, given no custom backend?
-**Why it matters:** You want local-first + *optional* sync, but you can't host
-custom server code (only packaged tools like WordPress). v1 won't build sync,
-but the eventual mechanism affects nothing structurally except confirming the
-sync-ready schema is enough.
-**Candidates:** (a) file-based sync via your own cloud drive (iCloud/Dropbox
-folder holding the SQLite file or an export); (b) a managed BaaS free tier
-(Supabase/Firebase) — no self-hosting; (c) a small WordPress plugin/REST
-endpoint as the sync server. **Interim assumption:** schema is sync-ready
-(UUID PK, timestamps, soft-delete); sync deferred entirely to post-v1.
+### 2026-05-23 — [RESOLVED] Cloud sync mechanism
+**Answer (Matthew):** Sync to **his own existing DB**, feasible as a **batch
+push at the end of each session**. Resolves the "no custom backend" worry — he
+already has the DB. Full sync is a fast-follow; v1 stays sync-ready (schema with
+UUID PK / timestamps / soft-delete) and may stub a session-end export.
+**Open sub-question for Phase 1:** the exact DB endpoint/credentials and whether
+to reuse the source app's remote MySQL. Phase 1 needs these to build the actual
+push — keep them out of version control (env/keychain).
 
-### 2026-05-23 — Do you have an Apple Developer ID for signing/notarization?
-**Why it matters:** Determines whether v1 ships a properly notarized `.dmg` or
-an unsigned bundle (users must right-click-open past Gatekeeper).
-**Interim assumption:** packaging scripts support signing/notarization but, if
-no cert is available in the build environment, Phase 1 produces an **unsigned**
-bundle and documents the exact signing steps in `packaging/SIGNING.md`.
+### 2026-05-23 — [RESOLVED, tentative] Apple Developer ID
+**Answer (Matthew):** Can likely obtain a signed Apple ID ("possibly"). Plan
+for a signed/notarized `.dmg`; keep the unsigned-build fallback + documented
+signing steps in `packaging/SIGNING.md` if the cert isn't present at build time.
 
 ### 2026-05-23 — Confirm Story Reader is deferred (not dropped) for v1.
 **Why it matters:** It was not in your must-keep selection. Confirming lets
@@ -33,11 +29,14 @@ Phase 1 either skip it cleanly or slot it after M3 if cheap.
 **Interim assumption:** deferred to post-v1; built only if it falls out cheaply
 once the practice-rendering scaffolding exists.
 
-### 2026-05-23 — Is bundling Whisper `base` (~140 MB) acceptable for app size?
-**Why it matters:** Bundling guarantees true offline first-run but inflates the
-`.dmg`. The alternative is download-on-first-run (needs network once).
-**Interim assumption:** bundle Whisper `base` for guaranteed offline; expose
-model size in settings.
+### 2026-05-23 — [RESOLVED] Whisper model — use `medium`
+**Answer (Matthew):** `base` accuracy isn't good enough — he uses `medium`, and
+an inaccurate transcript compromises the whole practice cycle. So default to
+`medium`. Since it's ~1.5 GB it's **not bundled**; downloaded on first run with
+progress, cached locally (offline thereafter). Size adjustable in settings.
+**Residual note for Phase 1:** confirm `medium` latency is tolerable on
+Matthew's Mac; lean on Apple-Silicon acceleration. If too slow, expose an easy
+`small`/`base` toggle (no ruling needed — just make it adjustable).
 
 ### 2026-05-23 — Which Piper voice per language meets your quality bar?
 **Why it matters:** Piper offers multiple voices per language at different

--- a/desktop/QUESTIONS.md
+++ b/desktop/QUESTIONS.md
@@ -1,0 +1,47 @@
+# Open Questions for Matthew — Miolingo Desktop
+
+Append-only. Phase 1 adds questions here when it wants Matthew's ruling but must
+**not block** — it makes a reasonable call (logged in DECISIONS.md) and keeps
+going. Matthew answers async; answers may redirect later work.
+
+Format: date, question, why it matters, the interim assumption Phase 1 is
+proceeding under.
+
+---
+
+### 2026-05-23 — How should optional cloud sync work, given no custom backend?
+**Why it matters:** You want local-first + *optional* sync, but you can't host
+custom server code (only packaged tools like WordPress). v1 won't build sync,
+but the eventual mechanism affects nothing structurally except confirming the
+sync-ready schema is enough.
+**Candidates:** (a) file-based sync via your own cloud drive (iCloud/Dropbox
+folder holding the SQLite file or an export); (b) a managed BaaS free tier
+(Supabase/Firebase) — no self-hosting; (c) a small WordPress plugin/REST
+endpoint as the sync server. **Interim assumption:** schema is sync-ready
+(UUID PK, timestamps, soft-delete); sync deferred entirely to post-v1.
+
+### 2026-05-23 — Do you have an Apple Developer ID for signing/notarization?
+**Why it matters:** Determines whether v1 ships a properly notarized `.dmg` or
+an unsigned bundle (users must right-click-open past Gatekeeper).
+**Interim assumption:** packaging scripts support signing/notarization but, if
+no cert is available in the build environment, Phase 1 produces an **unsigned**
+bundle and documents the exact signing steps in `packaging/SIGNING.md`.
+
+### 2026-05-23 — Confirm Story Reader is deferred (not dropped) for v1.
+**Why it matters:** It was not in your must-keep selection. Confirming lets
+Phase 1 either skip it cleanly or slot it after M3 if cheap.
+**Interim assumption:** deferred to post-v1; built only if it falls out cheaply
+once the practice-rendering scaffolding exists.
+
+### 2026-05-23 — Is bundling Whisper `base` (~140 MB) acceptable for app size?
+**Why it matters:** Bundling guarantees true offline first-run but inflates the
+`.dmg`. The alternative is download-on-first-run (needs network once).
+**Interim assumption:** bundle Whisper `base` for guaranteed offline; expose
+model size in settings.
+
+### 2026-05-23 — Which Piper voice per language meets your quality bar?
+**Why it matters:** Piper offers multiple voices per language at different
+quality/size tiers; you have strong opinions on TTS quality.
+**Interim assumption:** Phase 1 picks a reasonable medium-quality voice per
+language and produces sample clips (M7) for you to spot-check; weak ones get
+flagged here for replacement.

--- a/desktop/SPEC.md
+++ b/desktop/SPEC.md
@@ -85,8 +85,9 @@ Python sidecar = most moving parts, hardest to run autonomously); Flutter
 - The admin dashboard (`src/miolingo-admin.py`, `src/admin_mysql.py`) — server
   ops, not relevant to a distributed desktop app.
 - wav2vec2 ASR (Portuguese-only, heavy) — Whisper covers all languages.
-- Cloud sync **implementation** (schema must be sync-ready; sync itself is
-  post-v1 — see §6 and QUESTIONS.md).
+- Full cloud-sync **implementation** is a fast-follow, not core v1 (schema must
+  be sync-ready; target is Matthew's own DB via end-of-session batch push — see
+  §6 and QUESTIONS.md). v1 may stub a session-end export.
 - Auto-update (manual download for v1).
 - Windows/Linux builds.
 
@@ -101,8 +102,13 @@ Python sidecar = most moving parts, hardest to run autonomously); Flutter
   supplies credentials and is online. Off by default.
 - The TTS dispatcher must degrade gracefully: Piper (offline) → Google Cloud
   (if configured + online) → espeak (last resort).
-- **ASR: Whisper**, default model `base`, running locally. Requires `ffmpeg`
-  bundled in the app. wav2vec2 dropped.
+- **ASR: Whisper**, default model **`medium`**, running locally. Transcription
+  accuracy is load-bearing — an inaccurate transcript compromises the entire
+  practice/scoring cycle, so we favour accuracy over model size/speed. Model
+  size is user-adjustable in settings (down to `base` for slow machines).
+  Requires `ffmpeg` bundled. Use Apple-Silicon acceleration where available.
+  wav2vec2 dropped. (`medium` is ~1.5 GB → handled via download-on-first-run,
+  not bundled — see §8.)
 
 ---
 
@@ -112,11 +118,12 @@ Python sidecar = most moving parts, hardest to run autonomously); Flutter
   vocabulary — lives in a **local SQLite database** in the macOS app-support
   directory (`~/Library/Application Support/Miolingo/`). No network needed.
 - **No login/auth in v1.** Single implicit local user.
-- **Sync-ready schema (but no sync in v1):** design tables with stable UUID
-  primary keys, `created_at`/`updated_at` timestamps, and soft-delete flags so
-  optional cloud sync can be added later without a migration. The *mechanism*
-  for sync (given Matthew can't host custom backends) is unresolved — see
-  QUESTIONS.md. Do not build sync in v1.
+- **Sync-ready schema:** design tables with stable UUID primary keys,
+  `created_at`/`updated_at` timestamps, and soft-delete flags. Sync target is
+  **Matthew's own (existing remote) database**, as a **batch push at the end of
+  a session** (not live per-write). v1 keeps the schema sync-ready and may stub
+  a session-end export; the full sync push is a fast-follow, not core v1 — see
+  QUESTIONS.md for the exact endpoint/credentials.
 - **No in-app state framework reruns.** UI state is held in Qt
   models/view-state, not by re-executing the whole program. Settings persist to
   SQLite (mirrors `config.load_settings`/`save_settings`, DB path).
@@ -181,8 +188,9 @@ is checkable without Matthew.
       time, per language. Renders from local data with no network.
 
 **Offline**
-- [ ] With networking disabled, the full core loop (select → Piper audio →
-      record → Whisper score → save → History → Stats) works end to end.
+- [ ] After the one-time Whisper-model download, with networking disabled the
+      full core loop (select → Piper audio → record → Whisper score → save →
+      History → Stats) works end to end.
 
 **Quality gates**
 - [ ] `pytest -q` green headless (`QT_QPA_PLATFORM=offscreen`), including unit
@@ -191,9 +199,12 @@ is checkable without Matthew.
 
 **Packaging**
 - [ ] `python packaging/build_macos.py` produces a launchable `.app`/`.dmg`
-      bundling Python, Qt, Whisper `base`, ffmpeg, Piper voices, and
-      `language_materials/`. (Signing/notarization gated on Apple ID — if
-      absent, an unsigned bundle + documented signing steps satisfy this.)
+      bundling Python, Qt, ffmpeg, Piper voices, and `language_materials/`. The
+      Whisper `medium` model is fetched on first run (with progress UI) and
+      cached locally; offline works after that one-time download.
+      (Signing/notarization gated on Apple ID — Matthew expects to provide one;
+      if absent at build time, an unsigned bundle + documented signing steps
+      satisfy this.)
 
 **Non-goals respected**
 - [ ] No login UI, no remote DB/tunnel code, no admin dashboard, no Windows/

--- a/desktop/SPEC.md
+++ b/desktop/SPEC.md
@@ -1,0 +1,200 @@
+# Miolingo Desktop — Product Requirements (SPEC)
+
+**Status:** Phase 0 (approved direction, ready for autonomous build)
+**Owner:** Matthew Fairtlough
+**Last updated:** 2026-05-23
+
+---
+
+## 1. Problem & goal
+
+Miolingo is a multi-language pronunciation trainer. The current implementation
+is a Streamlit web app backed by remote MySQL over an SSH tunnel. Streamlit
+re-runs the whole script on every interaction, which is **unacceptably slow**,
+especially on the shared community server. Matthew cannot host custom server
+code (hosting only supports packaged tools like WordPress).
+
+**Goal:** ship a **native macOS desktop app** that delivers the same core
+training experience with a snappy, no-full-reload UI, works offline, and stores
+user data locally — distributed as a downloadable app rather than a hosted site.
+
+---
+
+## 2. Chosen target stack (decision)
+
+**PySide6 (Qt for Python) + PyInstaller**, packaged as a signed/notarized macOS
+`.dmg`.
+
+**Why this stack:**
+- The expensive, correctness-critical logic (Whisper ASR, espeak/Piper TTS,
+  Levenshtein/phoneme scoring, translation, materials loading) is **already
+  Python and already largely decoupled** from Streamlit. PySide6 keeps 100% of
+  that core — the migration is "replace the UI shell + storage," not a rewrite.
+- Fully offline-capable; no JS/Python bridge or Rust toolchain to maintain.
+- One Python codebase ports cleanly to Windows/Linux later (PyInstaller targets
+  all three) without rewriting business logic.
+- Headlessly testable (`pytest-qt` + `QT_QPA_PLATFORM=offscreen`), which the
+  autonomous Phase 1 needs.
+
+**Alternatives considered:** pywebview + web UI (rejected: frontend rewrite in
+JS + bridge complexity); Tauri + Python sidecar (rejected: Rust + packaged-
+Python sidecar = most moving parts, hardest to run autonomously); Flutter
+(rejected: full Dart rewrite, loses the Python ASR core); BeeWare/Toga
+(rejected: immature for heavy deps like torch/whisper). See DECISIONS.md.
+
+---
+
+## 3. Target users & platforms
+
+- **v1: macOS only** (Apple Silicon + Intel if feasible from one build).
+- Keep the codebase cross-platform-clean so Windows/Linux are a cheap later
+  follow-up. **Windows/Linux are explicit non-goals for v1.**
+- Single local user per install (see §6).
+
+---
+
+## 4. Feature requirements
+
+### 4.1 Must-keep (v1)
+
+| Feature | Source reference | Notes |
+|---|---|---|
+| **Quick Practice** | `render_quick_practice_tab`, `practice_word_from_audio` (`src/app.py`), `src/scoring/`, `src/audio/asr.py` | Core loop: pick phrase/word → hear target audio → record → transcribe → score → show feedback. This is the product. |
+| **Vocabulary** | personal-vocabulary feature in `src/app.py` + `src/app_mysql.py` | Per-language word tracker: add, edit, source context, autofill, CSV export, practice-from-vocab. |
+| **History** | `load_history`/`save_history` (`src/app.py`), progress tables in `src/app_mysql.py` | List of past practice attempts with scores. |
+| **Statistics** | `render_statistics_tab` (`src/app.py`) | Currently mostly unimplemented in Streamlit. v1 should ship at least basic charts (per-language accuracy over time, attempts count). This is the chance to actually build it. |
+| **Bundled language content** | `language_materials/` (static JSON/MD) | Portuguese (BR/PT), French, German, Spanish, Italian, Dutch, English. Ships with the app; no network needed. |
+| **ASR scoring** | `src/audio/asr.py`, `src/scoring/` | Whisper (local). Phoneme/IPA comparison via espeak. |
+| **Offline neural TTS** | new (Piper) + `src/audio/tts.py` | See §5. |
+| **Settings** | `src/config.py` | Language, voice, Whisper model size, scoring algorithm, etc. Persisted locally. |
+
+### 4.2 Nice-to-have (v1 if cheap, else fast-follow)
+
+- **Story Reader** (full story + scene-by-scene). Deferred to post-v1 unless it
+  falls out cheaply once Quick Practice + the rendering scaffolding exist.
+  *(Confirm deferral — see QUESTIONS.md.)*
+- **Online premium TTS** (Google Cloud TTS) as an optional upgrade over Piper.
+- **LLM/DeepL translation** (`src/translation*.py`) as an optional online aid.
+
+### 4.3 Non-goals (v1)
+
+- Multi-user accounts / login / Argon2 auth (single local user — see §6).
+- Remote MySQL, SSH tunnels, connection pooling/monitoring
+  (`src/connection_pool.py`, `src/connection_monitor.py`, `src/app_mysql.py`'s
+  remote paths).
+- The admin dashboard (`src/miolingo-admin.py`, `src/admin_mysql.py`) — server
+  ops, not relevant to a distributed desktop app.
+- wav2vec2 ASR (Portuguese-only, heavy) — Whisper covers all languages.
+- Cloud sync **implementation** (schema must be sync-ready; sync itself is
+  post-v1 — see §6 and QUESTIONS.md).
+- Auto-update (manual download for v1).
+- Windows/Linux builds.
+
+---
+
+## 5. Audio (TTS) requirements
+
+- **Default offline TTS: Piper** (neural, local, fast, MIT-licensed). Bundle
+  one good voice per supported language. espeak quality is unacceptable and is
+  demoted to a last-resort fallback only.
+- **Optional online TTS: Google Cloud TTS** as a quality upgrade when the user
+  supplies credentials and is online. Off by default.
+- The TTS dispatcher must degrade gracefully: Piper (offline) → Google Cloud
+  (if configured + online) → espeak (last resort).
+- **ASR: Whisper**, default model `base`, running locally. Requires `ffmpeg`
+  bundled in the app. wav2vec2 dropped.
+
+---
+
+## 6. Data, state & accounts
+
+- **Local-first.** All user data — settings, practice history, progress,
+  vocabulary — lives in a **local SQLite database** in the macOS app-support
+  directory (`~/Library/Application Support/Miolingo/`). No network needed.
+- **No login/auth in v1.** Single implicit local user.
+- **Sync-ready schema (but no sync in v1):** design tables with stable UUID
+  primary keys, `created_at`/`updated_at` timestamps, and soft-delete flags so
+  optional cloud sync can be added later without a migration. The *mechanism*
+  for sync (given Matthew can't host custom backends) is unresolved — see
+  QUESTIONS.md. Do not build sync in v1.
+- **No in-app state framework reruns.** UI state is held in Qt
+  models/view-state, not by re-executing the whole program. Settings persist to
+  SQLite (mirrors `config.load_settings`/`save_settings`, DB path).
+
+---
+
+## 7. Performance requirements
+
+Target profile: **snappy UI, scoring best-effort.**
+
+- **UI interactions feel instant** — any click/keypress/tab-switch responds in
+  **< 100 ms**; there is **no full-page rerun** (the Streamlit failure mode).
+- **No UI freezes:** Whisper transcription, TTS synthesis, and file IO run off
+  the UI thread (Qt worker threads / `QThreadPool`). The UI always remains
+  responsive and shows clear progress during transcription.
+- **Transcription latency is best-effort** (no hard SLA) but must show a
+  determinate-or-spinner progress indicator and be cancellable.
+- **Cold start** (app launch to interactive) target **< 5 s**; first
+  transcription may be slower due to model load (show a one-time "loading
+  model" state).
+
+---
+
+## 8. Distribution & updates
+
+- **Signed and notarized `.dmg`**, direct download. Requires Matthew's Apple
+  Developer ID (see QUESTIONS.md — if unavailable, Phase 1 produces an unsigned
+  build + documents the signing/notarization steps to run later).
+- **Manual updates** for v1 (download new version). No Sparkle/auto-update, no
+  App Store.
+- Packaging scripts live in `desktop/packaging/` and must be runnable as a
+  single command.
+
+---
+
+## 9. Acceptance criteria (agent-verifiable "done")
+
+Phase 1 is **v1-complete** when all of the following are objectively true. Each
+is checkable without Matthew.
+
+**Core loop**
+- [ ] `python -m miolingo_desktop.main` launches a PySide6 window on macOS with
+      no Streamlit imports anywhere under `desktop/`.
+- [ ] User can select a language and a phrase/word from bundled
+      `language_materials/` content.
+- [ ] User can play target audio generated by **Piper**, offline.
+- [ ] User can record audio, have it transcribed by Whisper, and see a
+      pronunciation score + edit-level feedback. The UI never freezes during
+      transcription (verified by a test that runs scoring off-thread).
+- [ ] The score produced by the ported scoring code matches the source app's
+      output for a fixed (audio, reference) fixture set (regression test).
+
+**Persistence**
+- [ ] Practice attempts are saved to local SQLite and appear in **History**
+      across app restarts.
+- [ ] **Vocabulary** add/edit/delete/CSV-export works and persists locally.
+- [ ] **Settings** persist locally and are restored on relaunch.
+- [ ] DB schema uses UUID PKs + `created_at`/`updated_at` + soft-delete.
+
+**Statistics**
+- [ ] **Statistics** shows at least: attempts count and accuracy trend over
+      time, per language. Renders from local data with no network.
+
+**Offline**
+- [ ] With networking disabled, the full core loop (select → Piper audio →
+      record → Whisper score → save → History → Stats) works end to end.
+
+**Quality gates**
+- [ ] `pytest -q` green headless (`QT_QPA_PLATFORM=offscreen`), including unit
+      tests for ported core logic and at least one Qt smoke test per view.
+- [ ] `ruff` and `mypy` pass.
+
+**Packaging**
+- [ ] `python packaging/build_macos.py` produces a launchable `.app`/`.dmg`
+      bundling Python, Qt, Whisper `base`, ffmpeg, Piper voices, and
+      `language_materials/`. (Signing/notarization gated on Apple ID — if
+      absent, an unsigned bundle + documented signing steps satisfy this.)
+
+**Non-goals respected**
+- [ ] No login UI, no remote DB/tunnel code, no admin dashboard, no Windows/
+      Linux build scripts in v1.


### PR DESCRIPTION
## Summary
Phase 0 (planning only — no migration code) for porting Miolingo off Streamlit
to a native **macOS** desktop app. All docs are self-contained under `desktop/`;
the existing Streamlit app is left untouched as reference.

- **Stack chosen:** PySide6/Qt + PyInstaller (keeps the existing Python ASR/TTS/scoring core; only the UI shell + storage change).
- **Storage:** local-first SQLite, sync-ready schema, no auth (single local user).
- **TTS:** Piper neural voices as default offline engine (espeak demoted); Google Cloud optional/online.
- **ASR:** Whisper local (`base`), wav2vec2 dropped.
- **Perf bar:** snappy UI / no full reruns / never freeze (work off-thread).
- **Dist:** signed/notarized `.dmg`, manual updates, macOS-only v1.

### Documents
- `desktop/CLAUDE.md` — build/test/run, **hard guardrails** (feature branch, always PR, never push to main, tests green before PR), and the **autonomy convention**.
- `desktop/SPEC.md` — PRD: requirements, recorded stack decision, non-goals, agent-verifiable acceptance criteria.
- `desktop/MIGRATION_PLAN.md` — 9 milestones, one PR each, **vertical slice (M3) before breadth**.
- `desktop/DECISIONS.md` / `desktop/QUESTIONS.md` — seeded for Phase 1.

## Test plan
- [ ] Docs-only PR; no code paths touched, existing app unaffected.
- [ ] Review the stack decision and acceptance criteria in SPEC.md.
- [ ] Answer the 5 open items in QUESTIONS.md (sync mechanism, Apple Dev ID, Story Reader deferral, Whisper bundle size, Piper voices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)