### PR TITLE
desktop(M1): port the UI-free core

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -17,3 +17,9 @@ dist/
 *.sqlite3
 secrets.toml
 .env
+
+# The repo-root .gitignore has a broad `config.*` pattern (for the Streamlit
+# app's practice_config.json etc.) which silently swallows our source module
+# desktop/miolingo_desktop/core/config.py. Re-include it explicitly here so it
+# is tracked. (gitignore: a more specific negation can re-include a file.)
+!miolingo_desktop/core/config.py

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -127,6 +127,51 @@ typing on logic ported from an untyped Streamlit app on day one.
 **Alternatives:** full strict mypy (too much churn up front, reversible to
 tighten later).
 
+### 2026-05-23 (M1) — Core defaults: Whisper `medium`, TTS engine `piper`
+**Decision:** `core/config.DEFAULT_SETTINGS` sets `whisper_model_size="medium"`
+and `tts_engine="piper"` (the source app defaulted to `base` / `google_cloud`).
+**Reasoning:** Matches ratified Phase-0 decisions (accuracy-first ASR; offline
+neural TTS default). Dispatcher order: Piper -> Google Cloud (only if an api_key
+is supplied) -> espeak.
+**Alternatives:** keep source defaults (contradicts Phase-0 rulings).
+
+### 2026-05-23 (M1) — Drop wav2vec2; drop `format_ipa` HTML helper from core
+**Decision:** The ported `asr.py` is Whisper-only (wav2vec2 removed).
+`phonemes.format_ipa` (returned an HTML `<span>`) is NOT ported into `core/` —
+IPA markup is a UI concern for the Qt layer.
+**Reasoning:** wav2vec2 was Portuguese-only/heavy (Phase-0). Keeping HTML out of
+`core/` preserves the UI-framework-free guarantee.
+**Alternatives:** keep `format_ipa` (leaks presentation into core).
+
+### 2026-05-23 (M1) — Replace Streamlit caching/session with plain mechanisms
+**Decision:** `@st.cache_data` -> `functools.lru_cache`; Whisper model
+`st.session_state` cache -> a module-level dict with `clear_model_cache()`;
+`st.spinner` -> optional `progress_fn`; `st.warning`/`st.error` -> optional
+`warn_fn`/`error_fn` (default `logging`); `st.secrets[...]` -> an explicit
+`api_key` argument (no global secrets in core).
+**Reasoning:** Removes Streamlit coupling while preserving behaviour; callbacks
+let the Qt worker thread report progress without core importing PySide6.
+**Alternatives:** custom cache class (unneeded).
+
+### 2026-05-23 (M1) — Materials dir via env override + repo walk-up
+**Decision:** `materials.get_data_dir()` returns `$MIOLINGO_MATERIALS_DIR` if
+set, else walks up to the repo-root `language_materials/`. lru_cached; tests
+`cache_clear()` around overrides.
+**Reasoning:** Dev reads the real bundled content unchanged; packaging (M8)
+points the env var at bundled resources without code changes.
+**Alternatives:** hardcode a path (breaks under PyInstaller).
+
+### 2026-05-23 (M1) — Scoring parity proven at the pure-scoring layer
+**Decision:** The parity regression locks the ported edit-distance scoring via
+(a) hardcoded JSON fixtures with certain expected values and (b) a cross-check
+against an independent reference Levenshtein over multi-edit/unicode strings.
+The audio->phoneme stage is a manual test (needs espeak + a recording).
+**Reasoning:** `comparison.py` is copied byte-for-byte, so identical output is
+guaranteed and provable headlessly; the audio stage can't run in CI without a
+mic/model, so it's marked manual rather than faked.
+**Alternatives:** bundle a real audio fixture + model (huge, still needs a
+Mac/mic to capture) — deferred to M3's manual acceptance.
+
 ### 2026-05-23 — Story Reader deferred to post-v1
 **Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
 it in only if cheap after M3, else post-v1.

--- a/desktop/miolingo_desktop/core/__init__.py
+++ b/desktop/miolingo_desktop/core/__init__.py
@@ -1,6 +1,16 @@
 """UI-framework-free business logic (ported from the Streamlit app).
 
-Nothing in this package may import ``streamlit`` or ``PySide6``. It takes plain
-arguments and returns plain values so it stays headlessly testable. Populated
-from Milestone 1 onward.
+Nothing in this package may import ``streamlit`` or ``PySide6`` (enforced by
+``tests/unit/test_core_purity.py``). It takes plain arguments and returns plain
+values so it stays headlessly testable.
+
+Modules:
+- ``config``       — language/voice tables + default settings.
+- ``comparison``   — Levenshtein scoring (verbatim from source; parity-locked).
+- ``phonemes``     — espeak IPA/phoneme extraction.
+- ``import_header``— ``(source, target)`` header parsing.
+- ``materials``    — bundled language-materials discovery/loading.
+- ``asr``          — Whisper transcription (model load separated for off-thread).
+- ``tts``          — TTS engines + Piper->GoogleCloud->espeak dispatcher.
+- ``practice``     — the practice/scoring orchestration pipeline.
 """

--- a/desktop/miolingo_desktop/core/asr.py
+++ b/desktop/miolingo_desktop/core/asr.py
@@ -1,0 +1,137 @@
+"""Automatic Speech Recognition (Whisper, local).
+
+Ported from ``src/audio/asr.py`` with all Streamlit coupling removed:
+- ``st.session_state`` model caching -> a plain in-process module cache.
+- ``st.spinner`` -> an optional ``progress_fn`` callback (the Qt layer wires a
+  worker-thread progress signal to it; defaults to a no-op).
+- ``st.warning``/``st.error`` -> an optional ``warn_fn`` (defaults to logging).
+- wav2vec2 dropped entirely (DECISIONS.md: Whisper covers all languages).
+
+Transcription itself is a pure function: it takes a loaded model and returns
+text. Model loading is separated so the UI can run it off-thread with progress.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from collections.abc import Callable
+
+from .config import LANGUAGE_CONFIG
+
+logger = logging.getLogger(__name__)
+
+ProgressFn = Callable[[str], None]
+WarnFn = Callable[[str], None]
+
+# In-process model cache: model_name -> loaded whisper model.
+_WHISPER_CACHE: dict[str, object] = {}
+
+
+def _default_warn(msg: str) -> None:
+    logger.warning(msg)
+
+
+def get_whisper_model(model_name: str, *, progress_fn: ProgressFn | None = None) -> object:
+    """Load (or return cached) a Whisper model by name.
+
+    The first load of a model that is not present locally triggers
+    openai-whisper's download-on-first-run (cached under ``~/.cache/whisper``);
+    ``progress_fn`` is called once before the potentially slow load so the UI
+    can show a "loading model" state.
+    """
+    cached = _WHISPER_CACHE.get(model_name)
+    if cached is not None:
+        return cached
+
+    if progress_fn is not None:
+        progress_fn(f"Loading Whisper model '{model_name}'...")
+
+    import whisper  # imported lazily; heavy dependency
+
+    model = whisper.load_model(model_name)
+    _WHISPER_CACHE[model_name] = model
+    return model
+
+
+def clear_model_cache() -> None:
+    """Drop cached models (used by tests and on a settings model-size change)."""
+    _WHISPER_CACHE.clear()
+
+
+def transcribe_audio_whisper(
+    audio_file: str,
+    model: object,
+    language_code: str = "pt",
+) -> str:
+    """Transcribe *audio_file* with a loaded Whisper *model*.
+
+    Includes the source app's hallucination guards: returns a bracketed error
+    string if a short pattern repeats 10+ times or the transcript exceeds 100
+    words.
+    """
+    result = model.transcribe(  # type: ignore[attr-defined]
+        audio=audio_file,
+        language=language_code,
+        task="transcribe",
+        temperature=0.0,
+        no_speech_threshold=0.6,
+        logprob_threshold=-1.0,
+        condition_on_previous_text=False,
+        word_timestamps=False,
+        compression_ratio_threshold=2.4,
+    )
+
+    detected_lang = result.get("language", "unknown")
+    if detected_lang != language_code:
+        warnings.warn(
+            f"Whisper detected language '{detected_lang}' instead of '{language_code}'",
+            stacklevel=2,
+        )
+
+    transcribed_text = result["text"].strip().lower()
+
+    words = transcribed_text.split()
+    if len(words) > 20:
+        for pattern_len in (2, 3, 4):
+            if len(words) >= pattern_len * 10:
+                pattern = " ".join(words[:pattern_len])
+                repetitions = transcribed_text.count(pattern)
+                if repetitions >= 10:
+                    warnings.warn(
+                        f"Whisper hallucination detected: '{pattern}' x{repetitions}",
+                        stacklevel=2,
+                    )
+                    return f"[hallucination detected: '{pattern}' x{repetitions}]"
+
+        if len(words) > 100:
+            warnings.warn(
+                f"Suspiciously long transcription: {len(words)} words", stacklevel=2
+            )
+            return f"[error: transcription too long - {len(words)} words, possible hallucination]"
+
+    return transcribed_text
+
+
+def transcribe_audio(
+    audio_file: str,
+    settings: dict,
+    language: str = "Portuguese",
+    *,
+    warn_fn: WarnFn | None = None,
+    progress_fn: ProgressFn | None = None,
+) -> str:
+    """Transcribe *audio_file* using Whisper, honouring *settings*.
+
+    ``settings`` supplies ``whisper_model_size`` (default ``medium``). The
+    ``language`` name selects the Whisper language code via ``LANGUAGE_CONFIG``.
+    """
+    if warn_fn is None:
+        warn_fn = _default_warn
+
+    lang_config = LANGUAGE_CONFIG[language]
+    lang_code = str(lang_config["code"])
+
+    model_size = str(settings.get("whisper_model_size", "medium"))
+    model = get_whisper_model(model_size, progress_fn=progress_fn)
+    return transcribe_audio_whisper(audio_file, model, lang_code)

--- a/desktop/miolingo_desktop/core/comparison.py
+++ b/desktop/miolingo_desktop/core/comparison.py
@@ -1,0 +1,109 @@
+"""Phoneme comparison and scoring algorithms.
+
+Ported verbatim from the Streamlit app's ``src/scoring/comparison.py`` — these
+were already pure functions with no UI coupling, so the desktop port is a
+straight copy. Keeping them byte-identical guarantees scoring parity with the
+source app (see ``tests/unit/test_scoring_parity.py``).
+"""
+
+from __future__ import annotations
+
+
+def levenshtein_distance(s1: str, s2: str) -> int:
+    """Minimum single-character edits (insert/delete/substitute) between strings."""
+    if len(s1) < len(s2):
+        return levenshtein_distance(s2, s1)
+
+    if len(s2) == 0:
+        return len(s1)
+
+    previous_row = list(range(len(s2) + 1))
+    for i, c1 in enumerate(s1):
+        current_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = previous_row[j + 1] + 1
+            deletions = current_row[j] + 1
+            substitutions = previous_row[j] + (c1 != c2)
+            current_row.append(min(insertions, deletions, substitutions))
+        previous_row = current_row
+
+    return previous_row[-1]
+
+
+def get_edit_operations(s1: str, s2: str) -> list[tuple[str, int, str, str]]:
+    """Return the edit operations transforming s1 into s2.
+
+    Each tuple is ``(operation, position, char1, char2)`` where operation is
+    'match', 'substitute', 'insert', or 'delete'.
+    """
+    m, n = len(s1), len(s2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if s1[i - 1] == s2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = 1 + min(
+                    dp[i - 1][j],  # delete
+                    dp[i][j - 1],  # insert
+                    dp[i - 1][j - 1],  # substitute
+                )
+
+    operations: list[tuple[str, int, str, str]] = []
+    i, j = m, n
+    while i > 0 or j > 0:
+        if i > 0 and j > 0 and s1[i - 1] == s2[j - 1]:
+            operations.append(("match", i - 1, s1[i - 1], s2[j - 1]))
+            i -= 1
+            j -= 1
+        elif i > 0 and j > 0 and dp[i][j] == dp[i - 1][j - 1] + 1:
+            operations.append(("substitute", i - 1, s1[i - 1], s2[j - 1]))
+            i -= 1
+            j -= 1
+        elif j > 0 and dp[i][j] == dp[i][j - 1] + 1:
+            operations.append(("insert", i, "-", s2[j - 1]))
+            j -= 1
+        elif i > 0 and dp[i][j] == dp[i - 1][j] + 1:
+            operations.append(("delete", i - 1, s1[i - 1], "-"))
+            i -= 1
+
+    operations.reverse()
+    return operations
+
+
+def compare_phonemes_edit_distance(
+    user_phonemes: str, correct_phonemes: str
+) -> tuple[bool, float, int]:
+    """Compare phonemes via Levenshtein.
+
+    Returns ``(exact_match, similarity[0..1], distance)``.
+    """
+    exact_match = user_phonemes == correct_phonemes
+
+    if len(correct_phonemes) == 0:
+        return exact_match, 0.0, len(user_phonemes)
+
+    distance = levenshtein_distance(user_phonemes, correct_phonemes)
+    max_length = max(len(user_phonemes), len(correct_phonemes))
+    similarity = 1.0 - (distance / max_length)
+
+    return exact_match, similarity, distance
+
+
+def compare_phonemes(
+    user_phonemes: str,
+    correct_phonemes: str,
+    algorithm: str = "edit_distance",
+) -> tuple[bool, float, int]:
+    """Modular phoneme comparison.
+
+    The legacy "positional" algorithm was removed upstream; any unknown
+    ``algorithm`` value falls back to edit distance (matches source behaviour).
+    """
+    return compare_phonemes_edit_distance(user_phonemes, correct_phonemes)

--- a/desktop/miolingo_desktop/core/config.py
+++ b/desktop/miolingo_desktop/core/config.py
@@ -1,0 +1,210 @@
+"""Miolingo configuration: language definitions, voice mappings, default settings.
+
+Ported from ``src/config.py``. The language/voice tables are copied verbatim
+(pure data). The Streamlit/DB-coupled ``load_settings``/``save_settings`` are
+NOT ported here — settings persistence is owned by the SQLite storage layer
+(Milestone 2/4). This module only provides ``DEFAULT_SETTINGS`` and the pure
+language-helper functions.
+
+Default changes vs the source app (per DECISIONS.md):
+- ``whisper_model_size`` defaults to ``"medium"`` (was ``"base"``).
+- ``tts_engine`` defaults to ``"piper"`` (offline neural; was ``"google_cloud"``).
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Language configuration
+# ---------------------------------------------------------------------------
+
+LANGUAGE_CONFIG: dict[str, dict] = {
+    "English": {
+        "code": "en",
+        "display_name": "English Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["en-gb", "en-us"],
+            "gtts": ["en"],
+            "espeak": ["en-gb", "en"],
+        },
+    },
+    "Portuguese": {
+        "code": "pt",
+        "display_name": "Portuguese Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["pt-br", "pt"],
+            "gtts": ["pt-br", "pt"],
+            "espeak": ["pt-br", "pt"],
+        },
+    },
+    "Dutch": {
+        "code": "nl",
+        "display_name": "Dutch/Flemish Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["nl", "nl-be"],
+            "gtts": ["nl"],
+            "espeak": ["nl"],
+        },
+    },
+    "French": {
+        "code": "fr",
+        "display_name": "French Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["fr", "fr-fr"],
+            "gtts": ["fr"],
+            "espeak": ["fr-fr"],
+        },
+    },
+    "German": {
+        "code": "de",
+        "display_name": "German Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["de", "de-de"],
+            "gtts": ["de"],
+            "espeak": ["de"],
+        },
+    },
+    "Italian": {
+        "code": "it",
+        "display_name": "Italian Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["it", "it-it"],
+            "gtts": ["it"],
+            "espeak": ["it"],
+        },
+    },
+    "Spanish": {
+        "code": "es",
+        "display_name": "Spanish Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["es", "es-es"],
+            "gtts": ["es"],
+            "espeak": ["es"],
+        },
+    },
+}
+
+# Voice locale normalization: lowercase codes -> BCP 47 format
+VOICE_LOCALE_NORMALIZATION: dict[str, str] = {
+    "en": "en-US",
+    "en-gb": "en-GB",
+    "en-us": "en-US",
+    "pt-br": "pt-BR",
+    "pt": "pt-PT",
+    "fr": "fr-FR",
+    "fr-fr": "fr-FR",
+    "nl": "nl-NL",
+    "nl-be": "nl-BE",
+    "de": "de-DE",
+    "de-de": "de-DE",
+    "it": "it-IT",
+    "it-it": "it-IT",
+    "es": "es-ES",
+    "es-es": "es-ES",
+}
+
+# Google Cloud TTS voice names per locale (optional online engine).
+GOOGLE_CLOUD_VOICES: dict[str, str] = {
+    "en-GB": "en-GB-Standard-A",
+    "en-US": "en-US-Standard-A",
+    "pt-BR": "pt-BR-Standard-A",
+    "pt-PT": "pt-PT-Standard-A",
+    "fr-FR": "fr-FR-Standard-A",
+    "nl-NL": "nl-NL-Standard-A",
+    "nl-BE": "nl-BE-Standard-A",
+    "de-DE": "de-DE-Standard-A",
+    "it-IT": "it-IT-Standard-A",
+    "es-ES": "es-ES-Standard-A",
+}
+
+# ---------------------------------------------------------------------------
+# Default settings (desktop)
+# ---------------------------------------------------------------------------
+
+DEFAULT_SETTINGS: dict[str, object] = {
+    "speed": 140,
+    "pitch": 35,
+    "voice": "pt-br",
+    "model": "medium",
+    "duration": 3,
+    "comparison_algorithm": "edit_distance",
+    "asr_engine": "whisper",
+    "whisper_model_size": "medium",  # DECISIONS.md: accuracy over size
+    "silence_threshold": 0.01,
+    "use_wav_audio": False,
+    "tts_engine": "piper",  # DECISIONS.md: Piper offline neural is the default
+    "gtts_slow": False,
+    "source_language": "English",
+    "debug_mode": False,
+}
+
+# ---------------------------------------------------------------------------
+# Material-code -> Training-language mapping
+# ---------------------------------------------------------------------------
+
+MATERIAL_TO_TRAINING: dict[str, str] = {
+    "en": "English",
+    "de": "German",
+    "es": "Spanish",
+    "fr": "French",
+    "it": "Italian",
+    "nl": "Dutch",
+    "pt": "Portuguese",
+}
+
+SOURCE_LANGUAGE_OPTIONS: list[str] = [
+    "English",
+    "French",
+    "German",
+    "Spanish",
+    "Italian",
+    "Dutch",
+    "Portuguese",
+]
+
+
+# ---------------------------------------------------------------------------
+# Language helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def get_language_code(language_name: str) -> str:
+    """Map a language name to its short code."""
+    if language_name.lower() == "english":
+        return "en"
+    if language_name in LANGUAGE_CONFIG:
+        return str(LANGUAGE_CONFIG[language_name].get("code", language_name.lower()))
+    return language_name.lower()
+
+
+def get_language_for_provider(provider: str, language_name: str) -> str:
+    """Get the language identifier expected by a translation provider."""
+    if provider == "google":
+        return get_language_code(language_name)
+    return language_name
+
+
+def default_settings() -> dict[str, object]:
+    """Return a fresh copy of the default settings dict."""
+    return dict(DEFAULT_SETTINGS)
+
+
+# ---------------------------------------------------------------------------
+# Option lists for the Settings UI (kept here so the UI holds no choices itself)
+# ---------------------------------------------------------------------------
+
+WHISPER_MODEL_SIZES: list[str] = ["tiny", "base", "small", "medium", "large"]
+TTS_ENGINES: list[str] = ["piper", "google_cloud", "espeak"]
+COMPARISON_ALGORITHMS: list[str] = ["edit_distance"]
+
+
+def voices_for_language(language_name: str) -> list[str]:
+    """All distinct voice codes configured for *language_name* across engines."""
+    cfg = LANGUAGE_CONFIG.get(language_name)
+    if not cfg:
+        return []
+    seen: list[str] = []
+    for codes in cfg.get("voices", {}).values():
+        for code in codes:
+            if code not in seen:
+                seen.append(code)
+    return seen

--- a/desktop/miolingo_desktop/core/import_header.py
+++ b/desktop/miolingo_desktop/core/import_header.py
@@ -1,0 +1,32 @@
+"""Shared parsing for the ``(source, target)`` language-pair header.
+
+Ported verbatim from ``src/import_header.py`` (pure, no UI coupling). Used when
+filtering bundled language-material files so the header line does not leak into
+previews or counts.
+
+Accepted forms::
+
+    (pt, en)
+    # (pt, en)
+    (  FR  ,  EN  )
+"""
+
+from __future__ import annotations
+
+import re
+
+HEADER_RE = re.compile(
+    r"^\s*#?\s*\(\s*([a-z]{2,5})\s*,\s*([a-z]{2,5})\s*\)\s*$",
+    re.IGNORECASE,
+)
+
+
+def is_header_line(raw: str) -> bool:
+    """Return True if *raw* is a ``(source, target)`` header tuple."""
+    return bool(HEADER_RE.match(raw))
+
+
+def parse_header(raw: str) -> tuple[str, str] | None:
+    """Return ``(source_code, target_code)`` lowercased, or ``None``. Never raises."""
+    m = HEADER_RE.match(raw)
+    return (m.group(1).lower(), m.group(2).lower()) if m else None

--- a/desktop/miolingo_desktop/core/materials.py
+++ b/desktop/miolingo_desktop/core/materials.py
@@ -1,0 +1,353 @@
+"""Language materials discovery and loading.
+
+Ported from ``src/app_language_materials.py`` with ``@st.cache_data`` replaced
+by ``functools.lru_cache`` (in-process). Logic is otherwise preserved so the
+desktop app reads the exact same bundled ``language_materials/`` content.
+
+The content directory is resolved by ``get_data_dir()``:
+1. the ``MIOLINGO_MATERIALS_DIR`` environment variable, if set (packaging/M8
+   points this at the bundled resources);
+2. otherwise the repo-root ``language_materials/`` (dev mode), located by
+   walking up from this file.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+from pathlib import Path
+
+from .import_header import is_header_line
+
+CACHE_VERSION = "1.10.1"
+
+
+@functools.lru_cache(maxsize=1)
+def get_data_dir() -> Path:
+    """Resolve the bundled language-materials directory."""
+    env = os.environ.get("MIOLINGO_MATERIALS_DIR")
+    if env:
+        return Path(env)
+    # Walk up to the repo root (contains a top-level ``language_materials/``).
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "language_materials"
+        if candidate.is_dir():
+            return candidate
+    # Fallback: repo-root guess two levels above desktop/.
+    return here.parents[3] / "language_materials"
+
+
+def _unified_dir() -> Path:
+    return get_data_dir() / "unified"
+
+
+@functools.lru_cache(maxsize=1)
+def get_available_languages(_cache_version: str = CACHE_VERSION) -> list[str]:
+    """Languages with materials, from per-language dirs plus unified files."""
+    data_dir = get_data_dir()
+    if not data_dir.exists():
+        return []
+
+    per_lang = {
+        d.name
+        for d in data_dir.iterdir()
+        if d.is_dir() and not d.name.startswith(".") and d.name != "unified"
+    }
+
+    unified_langs: set[str] = set()
+    unified = _unified_dir()
+    for subdir_name in ("phrases", "phrasebook", "stories"):
+        subdir = unified / subdir_name
+        if subdir.is_dir():
+            candidates = sorted(subdir.glob("*.json"))
+            if candidates:
+                try:
+                    with open(candidates[0], encoding="utf-8") as f:
+                        meta = json.load(f).get("meta", {})
+                    unified_langs.update(meta.get("languages", []))
+                    break
+                except Exception:
+                    pass
+
+    return sorted(per_lang | unified_langs)
+
+
+@functools.lru_cache(maxsize=64)
+def get_language_structure(
+    language: str, _cache_version: str = CACHE_VERSION
+) -> dict[str, list[str]]:
+    """Aggregate a language's files into ``phrases``/``words`` (+ unified cats)."""
+    data_dir = get_data_dir()
+    lang_dir = data_dir / language
+    aggregated: dict[str, list[str]] = {"phrases": [], "words": []}
+    excluded_dirs = {"phrases-original", "story-scenes"}
+
+    iterdir = sorted(lang_dir.iterdir()) if lang_dir.exists() else []
+    for category_dir in iterdir:
+        if not category_dir.is_dir() or category_dir.name.startswith("."):
+            continue
+        if (
+            category_dir.name in excluded_dirs
+            or "-original" in category_dir.name
+            or "backup" in category_dir.name
+        ):
+            continue
+
+        txt_files = sorted(f.name for f in category_dir.glob("*.txt"))
+        json_files = sorted(f.name for f in category_dir.glob("*.json"))
+        files = txt_files + json_files
+        if not files:
+            continue
+
+        if category_dir.name == "phrases" or category_dir.name.startswith("phrases-"):
+            aggregated["phrases"].extend(files)
+        elif category_dir.name == "words" or category_dir.name.startswith("words-"):
+            aggregated["words"].extend(files)
+        else:
+            aggregated[category_dir.name] = files
+
+    result = {k: v for k, v in aggregated.items() if v}
+
+    unified_category_map = {
+        "stories": "unified-stories",
+        "phrases": "unified-phrases",
+        "phrasebook": "unified-phrasebook",
+    }
+    unified = _unified_dir()
+    for subdir, category_name in unified_category_map.items():
+        unified_subdir = unified / subdir
+        if unified_subdir.is_dir():
+            files = sorted(f.name for f in unified_subdir.glob("*.json"))
+            if files:
+                try:
+                    with open(unified_subdir / files[0], encoding="utf-8") as f:
+                        meta = json.load(f).get("meta", {})
+                    if language in meta.get("languages", []):
+                        result[category_name] = files
+                except Exception:
+                    pass
+
+    return result
+
+
+def get_file_metadata(
+    language: str, category: str, filename: str, source_language: str = "en"
+) -> dict:
+    """Return metadata (path, line_count, has_translations, has_ipa, preview)."""
+    if category.startswith("unified-"):
+        subdir = category.replace("unified-", "", 1)
+        file_path = _unified_dir() / subdir / filename
+    else:
+        file_path = get_data_dir() / language / category / filename
+
+    if not file_path.exists():
+        return {}
+
+    try:
+        if file_path.suffix == ".json":
+            with open(file_path, encoding="utf-8") as f:
+                data = json.load(f)
+
+            if isinstance(data, dict) and "meta" in data and "phrases" in data:
+                meta = data["meta"]
+                phrases = data["phrases"]
+                preview = []
+                for phrase in phrases[:3]:
+                    text = phrase.get("text", {}).get(language, "")
+                    if not text:
+                        continue
+                    trans = phrase.get("text", {}).get(source_language) or phrase.get(
+                        "text", {}
+                    ).get("en", "")
+                    if trans == text:
+                        trans = ""
+                    ipa = phrase.get("ipa", {}).get(language, "")
+                    if trans and ipa:
+                        preview.append(f"{text} | {trans} | {ipa}")
+                    elif trans:
+                        preview.append(f"{text} | {trans}")
+                    else:
+                        preview.append(text)
+                return {
+                    "path": file_path,
+                    "line_count": meta.get("phrase_count", len(phrases)),
+                    "has_translations": True,
+                    "has_ipa": any(p.get("ipa", {}).get(language) for p in phrases[:5]),
+                    "preview": preview,
+                }
+
+            if isinstance(data, dict):
+                lang_keys = [k for k in data if k not in ("scene_number", "scene_title")]
+                if not lang_keys:
+                    return _empty_meta(file_path)
+                lang_key = lang_keys[0]
+                phrases = data[lang_key]
+                preview = []
+                for phrase in phrases[:3]:
+                    text = phrase.get(lang_key, "")
+                    translation = phrase.get("english", "")
+                    ipa = phrase.get("ipa", "")
+                    if translation and ipa:
+                        preview.append(f"{text} | {translation} | {ipa}")
+                    elif translation:
+                        preview.append(f"{text} | {translation}")
+                    else:
+                        preview.append(text)
+                return {
+                    "path": file_path,
+                    "line_count": len(phrases),
+                    "has_translations": bool(phrases and phrases[0].get("english")),
+                    "has_ipa": bool(phrases and phrases[0].get("ipa")),
+                    "preview": preview,
+                }
+            return _empty_meta(file_path)
+
+        with open(file_path, encoding="utf-8") as f:
+            all_lines = f.readlines()
+
+        content_lines = [
+            s
+            for line in all_lines
+            if (s := line.strip())
+            and not s.startswith("#")
+            and not is_header_line(line)
+        ]
+        if not content_lines:
+            return _empty_meta(file_path)
+
+        sample = content_lines[0]
+        return {
+            "path": file_path,
+            "line_count": len(content_lines),
+            "has_translations": "|" in sample,
+            "has_ipa": "[" in sample and "]" in sample,
+            "preview": content_lines[:3],
+        }
+    except Exception as e:  # noqa: BLE001 - mirror source's broad guard
+        meta = _empty_meta(file_path)
+        meta["error"] = str(e)
+        return meta
+
+
+def _empty_meta(file_path: Path) -> dict:
+    return {
+        "path": file_path,
+        "line_count": 0,
+        "has_translations": False,
+        "has_ipa": False,
+        "preview": [],
+    }
+
+
+@functools.lru_cache(maxsize=128)
+def load_unified_phrase_file(
+    file_path_str: str, target_lang: str, source_lang: str
+) -> tuple[dict, ...]:
+    """Load a unified multi-language JSON file, projecting one language pair.
+
+    Returns a tuple (hashable, so it's lru_cache-friendly) of
+    ``{text, translation, ipa}`` dicts. Callers can ``list(...)`` it.
+    """
+    with open(file_path_str, encoding="utf-8") as f:
+        doc = json.load(f)
+
+    phrases: list[dict] = []
+    for entry in doc.get("phrases", []):
+        target_text = entry.get("text", {}).get(target_lang)
+        if not target_text:
+            continue
+        source_text = entry.get("text", {}).get(source_lang) or entry.get("text", {}).get(
+            "en", ""
+        )
+        ipa_text = entry.get("ipa", {}).get(target_lang, "")
+        phrases.append(
+            {"text": target_text, "translation": source_text, "ipa": ipa_text or None}
+        )
+    return tuple(phrases)
+
+
+def load_phrase_file(file_path_str: str) -> list[dict]:
+    """Load and parse a phrase/word file (TXT or JSON) within the data dir."""
+    file_path = Path(file_path_str)
+
+    try:
+        file_path_resolved = file_path.resolve()
+        data_dir_resolved = get_data_dir().resolve()
+        if not file_path_resolved.is_relative_to(data_dir_resolved):
+            raise ValueError("Invalid file path: outside language materials directory")
+    except Exception as e:
+        raise ValueError(f"Invalid file path: {e}") from e
+
+    unified_resolved = _unified_dir().resolve()
+    if str(file_path_resolved).startswith(str(unified_resolved)):
+        raise ValueError(
+            "Unified files must be loaded via load_unified_phrase_file() with "
+            "explicit target/source language parameters"
+        )
+
+    if file_path.suffix == ".json":
+        with open(file_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        lang_code = None
+        phrases_data = None
+        for key in ("fr", "pt", "es", "de", "nl", "it"):
+            if key in data and isinstance(data[key], list):
+                lang_code = key
+                phrases_data = data[key]
+                break
+        if phrases_data is None:
+            if isinstance(data, list):
+                phrases_data = data
+            else:
+                raise ValueError("Could not find phrase list in JSON file")
+
+        phrases = []
+        for item in phrases_data:
+            text = item.get(lang_code) if lang_code else item.get("french", item.get("text", ""))
+            phrases.append(
+                {
+                    "text": text,
+                    "translation": item.get("english", item.get("translation")),
+                    "ipa": item.get("ipa"),
+                }
+            )
+        return phrases
+
+    with open(file_path, encoding="utf-8") as f:
+        content = f.read()
+
+    phrases = []
+    for raw in content.split("\n"):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or is_header_line(stripped):
+            continue
+        line = stripped
+        if "|" in line:
+            parts = [p.strip() for p in line.split("|")]
+            phrases.append(
+                {
+                    "text": parts[0],
+                    "translation": parts[1] if len(parts) > 1 else None,
+                    "ipa": parts[2] if len(parts) > 2 else None,
+                }
+            )
+        else:
+            phrases.append({"text": line, "translation": None, "ipa": None})
+    return phrases
+
+
+def format_language_name(lang_code: str) -> str:
+    """Format a language code for display (kept pure; no emoji-free requirement)."""
+    language_map = {
+        "en": "English",
+        "fr": "French",
+        "pt": "Portuguese",
+        "nl": "Dutch",
+        "de": "German",
+        "it": "Italian",
+        "es": "Spanish",
+    }
+    return language_map.get(lang_code, lang_code.upper())

--- a/desktop/miolingo_desktop/core/phonemes.py
+++ b/desktop/miolingo_desktop/core/phonemes.py
@@ -1,0 +1,111 @@
+"""IPA and phoneme extraction via espeak.
+
+Ported from ``src/scoring/phonemes.py`` (already pure). The HTML-producing
+``format_ipa`` helper was intentionally NOT ported — HTML/markup is a UI concern
+and belongs in the Qt layer, keeping ``core/`` framework-free.
+
+Runtime dependency: an espeak binary must be on PATH (``espeak`` on macOS via
+MacPorts, ``espeak-ng`` on Debian/Ubuntu). espeak is used only for IPA/phoneme
+*scoring*, not for audio playback (that is Piper — see ``tts.py``).
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+ESPEAK_LANG_MAP: dict[str, str] = {
+    "pt": "pt-br",
+    "fr": "fr-fr",
+    "nl": "nl",
+    "de": "de",
+    "it": "it",
+    "es": "es",
+    "en": "en",
+}
+
+
+@functools.lru_cache(maxsize=1)
+def get_espeak_path() -> str:
+    """Resolve the espeak binary path.
+
+    Order: MacPorts local path, then ``espeak``/``espeak-ng`` on PATH. Falls
+    back to the bare name ``espeak`` so callers still get a sensible command
+    (and a clean FileNotFoundError) if nothing is installed.
+    """
+    local_path = "/opt/local/bin/espeak"
+    if Path(local_path).exists():
+        return local_path
+
+    for name in ("espeak", "espeak-ng"):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    return "espeak"
+
+
+@functools.lru_cache(maxsize=256)
+def get_phonemes(text: str, voice: str = "pt-br") -> str:
+    """Get the phoneme representation of *text* using espeak."""
+    try:
+        result = subprocess.run(
+            [get_espeak_path(), "-v", voice, "-q", "--phonout=/dev/stdout", "-x", text],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        return f"[phonemes unavailable: {e}]"
+
+
+def normalize_for_phoneme_scoring(s: str) -> str:
+    """Strip whitespace and espeak pause phonemes (``_:`` ``_!`` ``_|`` ...).
+
+    Leaves only pronunciation phonemes so scoring ignores word boundaries and
+    punctuation-induced pauses.
+    """
+    if not s:
+        return ""
+    s = re.sub(r"\s+", "", s.strip())
+    s = re.sub(r"_[:!|]+", "", s)
+    return s
+
+
+@functools.lru_cache(maxsize=256)
+def get_ipa(text: str, voice: str = "pt-br") -> str:
+    """Get IPA transcription for *text* (espeak newlines normalised to spaces)."""
+    try:
+        result = subprocess.run(
+            [get_espeak_path(), "-v", voice, "--ipa", "-q", text],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        ipa = result.stdout.strip()
+        return " ".join(ipa.split())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "[IPA unavailable]"
+
+
+def get_ipa_from_espeak(text: str, lang_code: str) -> str:
+    """Generate IPA for *text* given a short language code (pt, fr, nl, ...)."""
+    espeak_lang = ESPEAK_LANG_MAP.get(lang_code, lang_code)
+    try:
+        result = subprocess.run(
+            [get_espeak_path(), "-v", espeak_lang, "-q", "--ipa", text],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return " ".join(result.stdout.strip().split())
+        return "[error]"
+    except subprocess.TimeoutExpired:
+        return "[timeout]"
+    except Exception as e:  # noqa: BLE001 - mirror source's broad guard
+        return f"[error: {e}]"

--- a/desktop/miolingo_desktop/core/practice.py
+++ b/desktop/miolingo_desktop/core/practice.py
@@ -1,0 +1,152 @@
+"""Practice orchestration: score recorded audio against a target phrase.
+
+Ported from ``src/scoring/practice.py`` with Streamlit removed. The pipeline:
+1. trim silence on the user recording,
+2. ASR transcription (Whisper),
+3. phoneme/IPA generation for target and recognised text,
+4. phoneme comparison + scoring,
+5. assemble a result dict.
+
+Persistence (DB writes) is delegated to the ``on_result`` callback so this
+function stays UI- and storage-agnostic. ``error_fn``/``warn_fn`` default to
+logging instead of ``st.error``/``st.warning``. The whole function is safe to
+run on a Qt worker thread.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+
+from .asr import ProgressFn, transcribe_audio
+from .comparison import compare_phonemes
+from .phonemes import get_ipa, get_phonemes, normalize_for_phoneme_scoring
+
+logger = logging.getLogger(__name__)
+
+
+def trim_silence(audio_bytes: bytes, silence_threshold: float = 0.01) -> tuple[bytes, bytes]:
+    """Trim leading/trailing silence from a WAV recording.
+
+    Returns ``(trimmed_bytes, original_bytes)``; on any failure both are the
+    original bytes (lossless fallback).
+    """
+    try:
+        buf = io.BytesIO(audio_bytes)
+        audio_data, sample_rate = sf.read(buf)
+
+        frame_length = int(0.02 * sample_rate)
+        energy = np.array(
+            [
+                np.sum(audio_data[i : i + frame_length] ** 2)
+                for i in range(0, len(audio_data) - frame_length, frame_length)
+            ]
+        )
+
+        threshold = silence_threshold * np.max(energy)
+        speech_frames = np.where(energy > threshold)[0]
+
+        if len(speech_frames) > 0:
+            padding_samples = int(0.2 * sample_rate)
+            start = max(0, speech_frames[0] * frame_length - padding_samples)
+            end = min(
+                len(audio_data),
+                (speech_frames[-1] + 1) * frame_length + padding_samples,
+            )
+            trimmed_audio = audio_data[start:end]
+
+            trimmed_buffer = io.BytesIO()
+            sf.write(trimmed_buffer, trimmed_audio, sample_rate, format="WAV")
+            return trimmed_buffer.getvalue(), audio_bytes
+        return audio_bytes, audio_bytes
+    except Exception:
+        return audio_bytes, audio_bytes
+
+
+def practice_word_from_audio(
+    text: str,
+    audio_bytes: bytes,
+    settings: dict,
+    *,
+    language: str = "Portuguese",
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+    error_fn: Callable[[str], None] | None = None,
+    warn_fn: Callable[[str], None] | None = None,
+    progress_fn: ProgressFn | None = None,
+    transcribe_fn: Callable[..., str] | None = None,
+) -> dict[str, Any] | None:
+    """Score a user's pronunciation against *text*. Returns a result dict or None.
+
+    ``transcribe_fn`` lets callers/tests inject a stub transcriber (defaults to
+    the real Whisper ``transcribe_audio``); this keeps the pipeline testable
+    without loading a model.
+    """
+    if error_fn is None:
+        error_fn = logger.error
+    if warn_fn is None:
+        warn_fn = logger.warning
+    if transcribe_fn is None:
+        transcribe_fn = transcribe_audio
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+    temp_audio = tmp.name
+    tmp.close()
+
+    try:
+        trimmed_wav_bytes, _ = trim_silence(
+            audio_bytes, silence_threshold=settings.get("silence_threshold", 0.01)
+        )
+        with open(temp_audio, "wb") as f:
+            f.write(trimmed_wav_bytes)
+
+        voice = settings.get("voice", "en")
+        correct_phonemes = get_phonemes(text, voice)
+        correct_ipa = get_ipa(text, voice)
+
+        recognized_text = transcribe_fn(
+            temp_audio, settings, language, warn_fn=warn_fn, progress_fn=progress_fn
+        )
+
+        user_phonemes = get_phonemes(recognized_text, voice)
+        user_ipa = get_ipa(recognized_text, voice)
+
+        correct_phonemes_normalized = normalize_for_phoneme_scoring(correct_phonemes)
+        user_phonemes_normalized = normalize_for_phoneme_scoring(user_phonemes)
+
+        algorithm = settings.get("comparison_algorithm", "edit_distance")
+        exact_match, similarity, edit_distance = compare_phonemes(
+            user_phonemes_normalized, correct_phonemes_normalized, algorithm=algorithm
+        )
+
+        result: dict[str, Any] = {
+            "target": text,
+            "recognized": recognized_text,
+            "correct_phonemes": correct_phonemes,
+            "user_phonemes": user_phonemes,
+            "correct_ipa": correct_ipa,
+            "user_ipa": user_ipa,
+            "exact_match": exact_match,
+            "similarity": similarity,
+            "edit_distance": edit_distance,
+            "correct_phonemes_normalized": correct_phonemes_normalized,
+            "user_phonemes_normalized": user_phonemes_normalized,
+            "user_audio_bytes": audio_bytes,
+            "user_audio_trimmed_bytes": trimmed_wav_bytes,
+        }
+
+        if on_result is not None:
+            on_result(result)
+        return result
+
+    except Exception as e:  # noqa: BLE001 - mirror source's broad guard
+        error_fn(f"Error during practice: {e}")
+        return None
+    finally:
+        Path(temp_audio).unlink(missing_ok=True)

--- a/desktop/miolingo_desktop/core/tts.py
+++ b/desktop/miolingo_desktop/core/tts.py
@@ -1,0 +1,225 @@
+"""Text-to-Speech engines and dispatcher.
+
+Ported from ``src/audio/tts.py`` with Streamlit removed:
+- ``@st.cache_data`` -> ``functools.lru_cache`` (in-process).
+- ``st.secrets[...]`` -> an explicit ``api_key`` argument (no global secrets).
+- ``st.warning`` -> an optional ``warn_fn`` (defaults to logging).
+
+Per SPEC §5 / DECISIONS.md the dispatcher priority is **Piper (offline neural)
+-> Google Cloud (optional, online) -> espeak (last resort)**. This differs from
+the source app, whose default was Google Cloud.
+
+Each engine returns ``(audio_bytes, mime_format)``. Full Piper voice coverage
+and bundled voice files land in Milestone 7; this module wires the engine and
+the fallback order. ``synthesize_piper`` raises ``PiperUnavailable`` when no
+voice is resolvable so the dispatcher can fall back cleanly — this keeps the
+dispatcher logic testable in M1 without bundled voices.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import string
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from .config import GOOGLE_CLOUD_VOICES, VOICE_LOCALE_NORMALIZATION
+
+logger = logging.getLogger(__name__)
+
+WarnFn = Callable[[str], None]
+AudioResult = tuple[bytes, str]
+
+
+class PiperUnavailable(RuntimeError):
+    """Raised when a Piper voice for the requested locale cannot be resolved."""
+
+
+def _default_warn(msg: str) -> None:
+    logger.warning(msg)
+
+
+# ---------------------------------------------------------------------------
+# Engine: Piper (local, offline neural) — default
+# ---------------------------------------------------------------------------
+
+# Locale -> Piper voice model name. Populated/bundled in Milestone 7. Empty for
+# now so M1 can prove the fallback path; M7 fills this and ships the .onnx files.
+PIPER_VOICES: dict[str, str] = {}
+
+
+def resolve_piper_voice(locale: str, voices: dict[str, str] | None = None) -> str:
+    """Return the Piper voice model name for *locale*, or raise PiperUnavailable."""
+    table = PIPER_VOICES if voices is None else voices
+    name = table.get(locale)
+    if not name:
+        raise PiperUnavailable(f"No bundled Piper voice for locale '{locale}'")
+    return name
+
+
+def synthesize_piper(
+    text: str,
+    locale: str = "pt-BR",
+    *,
+    voices: dict[str, str] | None = None,
+    use_wav: bool = True,
+) -> AudioResult:
+    """Synthesize *text* with Piper for *locale*.
+
+    Raises :class:`PiperUnavailable` if no voice is registered for the locale
+    (the normal case until Milestone 7 bundles voices). The actual Piper
+    invocation is implemented in M7; this signature is stable so the dispatcher
+    and tests can rely on it now.
+    """
+    resolve_piper_voice(locale, voices)
+    # Implemented in Milestone 7 (loads the .onnx voice + runs piper).
+    raise PiperUnavailable(
+        "Piper synthesis is not wired until Milestone 7 (no bundled voices yet)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Engine: eSpeak (local, offline) — last resort
+# ---------------------------------------------------------------------------
+
+
+def speak_text(
+    text: str,
+    voice: str = "pt-br",
+    speed: int = 160,
+    pitch: int = 40,
+) -> AudioResult:
+    """Generate speech with espeak. Returns ``(wav_bytes, 'audio/wav')``."""
+    from .phonemes import get_espeak_path
+
+    try:
+        result = subprocess.run(
+            [
+                get_espeak_path(),
+                "-v", voice,
+                "-s", str(speed),
+                "-p", str(pitch),
+                "--stdout",
+                text,
+            ],
+            capture_output=True,
+            check=True,
+        )
+        return result.stdout, "audio/wav"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return b"", "audio/wav"
+
+
+# ---------------------------------------------------------------------------
+# Engine: Google Cloud TTS (REST, optional online upgrade)
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=512)
+def speak_text_google_cloud(
+    text: str,
+    lang: str = "pt-BR",
+    use_wav: bool = False,
+    speaking_rate: float = 1.0,
+    *,
+    api_key: str | None = None,
+) -> AudioResult:
+    """Generate speech via Google Cloud TTS REST API. Requires an explicit api_key."""
+    import base64
+
+    import requests
+
+    if api_key is None:
+        raise ValueError("Google Cloud TTS requires an api_key (no global secrets)")
+
+    voice_name = GOOGLE_CLOUD_VOICES.get(lang, "pt-BR-Standard-A")
+    audio_encoding = "LINEAR16" if use_wav else "MP3"
+
+    url = "https://texttospeech.googleapis.com/v1/text:synthesize"
+    headers = {
+        "X-goog-api-key": api_key,
+        "Content-Type": "application/json; charset=utf-8",
+    }
+    payload = {
+        "input": {"text": text},
+        "voice": {"languageCode": lang[:5], "name": voice_name},
+        "audioConfig": {"audioEncoding": audio_encoding, "speakingRate": speaking_rate},
+    }
+
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Google Cloud TTS API error {response.status_code}: {response.text[:200]}"
+        )
+
+    audio_bytes = base64.b64decode(response.json().get("audioContent", ""))
+    return audio_bytes, ("audio/wav" if use_wav else "audio/mp3")
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher: Piper -> Google Cloud -> espeak
+# ---------------------------------------------------------------------------
+
+
+def generate_target_audio(
+    text: str,
+    settings: dict,
+    *,
+    warn_fn: WarnFn | None = None,
+    google_api_key: str | None = None,
+    piper_voices: dict[str, str] | None = None,
+) -> AudioResult:
+    """Generate target pronunciation audio with graceful degradation.
+
+    Priority: Piper (offline) -> Google Cloud (if ``google_api_key`` and online)
+    -> espeak (last resort). The configured ``tts_engine`` selects the preferred
+    engine but fallbacks always apply.
+    """
+    if warn_fn is None:
+        warn_fn = _default_warn
+
+    text_no_punct = text.translate(str.maketrans("", "", string.punctuation))
+    voice = str(settings.get("voice", "pt-br"))
+    locale = VOICE_LOCALE_NORMALIZATION.get(voice, "pt-BR")
+    use_wav = bool(settings.get("use_wav_audio", False))
+    rate = 0.75 if settings.get("gtts_slow", False) else 1.0
+    engine = str(settings.get("tts_engine", "piper"))
+
+    def _espeak() -> AudioResult:
+        return speak_text(
+            text_no_punct,
+            voice=voice,
+            speed=int(settings.get("speed", 140)),
+            pitch=int(settings.get("pitch", 35)),
+        )
+
+    def _google() -> AudioResult:
+        return speak_text_google_cloud(
+            text_no_punct, lang=locale, use_wav=use_wav, speaking_rate=rate,
+            api_key=google_api_key,
+        )
+
+    def _piper() -> AudioResult:
+        return synthesize_piper(text_no_punct, locale=locale, voices=piper_voices,
+                                use_wav=use_wav)
+
+    # If the user explicitly forces espeak, honour it directly.
+    if engine == "espeak":
+        return _espeak()
+
+    # Default path: Piper first, then Google Cloud (if configured), then espeak.
+    try:
+        return _piper()
+    except PiperUnavailable as e:
+        warn_fn(f"Piper unavailable ({e}); trying Google Cloud TTS")
+
+    if google_api_key:
+        try:
+            return _google()
+        except Exception as e:  # noqa: BLE001 - degrade to espeak on any failure
+            warn_fn(f"Google Cloud TTS unavailable ({str(e)[:80]}); using espeak")
+
+    return _espeak()

--- a/desktop/tests/fixtures/scoring_parity.json
+++ b/desktop/tests/fixtures/scoring_parity.json
@@ -1,0 +1,10 @@
+{
+  "_doc": "Regression fixtures locking the ported scoring to known-good output. Each case: (user_phonemes_normalized, correct_phonemes_normalized) -> [exact_match, similarity, edit_distance]. Values use the edit-distance algorithm copied verbatim from src/scoring/comparison.py. Only cases with hand-verifiable, certain values are hardcoded here; the companion test ALSO cross-checks the ported algorithm against an independent reference Levenshtein over a broader (incl. multi-edit / unicode) set, so parity is provable without trusting hand-computed edit distances. Audio->phoneme extraction is covered by manual tests (needs espeak + a recording).",
+  "cases": [
+    {"user": "bcurz", "correct": "bcurz", "exact": true, "similarity": 1.0, "distance": 0},
+    {"user": "bcur", "correct": "bcurz", "exact": false, "similarity": 0.8, "distance": 1},
+    {"user": "kat", "correct": "kut", "exact": false, "similarity": 0.6666666666666667, "distance": 1},
+    {"user": "", "correct": "abc", "exact": false, "similarity": 0.0, "distance": 3},
+    {"user": "obrigadu", "correct": "obrigado", "exact": false, "similarity": 0.875, "distance": 1}
+  ]
+}

--- a/desktop/tests/unit/test_config.py
+++ b/desktop/tests/unit/test_config.py
@@ -1,0 +1,31 @@
+"""Tests for ported config + the desktop default-setting overrides."""
+
+from __future__ import annotations
+
+from miolingo_desktop.core import config
+
+
+def test_default_whisper_model_is_medium() -> None:
+    assert config.DEFAULT_SETTINGS["whisper_model_size"] == "medium"
+
+
+def test_default_tts_engine_is_piper() -> None:
+    assert config.DEFAULT_SETTINGS["tts_engine"] == "piper"
+
+
+def test_default_settings_returns_fresh_copy() -> None:
+    a = config.default_settings()
+    a["voice"] = "mutated"
+    b = config.default_settings()
+    assert b["voice"] != "mutated"
+
+
+def test_get_language_code() -> None:
+    assert config.get_language_code("English") == "en"
+    assert config.get_language_code("Portuguese") == "pt"
+    assert config.get_language_code("Klingon") == "klingon"
+
+
+def test_language_config_covers_supported_languages() -> None:
+    codes = {cfg["code"] for cfg in config.LANGUAGE_CONFIG.values()}
+    assert {"en", "pt", "fr", "de", "es", "it", "nl"} <= codes

--- a/desktop/tests/unit/test_core_purity.py
+++ b/desktop/tests/unit/test_core_purity.py
@@ -1,0 +1,40 @@
+"""Guardrail test: the ported ``core/`` package must be UI-framework-free.
+
+It walks every ``.py`` file under ``miolingo_desktop/core/`` and asserts no
+module imports ``streamlit`` or ``PySide6``. This is a hard project rule
+(``desktop/CLAUDE.md`` §1) — keeping core decoupled is what makes it headlessly
+testable and reusable.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import miolingo_desktop.core as core_pkg
+
+CORE_DIR = Path(core_pkg.__file__).resolve().parent
+FORBIDDEN_ROOTS = {"streamlit", "PySide6", "PyQt5", "PyQt6"}
+
+
+def _imported_roots(source: str) -> set[str]:
+    roots: set[str] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                roots.add(node.module.split(".")[0])
+    return roots
+
+
+def test_core_has_no_ui_framework_imports() -> None:
+    offenders: dict[str, set[str]] = {}
+    for py_file in CORE_DIR.rglob("*.py"):
+        roots = _imported_roots(py_file.read_text(encoding="utf-8"))
+        bad = roots & FORBIDDEN_ROOTS
+        if bad:
+            offenders[py_file.name] = bad
+    assert not offenders, f"UI-framework imports found in core/: {offenders}"

--- a/desktop/tests/unit/test_import_header.py
+++ b/desktop/tests/unit/test_import_header.py
@@ -1,0 +1,28 @@
+"""Tests for the ported language-pair header parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from miolingo_desktop.core.import_header import is_header_line, parse_header
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["(pt, en)", "# (pt, en)", "(  FR  ,  EN  )", "(de,nl)"],
+)
+def test_is_header_line_true(line: str) -> None:
+    assert is_header_line(line) is True
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["bonjour | hello", "", "# a comment", "(toolongcode, en)", "(pt)"],
+)
+def test_is_header_line_false(line: str) -> None:
+    assert is_header_line(line) is False
+
+
+def test_parse_header() -> None:
+    assert parse_header("(FR, EN)") == ("fr", "en")
+    assert parse_header("not a header") is None

--- a/desktop/tests/unit/test_materials.py
+++ b/desktop/tests/unit/test_materials.py
@@ -1,0 +1,100 @@
+"""Tests for language-materials discovery and loading.
+
+These run against the real bundled ``language_materials/`` tree (located via
+``get_data_dir()``), asserting structural invariants rather than exact
+filenames so they stay stable as content evolves. A synthetic temp tree
+exercises the parser edge cases deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core import materials
+
+
+def test_get_data_dir_exists() -> None:
+    data_dir = materials.get_data_dir()
+    assert data_dir.exists(), f"language_materials not found at {data_dir}"
+    assert data_dir.name == "language_materials"
+
+
+def test_available_languages_includes_core_set() -> None:
+    langs = set(materials.get_available_languages())
+    # The bundled content always ships at least these.
+    assert {"pt", "fr", "de", "es", "it", "nl"} <= langs
+
+
+def test_language_structure_has_phrases_or_words() -> None:
+    structure = materials.get_language_structure("pt")
+    assert structure, "expected non-empty structure for pt"
+    assert any(k in structure for k in ("phrases", "words"))
+
+
+def test_get_data_dir_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    materials.get_data_dir.cache_clear()
+    monkeypatch.setenv("MIOLINGO_MATERIALS_DIR", str(tmp_path))
+    try:
+        assert materials.get_data_dir() == tmp_path
+    finally:
+        materials.get_data_dir.cache_clear()
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_load_phrase_file_txt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    materials.get_data_dir.cache_clear()
+    monkeypatch.setenv("MIOLINGO_MATERIALS_DIR", str(tmp_path))
+    try:
+        f = tmp_path / "fr" / "phrases" / "phr-01.txt"
+        _write(
+            f,
+            "# a comment\n(fr, en)\nbonjour | hello | [bɔ̃ʒuʁ]\nmerci | thank you\nau revoir\n",
+        )
+        rows = materials.load_phrase_file(str(f))
+        assert len(rows) == 3  # comment + header line filtered out
+        assert rows[0] == {"text": "bonjour", "translation": "hello", "ipa": "[bɔ̃ʒuʁ]"}
+        assert rows[1] == {"text": "merci", "translation": "thank you", "ipa": None}
+        assert rows[2] == {"text": "au revoir", "translation": None, "ipa": None}
+    finally:
+        materials.get_data_dir.cache_clear()
+
+
+def test_load_phrase_file_rejects_path_traversal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    materials.get_data_dir.cache_clear()
+    monkeypatch.setenv("MIOLINGO_MATERIALS_DIR", str(tmp_path / "data"))
+    try:
+        (tmp_path / "data").mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("nope", encoding="utf-8")
+        with pytest.raises(ValueError):
+            materials.load_phrase_file(str(outside))
+    finally:
+        materials.get_data_dir.cache_clear()
+
+
+def test_load_unified_phrase_file(tmp_path: Path) -> None:
+    f = tmp_path / "u.json"
+    doc = {
+        "meta": {"languages": ["fr", "en"]},
+        "phrases": [
+            {"text": {"fr": "chat", "en": "cat"}, "ipa": {"fr": "ʃa"}},
+            {"text": {"en": "only english"}},  # skipped: no fr
+        ],
+    }
+    f.write_text(json.dumps(doc), encoding="utf-8")
+    rows = list(materials.load_unified_phrase_file(str(f), "fr", "en"))
+    assert rows == [{"text": "chat", "translation": "cat", "ipa": "ʃa"}]
+
+
+def test_format_language_name() -> None:
+    assert materials.format_language_name("fr") == "French"
+    assert materials.format_language_name("xx") == "XX"

--- a/desktop/tests/unit/test_practice_pipeline.py
+++ b/desktop/tests/unit/test_practice_pipeline.py
@@ -1,0 +1,83 @@
+"""Tests for the practice orchestration pipeline (headless, no models/espeak).
+
+The transcriber is injected via ``transcribe_fn`` and phoneme extraction is
+monkeypatched, so the full pipeline (trim -> transcribe -> phonemes -> score ->
+assemble -> on_result) runs deterministically with no Whisper model or espeak
+binary. A real audio->score run is a manual test (needs a mic + model).
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from miolingo_desktop.core import practice
+
+
+def _make_wav(seconds: float = 0.5, sr: int = 16000) -> bytes:
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False)
+    tone = 0.3 * np.sin(2 * np.pi * 220 * t)
+    buf = io.BytesIO()
+    sf.write(buf, tone, sr, format="WAV")
+    return buf.getvalue()
+
+
+def test_trim_silence_returns_bytes() -> None:
+    wav = _make_wav()
+    trimmed, original = practice.trim_silence(wav)
+    assert isinstance(trimmed, bytes)
+    assert original == wav
+
+
+def test_trim_silence_handles_garbage() -> None:
+    trimmed, original = practice.trim_silence(b"not audio")
+    assert trimmed == b"not audio"
+    assert original == b"not audio"
+
+
+def test_practice_pipeline_scores_and_calls_on_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Deterministic phonemes: target and recognised differ by one symbol.
+    monkeypatch.setattr(
+        practice, "get_phonemes", lambda text, voice="": "abc" if text == "ola" else "abd"
+    )
+    monkeypatch.setattr(practice, "get_ipa", lambda text, voice="": "[x]")
+
+    captured: dict = {}
+    result = practice.practice_word_from_audio(
+        "ola",
+        _make_wav(),
+        {"voice": "pt-br", "comparison_algorithm": "edit_distance"},
+        language="Portuguese",
+        on_result=captured.update,
+        transcribe_fn=lambda *a, **k: "olha",
+    )
+
+    assert result is not None
+    assert result["target"] == "ola"
+    assert result["recognized"] == "olha"
+    assert result["exact_match"] is False
+    assert result["edit_distance"] == 1
+    assert result["similarity"] == pytest.approx(2 / 3)
+    # on_result received the same dict.
+    assert captured["target"] == "ola"
+
+
+def test_practice_pipeline_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*a, **k):
+        raise RuntimeError("transcription exploded")
+
+    errors: list[str] = []
+    result = practice.practice_word_from_audio(
+        "ola",
+        _make_wav(),
+        {"voice": "pt-br"},
+        transcribe_fn=_boom,
+        error_fn=errors.append,
+    )
+    assert result is None
+    assert errors and "exploded" in errors[0]

--- a/desktop/tests/unit/test_scoring.py
+++ b/desktop/tests/unit/test_scoring.py
@@ -1,0 +1,64 @@
+"""Unit tests for the ported scoring/comparison logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from miolingo_desktop.core.comparison import (
+    compare_phonemes,
+    compare_phonemes_edit_distance,
+    get_edit_operations,
+    levenshtein_distance,
+)
+
+
+@pytest.mark.parametrize(
+    ("s1", "s2", "expected"),
+    [
+        ("", "", 0),
+        ("abc", "abc", 0),
+        ("abc", "abd", 1),
+        ("kitten", "sitting", 3),
+        ("", "abc", 3),
+        ("abc", "", 3),
+        ("flaw", "lawn", 2),
+    ],
+)
+def test_levenshtein_distance(s1: str, s2: str, expected: int) -> None:
+    assert levenshtein_distance(s1, s2) == expected
+    # Distance is symmetric.
+    assert levenshtein_distance(s2, s1) == expected
+
+
+def test_compare_phonemes_exact_match() -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance("bõʒuʁ", "bõʒuʁ")
+    assert exact is True
+    assert similarity == 1.0
+    assert distance == 0
+
+
+def test_compare_phonemes_partial() -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance("bõʒu", "bõʒuʁ")
+    assert exact is False
+    assert distance == 1
+    assert similarity == pytest.approx(1.0 - 1 / 5)
+
+
+def test_compare_phonemes_empty_reference() -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance("abc", "")
+    assert exact is False
+    assert similarity == 0.0
+    assert distance == 3
+
+
+def test_compare_phonemes_unknown_algorithm_falls_back() -> None:
+    # Unknown algorithm must behave exactly like edit_distance (source parity).
+    a = compare_phonemes("abc", "abd", algorithm="positional")
+    b = compare_phonemes_edit_distance("abc", "abd")
+    assert a == b
+
+
+def test_get_edit_operations_roundtrip() -> None:
+    ops = get_edit_operations("cat", "cut")
+    kinds = [op[0] for op in ops]
+    assert kinds == ["match", "substitute", "match"]

--- a/desktop/tests/unit/test_scoring_parity.py
+++ b/desktop/tests/unit/test_scoring_parity.py
@@ -1,0 +1,79 @@
+"""Scoring parity regression.
+
+Two layers of protection that the ported scoring matches the source app:
+
+1. Hardcoded fixtures (``tests/fixtures/scoring_parity.json``) with certain,
+   hand-verifiable expected outputs.
+2. A cross-check of the ported edit-distance against an INDEPENDENT reference
+   Levenshtein implementation over a broad set (including multi-edit and
+   unicode phoneme strings). This proves the algorithm is correct without
+   trusting hand-computed edit distances for tricky cases.
+
+SPEC acceptance: "the score produced by the ported scoring code matches the
+source app's output for a fixed (audio, reference) fixture set." Audio->phoneme
+extraction needs espeak + a real recording (a manual test); the pure scoring
+layer — where parity is deterministically provable headlessly — is locked here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core.comparison import compare_phonemes_edit_distance
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "scoring_parity.json"
+
+
+def _ref_levenshtein(a: str, b: str) -> int:
+    """Independent reference implementation (different code path than the port)."""
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i]
+        for j, cb in enumerate(b, 1):
+            curr.append(
+                min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + (0 if ca == cb else 1))
+            )
+        prev = curr
+    return prev[-1]
+
+
+def _load_cases() -> list[dict]:
+    with open(FIXTURE, encoding="utf-8") as f:
+        return json.load(f)["cases"]
+
+
+@pytest.mark.parametrize("case", _load_cases())
+def test_fixture_parity(case: dict) -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance(
+        case["user"], case["correct"]
+    )
+    assert exact is case["exact"]
+    assert distance == case["distance"]
+    assert similarity == pytest.approx(case["similarity"])
+
+
+@pytest.mark.parametrize(
+    ("user", "correct"),
+    [
+        ("bõʒuʁ", "bõʒuʁ"),
+        ("bõʒu", "bõʒuʁ"),
+        ("saudʒi", "saʊde"),
+        ("ɐ̃tɐ̃u", "ɐ̃tɐ̃w"),
+        ("obrigadu", "obrigado"),
+        ("", ""),
+        ("abc", ""),
+    ],
+)
+def test_ported_matches_independent_reference(user: str, correct: str) -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance(user, correct)
+    expected_distance = _ref_levenshtein(user, correct)
+    assert distance == expected_distance
+    assert exact is (user == correct)
+    if len(correct) == 0:
+        assert similarity == 0.0
+    else:
+        max_len = max(len(user), len(correct))
+        assert similarity == pytest.approx(1.0 - expected_distance / max_len)

--- a/desktop/tests/unit/test_tts_dispatch.py
+++ b/desktop/tests/unit/test_tts_dispatch.py
@@ -1,0 +1,67 @@
+"""Tests for the TTS dispatcher fallback order (Piper -> Google Cloud -> espeak).
+
+We don't synthesize real audio here; we verify the *selection/fallback* logic by
+monkeypatching the engine functions. Full Piper synthesis + per-voice clip tests
+land in Milestone 7.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from miolingo_desktop.core import tts
+
+
+def test_resolve_piper_voice_missing_raises() -> None:
+    with pytest.raises(tts.PiperUnavailable):
+        tts.resolve_piper_voice("pt-BR", voices={})
+
+
+def test_resolve_piper_voice_present() -> None:
+    assert tts.resolve_piper_voice("pt-BR", voices={"pt-BR": "pt_BR-faber"}) == "pt_BR-faber"
+
+
+def test_dispatch_prefers_piper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts, "synthesize_piper", lambda *a, **k: (b"PIPER", "audio/wav"))
+    out = tts.generate_target_audio("ola", {"tts_engine": "piper", "voice": "pt-br"})
+    assert out == (b"PIPER", "audio/wav")
+
+
+def test_dispatch_falls_back_to_google_when_piper_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_piper(*a, **k):
+        raise tts.PiperUnavailable("no voice")
+
+    monkeypatch.setattr(tts, "synthesize_piper", _no_piper)
+    monkeypatch.setattr(
+        tts, "speak_text_google_cloud", lambda *a, **k: (b"GOOGLE", "audio/mp3")
+    )
+    out = tts.generate_target_audio(
+        "ola", {"tts_engine": "piper", "voice": "pt-br"}, google_api_key="key"
+    )
+    assert out == (b"GOOGLE", "audio/mp3")
+
+
+def test_dispatch_falls_back_to_espeak_when_no_piper_no_google(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_piper(*a, **k):
+        raise tts.PiperUnavailable("no voice")
+
+    monkeypatch.setattr(tts, "synthesize_piper", _no_piper)
+    monkeypatch.setattr(tts, "speak_text", lambda *a, **k: (b"ESPEAK", "audio/wav"))
+    # No google_api_key -> skip Google, go straight to espeak.
+    out = tts.generate_target_audio("ola", {"tts_engine": "piper", "voice": "pt-br"})
+    assert out == (b"ESPEAK", "audio/wav")
+
+
+def test_dispatch_explicit_espeak(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts, "speak_text", lambda *a, **k: (b"ESPEAK", "audio/wav"))
+    out = tts.generate_target_audio("ola", {"tts_engine": "espeak", "voice": "pt-br"})
+    assert out == (b"ESPEAK", "audio/wav")
+
+
+def test_google_cloud_requires_api_key() -> None:
+    with pytest.raises(ValueError):
+        tts.speak_text_google_cloud.__wrapped__("hi", api_key=None)


### PR DESCRIPTION
## Milestone 1 — Port the UI-free core

Moves the business logic into `desktop/miolingo_desktop/core/`, stripped of all
Streamlit coupling. Everything here is UI-framework-free (no `streamlit`, no
`PySide6`) and headlessly testable.

> **Stacking:** this PR is **based on the M0 scaffold branch** (`claude/desktop-m0-scaffold`, PR #123), not directly on `Claude/Dev-Desktop`, because M0 is not yet merged and M1 imports the package scaffold M0 introduces. Merge M0 first, then re-target this PR to `Claude/Dev-Desktop` (or merge M0 into Dev-Desktop and rebase). The M1-only diff is the `core/` modules + tests.

### Ported modules (`core/`)
- `comparison.py` — Levenshtein + edit ops, **verbatim** from `src/scoring/comparison.py` (guarantees scoring parity).
- `phonemes.py` — espeak IPA/phoneme extraction; cross-platform binary discovery; HTML `format_ipa` deliberately left to the UI layer.
- `config.py` — language/voice tables; `DEFAULT_SETTINGS` with `whisper_model_size="medium"` + `tts_engine="piper"` (per DECISIONS); Streamlit/DB settings persistence dropped (owned by SQLite in M2/M4).
- `import_header.py` — `(source, target)` header parsing, verbatim.
- `materials.py` — content discovery/loading; `@st.cache_data` → `lru_cache`; data dir via `$MIOLINGO_MATERIALS_DIR` or repo walk-up (packaging-friendly).
- `asr.py` — Whisper-only (wav2vec2 dropped); model cache via module dict + `clear_model_cache()`; `st.spinner` → `progress_fn`, `st.warning` → `warn_fn`.
- `tts.py` — engines + dispatcher **Piper → Google Cloud (api_key only) → espeak**; `@st.cache_data` → `lru_cache`; `st.secrets` → explicit `api_key`. Piper synthesis itself lands in M7 (`PiperUnavailable` until then, so fallback is testable).
- `practice.py` — orchestration pipeline; callbacks default to `logging`; `transcribe_fn` injectable for headless tests.

### Tests (`tests/unit/`)
- Scoring + **parity regression**: hardcoded JSON fixtures + an independent reference Levenshtein cross-check over multi-edit/unicode phoneme strings.
- config defaults, import_header, materials (real tree + synthetic temp tree), TTS dispatcher fallback order, practice pipeline (stubbed transcriber/phonemes).
- **core-purity guard**: AST-scans `core/` and fails on any `streamlit`/`PySide6` import.

### Test plan
```bash
source /Users/matthew/Software/working/miolingo/venv/bin/activate
pip install -e "desktop[dev]"
cd desktop
QT_QPA_PLATFORM=offscreen pytest -q
ruff check . && mypy miolingo_desktop
```

> ⚠️ **Tests authored but NOT executed in-sandbox** — this environment denies running the venv Python/pytest (see `desktop/QUESTIONS.md`). Please run via CI/locally before merge. Audio→phoneme parity is a manual test (needs espeak + a recording), deferred to M3 acceptance.

### Guardrails
No `import streamlit` under `desktop/`. Existing Streamlit app untouched. No secrets committed.