### PR TITLE
desktop(M4): History + Settings views

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -17,3 +17,9 @@ dist/
 *.sqlite3
 secrets.toml
 .env
+
+# The repo-root .gitignore has a broad `config.*` pattern (for the Streamlit
+# app's practice_config.json etc.) which silently swallows our source module
+# desktop/miolingo_desktop/core/config.py. Re-include it explicitly here so it
+# is tracked. (gitignore: a more specific negation can re-include a file.)
+!miolingo_desktop/core/config.py

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -127,6 +127,51 @@ typing on logic ported from an untyped Streamlit app on day one.
 **Alternatives:** full strict mypy (too much churn up front, reversible to
 tighten later).
 
+### 2026-05-23 (M1) — Core defaults: Whisper `medium`, TTS engine `piper`
+**Decision:** `core/config.DEFAULT_SETTINGS` sets `whisper_model_size="medium"`
+and `tts_engine="piper"` (the source app defaulted to `base` / `google_cloud`).
+**Reasoning:** Matches ratified Phase-0 decisions (accuracy-first ASR; offline
+neural TTS default). Dispatcher order: Piper -> Google Cloud (only if an api_key
+is supplied) -> espeak.
+**Alternatives:** keep source defaults (contradicts Phase-0 rulings).
+
+### 2026-05-23 (M1) — Drop wav2vec2; drop `format_ipa` HTML helper from core
+**Decision:** The ported `asr.py` is Whisper-only (wav2vec2 removed).
+`phonemes.format_ipa` (returned an HTML `<span>`) is NOT ported into `core/` —
+IPA markup is a UI concern for the Qt layer.
+**Reasoning:** wav2vec2 was Portuguese-only/heavy (Phase-0). Keeping HTML out of
+`core/` preserves the UI-framework-free guarantee.
+**Alternatives:** keep `format_ipa` (leaks presentation into core).
+
+### 2026-05-23 (M1) — Replace Streamlit caching/session with plain mechanisms
+**Decision:** `@st.cache_data` -> `functools.lru_cache`; Whisper model
+`st.session_state` cache -> a module-level dict with `clear_model_cache()`;
+`st.spinner` -> optional `progress_fn`; `st.warning`/`st.error` -> optional
+`warn_fn`/`error_fn` (default `logging`); `st.secrets[...]` -> an explicit
+`api_key` argument (no global secrets in core).
+**Reasoning:** Removes Streamlit coupling while preserving behaviour; callbacks
+let the Qt worker thread report progress without core importing PySide6.
+**Alternatives:** custom cache class (unneeded).
+
+### 2026-05-23 (M1) — Materials dir via env override + repo walk-up
+**Decision:** `materials.get_data_dir()` returns `$MIOLINGO_MATERIALS_DIR` if
+set, else walks up to the repo-root `language_materials/`. lru_cached; tests
+`cache_clear()` around overrides.
+**Reasoning:** Dev reads the real bundled content unchanged; packaging (M8)
+points the env var at bundled resources without code changes.
+**Alternatives:** hardcode a path (breaks under PyInstaller).
+
+### 2026-05-23 (M1) — Scoring parity proven at the pure-scoring layer
+**Decision:** The parity regression locks the ported edit-distance scoring via
+(a) hardcoded JSON fixtures with certain expected values and (b) a cross-check
+against an independent reference Levenshtein over multi-edit/unicode strings.
+The audio->phoneme stage is a manual test (needs espeak + a recording).
+**Reasoning:** `comparison.py` is copied byte-for-byte, so identical output is
+guaranteed and provable headlessly; the audio stage can't run in CI without a
+mic/model, so it's marked manual rather than faked.
+**Alternatives:** bundle a real audio fixture + model (huge, still needs a
+Mac/mic to capture) — deferred to M3's manual acceptance.
+
 ### 2026-05-23 — Story Reader deferred to post-v1
 **Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
 it in only if cheap after M3, else post-v1.

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -228,6 +228,18 @@ asserting the worker callable runs on a non-GUI thread.
 **Alternatives:** put logic in the widget (untestable, risks UI-thread work);
 QThread subclassing (heavier than QRunnable for fire-and-forget tasks).
 
+### 2026-05-23 (M4) — History/Settings views + option lists live in core.config
+**Decision:** `HistoryView` is a read-only `QTableWidget` refreshed from
+`PracticeRepository` (and re-refreshed when its tab is shown). `SettingsView` is
+a form bound to `SettingsRepository`, loading effective settings on construct
+and persisting on save. The choice lists (`WHISPER_MODEL_SIZES`, `TTS_ENGINES`,
+`COMPARISON_ALGORITHMS`, `voices_for_language`) live in `core/config.py`, not in
+the widgets.
+**Reasoning:** Keeps domain choices testable and out of the UI; refresh-on-show
+avoids cross-view signal wiring while guaranteeing new attempts appear.
+**Alternatives:** a live model/signal from practice->history (more coupling than
+needed for v1); hardcode choices in the widget (untestable, drifts from config).
+
 ### 2026-05-23 — Story Reader deferred to post-v1
 **Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
 it in only if cheap after M3, else post-v1.

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -172,6 +172,38 @@ mic/model, so it's marked manual rather than faked.
 **Alternatives:** bundle a real audio fixture + model (huge, still needs a
 Mac/mic to capture) — deferred to M3's manual acceptance.
 
+### 2026-05-23 (M2) — Migrations: PRAGMA user_version runner (no alembic/yoyo)
+**Decision:** A ~30-line migration runner keyed on SQLite's
+`PRAGMA user_version`, with migrations as ordered `(version, sql)` pairs applied
+idempotently on every `Database` open. No alembic/yoyo dependency.
+**Reasoning:** A single local SQLite file doesn't justify a migration framework;
+`user_version` is the idiomatic SQLite mechanism, dependency-free, trivially
+bundles under PyInstaller, and is easy to test.
+**Alternatives:** alembic/yoyo (heavier deps, overkill for one local DB).
+
+### 2026-05-23 (M2) — Sync-ready schema shape
+**Decision:** Tables `settings`, `practice_attempts`, `vocabulary`. Every row
+has a UUID-text `id` PK, `created_at`/`updated_at` (ISO-8601 UTC), and a
+`deleted_at` soft-delete column (NULL = live; reads exclude deleted by default).
+A nullable `user_id` column anticipates the future batch sync (NULL in v1 —
+single local user). Vocabulary keeps a unique `(language_code, word)` index and
+re-capture resurrects a soft-deleted row + bumps `times_seen`, mirroring the
+source `vocab.py` upsert.
+**Reasoning:** SPEC §6 / DECISIONS sync-readiness; data shapes mirror
+`app_mysql`/`vocab` so the ported core fits without translation. Stored
+similarity is 0..100 (source convention) while the core pipeline uses 0..1 —
+`save_from_result` does the ×100 mapping.
+**Alternatives:** integer autoincrement PKs (collide across devices on sync);
+hard deletes (lose sync tombstones).
+
+### 2026-05-23 (M2) — DB location via $MIOLINGO_DB_PATH or app-support dir
+**Decision:** `paths.default_db_path()` returns `$MIOLINGO_DB_PATH` if set, else
+`~/Library/Application Support/Miolingo/miolingo.db` on macOS (with XDG/APPDATA
+fallbacks for cross-platform cleanliness). WAL journal mode; `foreign_keys=ON`.
+**Reasoning:** Tests/packaging override the path via env without touching call
+sites; WAL lets the UI thread read while a worker writes.
+**Alternatives:** hardcode the path (untestable, breaks under sandboxing).
+
 ### 2026-05-23 — Story Reader deferred to post-v1
 **Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
 it in only if cheap after M3, else post-v1.

--- a/desktop/DECISIONS.md
+++ b/desktop/DECISIONS.md
@@ -204,6 +204,30 @@ fallbacks for cross-platform cleanliness). WAL journal mode; `foreign_keys=ON`.
 sites; WAL lets the UI thread read while a worker writes.
 **Alternatives:** hardcode the path (untestable, breaks under sandboxing).
 
+### 2026-05-23 (M3) — Audio capture via sounddevice; QtMultimedia for playback
+**Decision:** Record the mic with `sounddevice` (16 kHz mono WAV bytes, matching
+the source app + Whisper). Play target audio with `PySide6.QtMultimedia`
+(`QMediaPlayer`), imported lazily so a missing QtMultimedia degrades gracefully
+(status message) rather than crashing import.
+**Reasoning:** sounddevice is what the source app uses and is simple/cross-
+platform; capture returns in-memory bytes (no temp files for the user path).
+Lazy QtMultimedia keeps the offscreen smoke tests runnable even if the module
+isn't present in a given environment.
+**Alternatives:** Qt's QAudioSource for capture (more boilerplate, no benefit).
+
+### 2026-05-23 (M3) — UI-free PracticeController as the seam; QThreadPool workers
+**Decision:** A `core/controller.PracticeController` (no PySide6) wires
+materials + the practice pipeline + storage; Qt views call it. Blocking work
+(TTS, capture, transcription) runs on `QThreadPool` via a generic `Worker`
+(`QRunnable` + signals), which optionally injects a `progress_fn` that emits a
+Qt signal.
+**Reasoning:** Keeps all logic headlessly testable (the full
+record(stub)->transcribe(stub)->score->save flow is asserted without Qt or a
+model) and guarantees the UI thread never blocks (SPEC §7) — proven by a test
+asserting the worker callable runs on a non-GUI thread.
+**Alternatives:** put logic in the widget (untestable, risks UI-thread work);
+QThread subclassing (heavier than QRunnable for fire-and-forget tasks).
+
 ### 2026-05-23 — Story Reader deferred to post-v1
 **Decision:** Story Reader (full + scene-by-scene) is not a v1 must-keep; slot
 it in only if cheap after M3, else post-v1.

--- a/desktop/miolingo_desktop/core/__init__.py
+++ b/desktop/miolingo_desktop/core/__init__.py
@@ -1,6 +1,16 @@
 """UI-framework-free business logic (ported from the Streamlit app).
 
-Nothing in this package may import ``streamlit`` or ``PySide6``. It takes plain
-arguments and returns plain values so it stays headlessly testable. Populated
-from Milestone 1 onward.
+Nothing in this package may import ``streamlit`` or ``PySide6`` (enforced by
+``tests/unit/test_core_purity.py``). It takes plain arguments and returns plain
+values so it stays headlessly testable.
+
+Modules:
+- ``config``       — language/voice tables + default settings.
+- ``comparison``   — Levenshtein scoring (verbatim from source; parity-locked).
+- ``phonemes``     — espeak IPA/phoneme extraction.
+- ``import_header``— ``(source, target)`` header parsing.
+- ``materials``    — bundled language-materials discovery/loading.
+- ``asr``          — Whisper transcription (model load separated for off-thread).
+- ``tts``          — TTS engines + Piper->GoogleCloud->espeak dispatcher.
+- ``practice``     — the practice/scoring orchestration pipeline.
 """

--- a/desktop/miolingo_desktop/core/asr.py
+++ b/desktop/miolingo_desktop/core/asr.py
@@ -1,0 +1,137 @@
+"""Automatic Speech Recognition (Whisper, local).
+
+Ported from ``src/audio/asr.py`` with all Streamlit coupling removed:
+- ``st.session_state`` model caching -> a plain in-process module cache.
+- ``st.spinner`` -> an optional ``progress_fn`` callback (the Qt layer wires a
+  worker-thread progress signal to it; defaults to a no-op).
+- ``st.warning``/``st.error`` -> an optional ``warn_fn`` (defaults to logging).
+- wav2vec2 dropped entirely (DECISIONS.md: Whisper covers all languages).
+
+Transcription itself is a pure function: it takes a loaded model and returns
+text. Model loading is separated so the UI can run it off-thread with progress.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from collections.abc import Callable
+
+from .config import LANGUAGE_CONFIG
+
+logger = logging.getLogger(__name__)
+
+ProgressFn = Callable[[str], None]
+WarnFn = Callable[[str], None]
+
+# In-process model cache: model_name -> loaded whisper model.
+_WHISPER_CACHE: dict[str, object] = {}
+
+
+def _default_warn(msg: str) -> None:
+    logger.warning(msg)
+
+
+def get_whisper_model(model_name: str, *, progress_fn: ProgressFn | None = None) -> object:
+    """Load (or return cached) a Whisper model by name.
+
+    The first load of a model that is not present locally triggers
+    openai-whisper's download-on-first-run (cached under ``~/.cache/whisper``);
+    ``progress_fn`` is called once before the potentially slow load so the UI
+    can show a "loading model" state.
+    """
+    cached = _WHISPER_CACHE.get(model_name)
+    if cached is not None:
+        return cached
+
+    if progress_fn is not None:
+        progress_fn(f"Loading Whisper model '{model_name}'...")
+
+    import whisper  # imported lazily; heavy dependency
+
+    model = whisper.load_model(model_name)
+    _WHISPER_CACHE[model_name] = model
+    return model
+
+
+def clear_model_cache() -> None:
+    """Drop cached models (used by tests and on a settings model-size change)."""
+    _WHISPER_CACHE.clear()
+
+
+def transcribe_audio_whisper(
+    audio_file: str,
+    model: object,
+    language_code: str = "pt",
+) -> str:
+    """Transcribe *audio_file* with a loaded Whisper *model*.
+
+    Includes the source app's hallucination guards: returns a bracketed error
+    string if a short pattern repeats 10+ times or the transcript exceeds 100
+    words.
+    """
+    result = model.transcribe(  # type: ignore[attr-defined]
+        audio=audio_file,
+        language=language_code,
+        task="transcribe",
+        temperature=0.0,
+        no_speech_threshold=0.6,
+        logprob_threshold=-1.0,
+        condition_on_previous_text=False,
+        word_timestamps=False,
+        compression_ratio_threshold=2.4,
+    )
+
+    detected_lang = result.get("language", "unknown")
+    if detected_lang != language_code:
+        warnings.warn(
+            f"Whisper detected language '{detected_lang}' instead of '{language_code}'",
+            stacklevel=2,
+        )
+
+    transcribed_text = result["text"].strip().lower()
+
+    words = transcribed_text.split()
+    if len(words) > 20:
+        for pattern_len in (2, 3, 4):
+            if len(words) >= pattern_len * 10:
+                pattern = " ".join(words[:pattern_len])
+                repetitions = transcribed_text.count(pattern)
+                if repetitions >= 10:
+                    warnings.warn(
+                        f"Whisper hallucination detected: '{pattern}' x{repetitions}",
+                        stacklevel=2,
+                    )
+                    return f"[hallucination detected: '{pattern}' x{repetitions}]"
+
+        if len(words) > 100:
+            warnings.warn(
+                f"Suspiciously long transcription: {len(words)} words", stacklevel=2
+            )
+            return f"[error: transcription too long - {len(words)} words, possible hallucination]"
+
+    return transcribed_text
+
+
+def transcribe_audio(
+    audio_file: str,
+    settings: dict,
+    language: str = "Portuguese",
+    *,
+    warn_fn: WarnFn | None = None,
+    progress_fn: ProgressFn | None = None,
+) -> str:
+    """Transcribe *audio_file* using Whisper, honouring *settings*.
+
+    ``settings`` supplies ``whisper_model_size`` (default ``medium``). The
+    ``language`` name selects the Whisper language code via ``LANGUAGE_CONFIG``.
+    """
+    if warn_fn is None:
+        warn_fn = _default_warn
+
+    lang_config = LANGUAGE_CONFIG[language]
+    lang_code = str(lang_config["code"])
+
+    model_size = str(settings.get("whisper_model_size", "medium"))
+    model = get_whisper_model(model_size, progress_fn=progress_fn)
+    return transcribe_audio_whisper(audio_file, model, lang_code)

--- a/desktop/miolingo_desktop/core/audio_capture.py
+++ b/desktop/miolingo_desktop/core/audio_capture.py
@@ -1,0 +1,43 @@
+"""Microphone capture -> WAV bytes (UI-free).
+
+Uses ``sounddevice`` (cross-platform, simple) to record at 16 kHz mono, matching
+the source app's recording format and Whisper's expected sample rate. Returns
+in-memory WAV bytes so the practice pipeline never touches the filesystem for
+capture.
+
+Recording obviously needs a microphone, so the live-capture path is exercised
+only by a ``@pytest.mark.manual`` test. ``encode_wav`` (pure) is unit-tested.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import soundfile as sf
+
+SAMPLE_RATE = 16000
+
+
+def encode_wav(samples: np.ndarray, sample_rate: int = SAMPLE_RATE) -> bytes:
+    """Encode float/int samples to WAV bytes (in memory)."""
+    buf = io.BytesIO()
+    sf.write(buf, samples, sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+def record_wav(duration: float = 3.0, sample_rate: int = SAMPLE_RATE) -> bytes:
+    """Record *duration* seconds from the default input device as WAV bytes.
+
+    Blocking — call this from a Qt worker thread, never the UI thread. Raises
+    ``RuntimeError`` if ``sounddevice`` (PortAudio) is unavailable.
+    """
+    try:
+        import sounddevice as sd
+    except Exception as e:  # noqa: BLE001 - import or PortAudio init failure
+        raise RuntimeError(f"Audio input unavailable: {e}") from e
+
+    frames = int(duration * sample_rate)
+    recording = sd.rec(frames, samplerate=sample_rate, channels=1, dtype="float32")
+    sd.wait()
+    return encode_wav(recording.reshape(-1), sample_rate)

--- a/desktop/miolingo_desktop/core/comparison.py
+++ b/desktop/miolingo_desktop/core/comparison.py
@@ -1,0 +1,109 @@
+"""Phoneme comparison and scoring algorithms.
+
+Ported verbatim from the Streamlit app's ``src/scoring/comparison.py`` — these
+were already pure functions with no UI coupling, so the desktop port is a
+straight copy. Keeping them byte-identical guarantees scoring parity with the
+source app (see ``tests/unit/test_scoring_parity.py``).
+"""
+
+from __future__ import annotations
+
+
+def levenshtein_distance(s1: str, s2: str) -> int:
+    """Minimum single-character edits (insert/delete/substitute) between strings."""
+    if len(s1) < len(s2):
+        return levenshtein_distance(s2, s1)
+
+    if len(s2) == 0:
+        return len(s1)
+
+    previous_row = list(range(len(s2) + 1))
+    for i, c1 in enumerate(s1):
+        current_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = previous_row[j + 1] + 1
+            deletions = current_row[j] + 1
+            substitutions = previous_row[j] + (c1 != c2)
+            current_row.append(min(insertions, deletions, substitutions))
+        previous_row = current_row
+
+    return previous_row[-1]
+
+
+def get_edit_operations(s1: str, s2: str) -> list[tuple[str, int, str, str]]:
+    """Return the edit operations transforming s1 into s2.
+
+    Each tuple is ``(operation, position, char1, char2)`` where operation is
+    'match', 'substitute', 'insert', or 'delete'.
+    """
+    m, n = len(s1), len(s2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if s1[i - 1] == s2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = 1 + min(
+                    dp[i - 1][j],  # delete
+                    dp[i][j - 1],  # insert
+                    dp[i - 1][j - 1],  # substitute
+                )
+
+    operations: list[tuple[str, int, str, str]] = []
+    i, j = m, n
+    while i > 0 or j > 0:
+        if i > 0 and j > 0 and s1[i - 1] == s2[j - 1]:
+            operations.append(("match", i - 1, s1[i - 1], s2[j - 1]))
+            i -= 1
+            j -= 1
+        elif i > 0 and j > 0 and dp[i][j] == dp[i - 1][j - 1] + 1:
+            operations.append(("substitute", i - 1, s1[i - 1], s2[j - 1]))
+            i -= 1
+            j -= 1
+        elif j > 0 and dp[i][j] == dp[i][j - 1] + 1:
+            operations.append(("insert", i, "-", s2[j - 1]))
+            j -= 1
+        elif i > 0 and dp[i][j] == dp[i - 1][j] + 1:
+            operations.append(("delete", i - 1, s1[i - 1], "-"))
+            i -= 1
+
+    operations.reverse()
+    return operations
+
+
+def compare_phonemes_edit_distance(
+    user_phonemes: str, correct_phonemes: str
+) -> tuple[bool, float, int]:
+    """Compare phonemes via Levenshtein.
+
+    Returns ``(exact_match, similarity[0..1], distance)``.
+    """
+    exact_match = user_phonemes == correct_phonemes
+
+    if len(correct_phonemes) == 0:
+        return exact_match, 0.0, len(user_phonemes)
+
+    distance = levenshtein_distance(user_phonemes, correct_phonemes)
+    max_length = max(len(user_phonemes), len(correct_phonemes))
+    similarity = 1.0 - (distance / max_length)
+
+    return exact_match, similarity, distance
+
+
+def compare_phonemes(
+    user_phonemes: str,
+    correct_phonemes: str,
+    algorithm: str = "edit_distance",
+) -> tuple[bool, float, int]:
+    """Modular phoneme comparison.
+
+    The legacy "positional" algorithm was removed upstream; any unknown
+    ``algorithm`` value falls back to edit distance (matches source behaviour).
+    """
+    return compare_phonemes_edit_distance(user_phonemes, correct_phonemes)

--- a/desktop/miolingo_desktop/core/config.py
+++ b/desktop/miolingo_desktop/core/config.py
@@ -1,0 +1,210 @@
+"""Miolingo configuration: language definitions, voice mappings, default settings.
+
+Ported from ``src/config.py``. The language/voice tables are copied verbatim
+(pure data). The Streamlit/DB-coupled ``load_settings``/``save_settings`` are
+NOT ported here — settings persistence is owned by the SQLite storage layer
+(Milestone 2/4). This module only provides ``DEFAULT_SETTINGS`` and the pure
+language-helper functions.
+
+Default changes vs the source app (per DECISIONS.md):
+- ``whisper_model_size`` defaults to ``"medium"`` (was ``"base"``).
+- ``tts_engine`` defaults to ``"piper"`` (offline neural; was ``"google_cloud"``).
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Language configuration
+# ---------------------------------------------------------------------------
+
+LANGUAGE_CONFIG: dict[str, dict] = {
+    "English": {
+        "code": "en",
+        "display_name": "English Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["en-gb", "en-us"],
+            "gtts": ["en"],
+            "espeak": ["en-gb", "en"],
+        },
+    },
+    "Portuguese": {
+        "code": "pt",
+        "display_name": "Portuguese Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["pt-br", "pt"],
+            "gtts": ["pt-br", "pt"],
+            "espeak": ["pt-br", "pt"],
+        },
+    },
+    "Dutch": {
+        "code": "nl",
+        "display_name": "Dutch/Flemish Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["nl", "nl-be"],
+            "gtts": ["nl"],
+            "espeak": ["nl"],
+        },
+    },
+    "French": {
+        "code": "fr",
+        "display_name": "French Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["fr", "fr-fr"],
+            "gtts": ["fr"],
+            "espeak": ["fr-fr"],
+        },
+    },
+    "German": {
+        "code": "de",
+        "display_name": "German Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["de", "de-de"],
+            "gtts": ["de"],
+            "espeak": ["de"],
+        },
+    },
+    "Italian": {
+        "code": "it",
+        "display_name": "Italian Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["it", "it-it"],
+            "gtts": ["it"],
+            "espeak": ["it"],
+        },
+    },
+    "Spanish": {
+        "code": "es",
+        "display_name": "Spanish Pronunciation Trainer",
+        "voices": {
+            "google_cloud": ["es", "es-es"],
+            "gtts": ["es"],
+            "espeak": ["es"],
+        },
+    },
+}
+
+# Voice locale normalization: lowercase codes -> BCP 47 format
+VOICE_LOCALE_NORMALIZATION: dict[str, str] = {
+    "en": "en-US",
+    "en-gb": "en-GB",
+    "en-us": "en-US",
+    "pt-br": "pt-BR",
+    "pt": "pt-PT",
+    "fr": "fr-FR",
+    "fr-fr": "fr-FR",
+    "nl": "nl-NL",
+    "nl-be": "nl-BE",
+    "de": "de-DE",
+    "de-de": "de-DE",
+    "it": "it-IT",
+    "it-it": "it-IT",
+    "es": "es-ES",
+    "es-es": "es-ES",
+}
+
+# Google Cloud TTS voice names per locale (optional online engine).
+GOOGLE_CLOUD_VOICES: dict[str, str] = {
+    "en-GB": "en-GB-Standard-A",
+    "en-US": "en-US-Standard-A",
+    "pt-BR": "pt-BR-Standard-A",
+    "pt-PT": "pt-PT-Standard-A",
+    "fr-FR": "fr-FR-Standard-A",
+    "nl-NL": "nl-NL-Standard-A",
+    "nl-BE": "nl-BE-Standard-A",
+    "de-DE": "de-DE-Standard-A",
+    "it-IT": "it-IT-Standard-A",
+    "es-ES": "es-ES-Standard-A",
+}
+
+# ---------------------------------------------------------------------------
+# Default settings (desktop)
+# ---------------------------------------------------------------------------
+
+DEFAULT_SETTINGS: dict[str, object] = {
+    "speed": 140,
+    "pitch": 35,
+    "voice": "pt-br",
+    "model": "medium",
+    "duration": 3,
+    "comparison_algorithm": "edit_distance",
+    "asr_engine": "whisper",
+    "whisper_model_size": "medium",  # DECISIONS.md: accuracy over size
+    "silence_threshold": 0.01,
+    "use_wav_audio": False,
+    "tts_engine": "piper",  # DECISIONS.md: Piper offline neural is the default
+    "gtts_slow": False,
+    "source_language": "English",
+    "debug_mode": False,
+}
+
+# ---------------------------------------------------------------------------
+# Material-code -> Training-language mapping
+# ---------------------------------------------------------------------------
+
+MATERIAL_TO_TRAINING: dict[str, str] = {
+    "en": "English",
+    "de": "German",
+    "es": "Spanish",
+    "fr": "French",
+    "it": "Italian",
+    "nl": "Dutch",
+    "pt": "Portuguese",
+}
+
+SOURCE_LANGUAGE_OPTIONS: list[str] = [
+    "English",
+    "French",
+    "German",
+    "Spanish",
+    "Italian",
+    "Dutch",
+    "Portuguese",
+]
+
+
+# ---------------------------------------------------------------------------
+# Language helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def get_language_code(language_name: str) -> str:
+    """Map a language name to its short code."""
+    if language_name.lower() == "english":
+        return "en"
+    if language_name in LANGUAGE_CONFIG:
+        return str(LANGUAGE_CONFIG[language_name].get("code", language_name.lower()))
+    return language_name.lower()
+
+
+def get_language_for_provider(provider: str, language_name: str) -> str:
+    """Get the language identifier expected by a translation provider."""
+    if provider == "google":
+        return get_language_code(language_name)
+    return language_name
+
+
+def default_settings() -> dict[str, object]:
+    """Return a fresh copy of the default settings dict."""
+    return dict(DEFAULT_SETTINGS)
+
+
+# ---------------------------------------------------------------------------
+# Option lists for the Settings UI (kept here so the UI holds no choices itself)
+# ---------------------------------------------------------------------------
+
+WHISPER_MODEL_SIZES: list[str] = ["tiny", "base", "small", "medium", "large"]
+TTS_ENGINES: list[str] = ["piper", "google_cloud", "espeak"]
+COMPARISON_ALGORITHMS: list[str] = ["edit_distance"]
+
+
+def voices_for_language(language_name: str) -> list[str]:
+    """All distinct voice codes configured for *language_name* across engines."""
+    cfg = LANGUAGE_CONFIG.get(language_name)
+    if not cfg:
+        return []
+    seen: list[str] = []
+    for codes in cfg.get("voices", {}).values():
+        for code in codes:
+            if code not in seen:
+                seen.append(code)
+    return seen

--- a/desktop/miolingo_desktop/core/controller.py
+++ b/desktop/miolingo_desktop/core/controller.py
@@ -1,0 +1,108 @@
+"""Application controller: wires core logic to storage, UI-free.
+
+This is the seam between the Qt views (M3+) and the rest of the system. It is
+deliberately framework-free (no PySide6) so the whole practice flow can be
+driven and asserted in a headless integration test. Qt workers call these
+methods off the UI thread.
+
+Responsibilities:
+- expose available languages / phrases from bundled materials,
+- run a practice attempt (transcribe + score) and persist the result,
+- read back recent history.
+
+Settings are read from the SQLite ``SettingsRepository``, falling back to
+``DEFAULT_SETTINGS`` for any key not yet stored.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from . import config, materials
+from .asr import ProgressFn
+from .practice import practice_word_from_audio
+from ..data import Database, PracticeRepository, SettingsRepository
+
+
+class PracticeController:
+    """Coordinates materials, the practice pipeline, and persistence."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+        self.settings_repo = SettingsRepository(db)
+        self.practice_repo = PracticeRepository(db)
+
+    # -- settings ----------------------------------------------------------
+
+    def effective_settings(self) -> dict[str, Any]:
+        """Stored settings merged over defaults (stored wins)."""
+        merged = config.default_settings()
+        merged.update(self.settings_repo.get_all())
+        return merged
+
+    # -- materials ---------------------------------------------------------
+
+    def available_languages(self) -> list[str]:
+        return materials.get_available_languages()
+
+    def phrases_for(self, language: str, category: str, filename: str) -> list[dict]:
+        meta = materials.get_file_metadata(language, category, filename)
+        path = meta.get("path")
+        if path is None:
+            return []
+        if category.startswith("unified-"):
+            # Project the unified file for (target=language, source=en).
+            return list(materials.load_unified_phrase_file(str(path), language, "en"))
+        return materials.load_phrase_file(str(path))
+
+    def language_categories(self, language: str) -> dict[str, list[str]]:
+        return materials.get_language_structure(language)
+
+    # -- practice ----------------------------------------------------------
+
+    def run_practice(
+        self,
+        *,
+        target_text: str,
+        audio_bytes: bytes,
+        language: str,
+        progress_fn: ProgressFn | None = None,
+        warn_fn: Callable[[str], None] | None = None,
+        transcribe_fn: Callable[..., str] | None = None,
+    ) -> dict[str, Any] | None:
+        """Score *audio_bytes* against *target_text* and persist the attempt.
+
+        Returns the result dict (also containing the saved ``attempt_id``), or
+        ``None`` on error. ``transcribe_fn`` is injectable for tests so the flow
+        runs without a Whisper model.
+        """
+        settings = self.effective_settings()
+        language_code = config.get_language_code(language)
+
+        saved_id: dict[str, str] = {}
+
+        def _persist(result: dict[str, Any]) -> None:
+            saved_id["id"] = self.practice_repo.save_from_result(language_code, result)
+
+        result = practice_word_from_audio(
+            target_text,
+            audio_bytes,
+            settings,
+            language=language,
+            on_result=_persist,
+            warn_fn=warn_fn,
+            progress_fn=progress_fn,
+            transcribe_fn=transcribe_fn,
+        )
+        if result is not None and "id" in saved_id:
+            result["attempt_id"] = saved_id["id"]
+        return result
+
+    # -- history -----------------------------------------------------------
+
+    def recent_history(
+        self, *, language: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        code = config.get_language_code(language) if language else None
+        return self.practice_repo.list_history(language_code=code, limit=limit)

--- a/desktop/miolingo_desktop/core/import_header.py
+++ b/desktop/miolingo_desktop/core/import_header.py
@@ -1,0 +1,32 @@
+"""Shared parsing for the ``(source, target)`` language-pair header.
+
+Ported verbatim from ``src/import_header.py`` (pure, no UI coupling). Used when
+filtering bundled language-material files so the header line does not leak into
+previews or counts.
+
+Accepted forms::
+
+    (pt, en)
+    # (pt, en)
+    (  FR  ,  EN  )
+"""
+
+from __future__ import annotations
+
+import re
+
+HEADER_RE = re.compile(
+    r"^\s*#?\s*\(\s*([a-z]{2,5})\s*,\s*([a-z]{2,5})\s*\)\s*$",
+    re.IGNORECASE,
+)
+
+
+def is_header_line(raw: str) -> bool:
+    """Return True if *raw* is a ``(source, target)`` header tuple."""
+    return bool(HEADER_RE.match(raw))
+
+
+def parse_header(raw: str) -> tuple[str, str] | None:
+    """Return ``(source_code, target_code)`` lowercased, or ``None``. Never raises."""
+    m = HEADER_RE.match(raw)
+    return (m.group(1).lower(), m.group(2).lower()) if m else None

--- a/desktop/miolingo_desktop/core/materials.py
+++ b/desktop/miolingo_desktop/core/materials.py
@@ -1,0 +1,353 @@
+"""Language materials discovery and loading.
+
+Ported from ``src/app_language_materials.py`` with ``@st.cache_data`` replaced
+by ``functools.lru_cache`` (in-process). Logic is otherwise preserved so the
+desktop app reads the exact same bundled ``language_materials/`` content.
+
+The content directory is resolved by ``get_data_dir()``:
+1. the ``MIOLINGO_MATERIALS_DIR`` environment variable, if set (packaging/M8
+   points this at the bundled resources);
+2. otherwise the repo-root ``language_materials/`` (dev mode), located by
+   walking up from this file.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+from pathlib import Path
+
+from .import_header import is_header_line
+
+CACHE_VERSION = "1.10.1"
+
+
+@functools.lru_cache(maxsize=1)
+def get_data_dir() -> Path:
+    """Resolve the bundled language-materials directory."""
+    env = os.environ.get("MIOLINGO_MATERIALS_DIR")
+    if env:
+        return Path(env)
+    # Walk up to the repo root (contains a top-level ``language_materials/``).
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "language_materials"
+        if candidate.is_dir():
+            return candidate
+    # Fallback: repo-root guess two levels above desktop/.
+    return here.parents[3] / "language_materials"
+
+
+def _unified_dir() -> Path:
+    return get_data_dir() / "unified"
+
+
+@functools.lru_cache(maxsize=1)
+def get_available_languages(_cache_version: str = CACHE_VERSION) -> list[str]:
+    """Languages with materials, from per-language dirs plus unified files."""
+    data_dir = get_data_dir()
+    if not data_dir.exists():
+        return []
+
+    per_lang = {
+        d.name
+        for d in data_dir.iterdir()
+        if d.is_dir() and not d.name.startswith(".") and d.name != "unified"
+    }
+
+    unified_langs: set[str] = set()
+    unified = _unified_dir()
+    for subdir_name in ("phrases", "phrasebook", "stories"):
+        subdir = unified / subdir_name
+        if subdir.is_dir():
+            candidates = sorted(subdir.glob("*.json"))
+            if candidates:
+                try:
+                    with open(candidates[0], encoding="utf-8") as f:
+                        meta = json.load(f).get("meta", {})
+                    unified_langs.update(meta.get("languages", []))
+                    break
+                except Exception:
+                    pass
+
+    return sorted(per_lang | unified_langs)
+
+
+@functools.lru_cache(maxsize=64)
+def get_language_structure(
+    language: str, _cache_version: str = CACHE_VERSION
+) -> dict[str, list[str]]:
+    """Aggregate a language's files into ``phrases``/``words`` (+ unified cats)."""
+    data_dir = get_data_dir()
+    lang_dir = data_dir / language
+    aggregated: dict[str, list[str]] = {"phrases": [], "words": []}
+    excluded_dirs = {"phrases-original", "story-scenes"}
+
+    iterdir = sorted(lang_dir.iterdir()) if lang_dir.exists() else []
+    for category_dir in iterdir:
+        if not category_dir.is_dir() or category_dir.name.startswith("."):
+            continue
+        if (
+            category_dir.name in excluded_dirs
+            or "-original" in category_dir.name
+            or "backup" in category_dir.name
+        ):
+            continue
+
+        txt_files = sorted(f.name for f in category_dir.glob("*.txt"))
+        json_files = sorted(f.name for f in category_dir.glob("*.json"))
+        files = txt_files + json_files
+        if not files:
+            continue
+
+        if category_dir.name == "phrases" or category_dir.name.startswith("phrases-"):
+            aggregated["phrases"].extend(files)
+        elif category_dir.name == "words" or category_dir.name.startswith("words-"):
+            aggregated["words"].extend(files)
+        else:
+            aggregated[category_dir.name] = files
+
+    result = {k: v for k, v in aggregated.items() if v}
+
+    unified_category_map = {
+        "stories": "unified-stories",
+        "phrases": "unified-phrases",
+        "phrasebook": "unified-phrasebook",
+    }
+    unified = _unified_dir()
+    for subdir, category_name in unified_category_map.items():
+        unified_subdir = unified / subdir
+        if unified_subdir.is_dir():
+            files = sorted(f.name for f in unified_subdir.glob("*.json"))
+            if files:
+                try:
+                    with open(unified_subdir / files[0], encoding="utf-8") as f:
+                        meta = json.load(f).get("meta", {})
+                    if language in meta.get("languages", []):
+                        result[category_name] = files
+                except Exception:
+                    pass
+
+    return result
+
+
+def get_file_metadata(
+    language: str, category: str, filename: str, source_language: str = "en"
+) -> dict:
+    """Return metadata (path, line_count, has_translations, has_ipa, preview)."""
+    if category.startswith("unified-"):
+        subdir = category.replace("unified-", "", 1)
+        file_path = _unified_dir() / subdir / filename
+    else:
+        file_path = get_data_dir() / language / category / filename
+
+    if not file_path.exists():
+        return {}
+
+    try:
+        if file_path.suffix == ".json":
+            with open(file_path, encoding="utf-8") as f:
+                data = json.load(f)
+
+            if isinstance(data, dict) and "meta" in data and "phrases" in data:
+                meta = data["meta"]
+                phrases = data["phrases"]
+                preview = []
+                for phrase in phrases[:3]:
+                    text = phrase.get("text", {}).get(language, "")
+                    if not text:
+                        continue
+                    trans = phrase.get("text", {}).get(source_language) or phrase.get(
+                        "text", {}
+                    ).get("en", "")
+                    if trans == text:
+                        trans = ""
+                    ipa = phrase.get("ipa", {}).get(language, "")
+                    if trans and ipa:
+                        preview.append(f"{text} | {trans} | {ipa}")
+                    elif trans:
+                        preview.append(f"{text} | {trans}")
+                    else:
+                        preview.append(text)
+                return {
+                    "path": file_path,
+                    "line_count": meta.get("phrase_count", len(phrases)),
+                    "has_translations": True,
+                    "has_ipa": any(p.get("ipa", {}).get(language) for p in phrases[:5]),
+                    "preview": preview,
+                }
+
+            if isinstance(data, dict):
+                lang_keys = [k for k in data if k not in ("scene_number", "scene_title")]
+                if not lang_keys:
+                    return _empty_meta(file_path)
+                lang_key = lang_keys[0]
+                phrases = data[lang_key]
+                preview = []
+                for phrase in phrases[:3]:
+                    text = phrase.get(lang_key, "")
+                    translation = phrase.get("english", "")
+                    ipa = phrase.get("ipa", "")
+                    if translation and ipa:
+                        preview.append(f"{text} | {translation} | {ipa}")
+                    elif translation:
+                        preview.append(f"{text} | {translation}")
+                    else:
+                        preview.append(text)
+                return {
+                    "path": file_path,
+                    "line_count": len(phrases),
+                    "has_translations": bool(phrases and phrases[0].get("english")),
+                    "has_ipa": bool(phrases and phrases[0].get("ipa")),
+                    "preview": preview,
+                }
+            return _empty_meta(file_path)
+
+        with open(file_path, encoding="utf-8") as f:
+            all_lines = f.readlines()
+
+        content_lines = [
+            s
+            for line in all_lines
+            if (s := line.strip())
+            and not s.startswith("#")
+            and not is_header_line(line)
+        ]
+        if not content_lines:
+            return _empty_meta(file_path)
+
+        sample = content_lines[0]
+        return {
+            "path": file_path,
+            "line_count": len(content_lines),
+            "has_translations": "|" in sample,
+            "has_ipa": "[" in sample and "]" in sample,
+            "preview": content_lines[:3],
+        }
+    except Exception as e:  # noqa: BLE001 - mirror source's broad guard
+        meta = _empty_meta(file_path)
+        meta["error"] = str(e)
+        return meta
+
+
+def _empty_meta(file_path: Path) -> dict:
+    return {
+        "path": file_path,
+        "line_count": 0,
+        "has_translations": False,
+        "has_ipa": False,
+        "preview": [],
+    }
+
+
+@functools.lru_cache(maxsize=128)
+def load_unified_phrase_file(
+    file_path_str: str, target_lang: str, source_lang: str
+) -> tuple[dict, ...]:
+    """Load a unified multi-language JSON file, projecting one language pair.
+
+    Returns a tuple (hashable, so it's lru_cache-friendly) of
+    ``{text, translation, ipa}`` dicts. Callers can ``list(...)`` it.
+    """
+    with open(file_path_str, encoding="utf-8") as f:
+        doc = json.load(f)
+
+    phrases: list[dict] = []
+    for entry in doc.get("phrases", []):
+        target_text = entry.get("text", {}).get(target_lang)
+        if not target_text:
+            continue
+        source_text = entry.get("text", {}).get(source_lang) or entry.get("text", {}).get(
+            "en", ""
+        )
+        ipa_text = entry.get("ipa", {}).get(target_lang, "")
+        phrases.append(
+            {"text": target_text, "translation": source_text, "ipa": ipa_text or None}
+        )
+    return tuple(phrases)
+
+
+def load_phrase_file(file_path_str: str) -> list[dict]:
+    """Load and parse a phrase/word file (TXT or JSON) within the data dir."""
+    file_path = Path(file_path_str)
+
+    try:
+        file_path_resolved = file_path.resolve()
+        data_dir_resolved = get_data_dir().resolve()
+        if not file_path_resolved.is_relative_to(data_dir_resolved):
+            raise ValueError("Invalid file path: outside language materials directory")
+    except Exception as e:
+        raise ValueError(f"Invalid file path: {e}") from e
+
+    unified_resolved = _unified_dir().resolve()
+    if str(file_path_resolved).startswith(str(unified_resolved)):
+        raise ValueError(
+            "Unified files must be loaded via load_unified_phrase_file() with "
+            "explicit target/source language parameters"
+        )
+
+    if file_path.suffix == ".json":
+        with open(file_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        lang_code = None
+        phrases_data = None
+        for key in ("fr", "pt", "es", "de", "nl", "it"):
+            if key in data and isinstance(data[key], list):
+                lang_code = key
+                phrases_data = data[key]
+                break
+        if phrases_data is None:
+            if isinstance(data, list):
+                phrases_data = data
+            else:
+                raise ValueError("Could not find phrase list in JSON file")
+
+        phrases = []
+        for item in phrases_data:
+            text = item.get(lang_code) if lang_code else item.get("french", item.get("text", ""))
+            phrases.append(
+                {
+                    "text": text,
+                    "translation": item.get("english", item.get("translation")),
+                    "ipa": item.get("ipa"),
+                }
+            )
+        return phrases
+
+    with open(file_path, encoding="utf-8") as f:
+        content = f.read()
+
+    phrases = []
+    for raw in content.split("\n"):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or is_header_line(stripped):
+            continue
+        line = stripped
+        if "|" in line:
+            parts = [p.strip() for p in line.split("|")]
+            phrases.append(
+                {
+                    "text": parts[0],
+                    "translation": parts[1] if len(parts) > 1 else None,
+                    "ipa": parts[2] if len(parts) > 2 else None,
+                }
+            )
+        else:
+            phrases.append({"text": line, "translation": None, "ipa": None})
+    return phrases
+
+
+def format_language_name(lang_code: str) -> str:
+    """Format a language code for display (kept pure; no emoji-free requirement)."""
+    language_map = {
+        "en": "English",
+        "fr": "French",
+        "pt": "Portuguese",
+        "nl": "Dutch",
+        "de": "German",
+        "it": "Italian",
+        "es": "Spanish",
+    }
+    return language_map.get(lang_code, lang_code.upper())

--- a/desktop/miolingo_desktop/core/phonemes.py
+++ b/desktop/miolingo_desktop/core/phonemes.py
@@ -1,0 +1,111 @@
+"""IPA and phoneme extraction via espeak.
+
+Ported from ``src/scoring/phonemes.py`` (already pure). The HTML-producing
+``format_ipa`` helper was intentionally NOT ported — HTML/markup is a UI concern
+and belongs in the Qt layer, keeping ``core/`` framework-free.
+
+Runtime dependency: an espeak binary must be on PATH (``espeak`` on macOS via
+MacPorts, ``espeak-ng`` on Debian/Ubuntu). espeak is used only for IPA/phoneme
+*scoring*, not for audio playback (that is Piper — see ``tts.py``).
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+ESPEAK_LANG_MAP: dict[str, str] = {
+    "pt": "pt-br",
+    "fr": "fr-fr",
+    "nl": "nl",
+    "de": "de",
+    "it": "it",
+    "es": "es",
+    "en": "en",
+}
+
+
+@functools.lru_cache(maxsize=1)
+def get_espeak_path() -> str:
+    """Resolve the espeak binary path.
+
+    Order: MacPorts local path, then ``espeak``/``espeak-ng`` on PATH. Falls
+    back to the bare name ``espeak`` so callers still get a sensible command
+    (and a clean FileNotFoundError) if nothing is installed.
+    """
+    local_path = "/opt/local/bin/espeak"
+    if Path(local_path).exists():
+        return local_path
+
+    for name in ("espeak", "espeak-ng"):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    return "espeak"
+
+
+@functools.lru_cache(maxsize=256)
+def get_phonemes(text: str, voice: str = "pt-br") -> str:
+    """Get the phoneme representation of *text* using espeak."""
+    try:
+        result = subprocess.run(
+            [get_espeak_path(), "-v", voice, "-q", "--phonout=/dev/stdout", "-x", text],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        return f"[phonemes unavailable: {e}]"
+
+
+def normalize_for_phoneme_scoring(s: str) -> str:
+    """Strip whitespace and espeak pause phonemes (``_:`` ``_!`` ``_|`` ...).
+
+    Leaves only pronunciation phonemes so scoring ignores word boundaries and
+    punctuation-induced pauses.
+    """
+    if not s:
+        return ""
+    s = re.sub(r"\s+", "", s.strip())
+    s = re.sub(r"_[:!|]+", "", s)
+    return s
+
+
+@functools.lru_cache(maxsize=256)
+def get_ipa(text: str, voice: str = "pt-br") -> str:
+    """Get IPA transcription for *text* (espeak newlines normalised to spaces)."""
+    try:
+        result = subprocess.run(
+            [get_espeak_path(), "-v", voice, "--ipa", "-q", text],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        ipa = result.stdout.strip()
+        return " ".join(ipa.split())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "[IPA unavailable]"
+
+
+def get_ipa_from_espeak(text: str, lang_code: str) -> str:
+    """Generate IPA for *text* given a short language code (pt, fr, nl, ...)."""
+    espeak_lang = ESPEAK_LANG_MAP.get(lang_code, lang_code)
+    try:
+        result = subprocess.run(
+            [get_espeak_path(), "-v", espeak_lang, "-q", "--ipa", text],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            return " ".join(result.stdout.strip().split())
+        return "[error]"
+    except subprocess.TimeoutExpired:
+        return "[timeout]"
+    except Exception as e:  # noqa: BLE001 - mirror source's broad guard
+        return f"[error: {e}]"

--- a/desktop/miolingo_desktop/core/practice.py
+++ b/desktop/miolingo_desktop/core/practice.py
@@ -1,0 +1,152 @@
+"""Practice orchestration: score recorded audio against a target phrase.
+
+Ported from ``src/scoring/practice.py`` with Streamlit removed. The pipeline:
+1. trim silence on the user recording,
+2. ASR transcription (Whisper),
+3. phoneme/IPA generation for target and recognised text,
+4. phoneme comparison + scoring,
+5. assemble a result dict.
+
+Persistence (DB writes) is delegated to the ``on_result`` callback so this
+function stays UI- and storage-agnostic. ``error_fn``/``warn_fn`` default to
+logging instead of ``st.error``/``st.warning``. The whole function is safe to
+run on a Qt worker thread.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+
+from .asr import ProgressFn, transcribe_audio
+from .comparison import compare_phonemes
+from .phonemes import get_ipa, get_phonemes, normalize_for_phoneme_scoring
+
+logger = logging.getLogger(__name__)
+
+
+def trim_silence(audio_bytes: bytes, silence_threshold: float = 0.01) -> tuple[bytes, bytes]:
+    """Trim leading/trailing silence from a WAV recording.
+
+    Returns ``(trimmed_bytes, original_bytes)``; on any failure both are the
+    original bytes (lossless fallback).
+    """
+    try:
+        buf = io.BytesIO(audio_bytes)
+        audio_data, sample_rate = sf.read(buf)
+
+        frame_length = int(0.02 * sample_rate)
+        energy = np.array(
+            [
+                np.sum(audio_data[i : i + frame_length] ** 2)
+                for i in range(0, len(audio_data) - frame_length, frame_length)
+            ]
+        )
+
+        threshold = silence_threshold * np.max(energy)
+        speech_frames = np.where(energy > threshold)[0]
+
+        if len(speech_frames) > 0:
+            padding_samples = int(0.2 * sample_rate)
+            start = max(0, speech_frames[0] * frame_length - padding_samples)
+            end = min(
+                len(audio_data),
+                (speech_frames[-1] + 1) * frame_length + padding_samples,
+            )
+            trimmed_audio = audio_data[start:end]
+
+            trimmed_buffer = io.BytesIO()
+            sf.write(trimmed_buffer, trimmed_audio, sample_rate, format="WAV")
+            return trimmed_buffer.getvalue(), audio_bytes
+        return audio_bytes, audio_bytes
+    except Exception:
+        return audio_bytes, audio_bytes
+
+
+def practice_word_from_audio(
+    text: str,
+    audio_bytes: bytes,
+    settings: dict,
+    *,
+    language: str = "Portuguese",
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+    error_fn: Callable[[str], None] | None = None,
+    warn_fn: Callable[[str], None] | None = None,
+    progress_fn: ProgressFn | None = None,
+    transcribe_fn: Callable[..., str] | None = None,
+) -> dict[str, Any] | None:
+    """Score a user's pronunciation against *text*. Returns a result dict or None.
+
+    ``transcribe_fn`` lets callers/tests inject a stub transcriber (defaults to
+    the real Whisper ``transcribe_audio``); this keeps the pipeline testable
+    without loading a model.
+    """
+    if error_fn is None:
+        error_fn = logger.error
+    if warn_fn is None:
+        warn_fn = logger.warning
+    if transcribe_fn is None:
+        transcribe_fn = transcribe_audio
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+    temp_audio = tmp.name
+    tmp.close()
+
+    try:
+        trimmed_wav_bytes, _ = trim_silence(
+            audio_bytes, silence_threshold=settings.get("silence_threshold", 0.01)
+        )
+        with open(temp_audio, "wb") as f:
+            f.write(trimmed_wav_bytes)
+
+        voice = settings.get("voice", "en")
+        correct_phonemes = get_phonemes(text, voice)
+        correct_ipa = get_ipa(text, voice)
+
+        recognized_text = transcribe_fn(
+            temp_audio, settings, language, warn_fn=warn_fn, progress_fn=progress_fn
+        )
+
+        user_phonemes = get_phonemes(recognized_text, voice)
+        user_ipa = get_ipa(recognized_text, voice)
+
+        correct_phonemes_normalized = normalize_for_phoneme_scoring(correct_phonemes)
+        user_phonemes_normalized = normalize_for_phoneme_scoring(user_phonemes)
+
+        algorithm = settings.get("comparison_algorithm", "edit_distance")
+        exact_match, similarity, edit_distance = compare_phonemes(
+            user_phonemes_normalized, correct_phonemes_normalized, algorithm=algorithm
+        )
+
+        result: dict[str, Any] = {
+            "target": text,
+            "recognized": recognized_text,
+            "correct_phonemes": correct_phonemes,
+            "user_phonemes": user_phonemes,
+            "correct_ipa": correct_ipa,
+            "user_ipa": user_ipa,
+            "exact_match": exact_match,
+            "similarity": similarity,
+            "edit_distance": edit_distance,
+            "correct_phonemes_normalized": correct_phonemes_normalized,
+            "user_phonemes_normalized": user_phonemes_normalized,
+            "user_audio_bytes": audio_bytes,
+            "user_audio_trimmed_bytes": trimmed_wav_bytes,
+        }
+
+        if on_result is not None:
+            on_result(result)
+        return result
+
+    except Exception as e:  # noqa: BLE001 - mirror source's broad guard
+        error_fn(f"Error during practice: {e}")
+        return None
+    finally:
+        Path(temp_audio).unlink(missing_ok=True)

--- a/desktop/miolingo_desktop/core/tts.py
+++ b/desktop/miolingo_desktop/core/tts.py
@@ -1,0 +1,225 @@
+"""Text-to-Speech engines and dispatcher.
+
+Ported from ``src/audio/tts.py`` with Streamlit removed:
+- ``@st.cache_data`` -> ``functools.lru_cache`` (in-process).
+- ``st.secrets[...]`` -> an explicit ``api_key`` argument (no global secrets).
+- ``st.warning`` -> an optional ``warn_fn`` (defaults to logging).
+
+Per SPEC §5 / DECISIONS.md the dispatcher priority is **Piper (offline neural)
+-> Google Cloud (optional, online) -> espeak (last resort)**. This differs from
+the source app, whose default was Google Cloud.
+
+Each engine returns ``(audio_bytes, mime_format)``. Full Piper voice coverage
+and bundled voice files land in Milestone 7; this module wires the engine and
+the fallback order. ``synthesize_piper`` raises ``PiperUnavailable`` when no
+voice is resolvable so the dispatcher can fall back cleanly — this keeps the
+dispatcher logic testable in M1 without bundled voices.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import string
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+from .config import GOOGLE_CLOUD_VOICES, VOICE_LOCALE_NORMALIZATION
+
+logger = logging.getLogger(__name__)
+
+WarnFn = Callable[[str], None]
+AudioResult = tuple[bytes, str]
+
+
+class PiperUnavailable(RuntimeError):
+    """Raised when a Piper voice for the requested locale cannot be resolved."""
+
+
+def _default_warn(msg: str) -> None:
+    logger.warning(msg)
+
+
+# ---------------------------------------------------------------------------
+# Engine: Piper (local, offline neural) — default
+# ---------------------------------------------------------------------------
+
+# Locale -> Piper voice model name. Populated/bundled in Milestone 7. Empty for
+# now so M1 can prove the fallback path; M7 fills this and ships the .onnx files.
+PIPER_VOICES: dict[str, str] = {}
+
+
+def resolve_piper_voice(locale: str, voices: dict[str, str] | None = None) -> str:
+    """Return the Piper voice model name for *locale*, or raise PiperUnavailable."""
+    table = PIPER_VOICES if voices is None else voices
+    name = table.get(locale)
+    if not name:
+        raise PiperUnavailable(f"No bundled Piper voice for locale '{locale}'")
+    return name
+
+
+def synthesize_piper(
+    text: str,
+    locale: str = "pt-BR",
+    *,
+    voices: dict[str, str] | None = None,
+    use_wav: bool = True,
+) -> AudioResult:
+    """Synthesize *text* with Piper for *locale*.
+
+    Raises :class:`PiperUnavailable` if no voice is registered for the locale
+    (the normal case until Milestone 7 bundles voices). The actual Piper
+    invocation is implemented in M7; this signature is stable so the dispatcher
+    and tests can rely on it now.
+    """
+    resolve_piper_voice(locale, voices)
+    # Implemented in Milestone 7 (loads the .onnx voice + runs piper).
+    raise PiperUnavailable(
+        "Piper synthesis is not wired until Milestone 7 (no bundled voices yet)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Engine: eSpeak (local, offline) — last resort
+# ---------------------------------------------------------------------------
+
+
+def speak_text(
+    text: str,
+    voice: str = "pt-br",
+    speed: int = 160,
+    pitch: int = 40,
+) -> AudioResult:
+    """Generate speech with espeak. Returns ``(wav_bytes, 'audio/wav')``."""
+    from .phonemes import get_espeak_path
+
+    try:
+        result = subprocess.run(
+            [
+                get_espeak_path(),
+                "-v", voice,
+                "-s", str(speed),
+                "-p", str(pitch),
+                "--stdout",
+                text,
+            ],
+            capture_output=True,
+            check=True,
+        )
+        return result.stdout, "audio/wav"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return b"", "audio/wav"
+
+
+# ---------------------------------------------------------------------------
+# Engine: Google Cloud TTS (REST, optional online upgrade)
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=512)
+def speak_text_google_cloud(
+    text: str,
+    lang: str = "pt-BR",
+    use_wav: bool = False,
+    speaking_rate: float = 1.0,
+    *,
+    api_key: str | None = None,
+) -> AudioResult:
+    """Generate speech via Google Cloud TTS REST API. Requires an explicit api_key."""
+    import base64
+
+    import requests
+
+    if api_key is None:
+        raise ValueError("Google Cloud TTS requires an api_key (no global secrets)")
+
+    voice_name = GOOGLE_CLOUD_VOICES.get(lang, "pt-BR-Standard-A")
+    audio_encoding = "LINEAR16" if use_wav else "MP3"
+
+    url = "https://texttospeech.googleapis.com/v1/text:synthesize"
+    headers = {
+        "X-goog-api-key": api_key,
+        "Content-Type": "application/json; charset=utf-8",
+    }
+    payload = {
+        "input": {"text": text},
+        "voice": {"languageCode": lang[:5], "name": voice_name},
+        "audioConfig": {"audioEncoding": audio_encoding, "speakingRate": speaking_rate},
+    }
+
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Google Cloud TTS API error {response.status_code}: {response.text[:200]}"
+        )
+
+    audio_bytes = base64.b64decode(response.json().get("audioContent", ""))
+    return audio_bytes, ("audio/wav" if use_wav else "audio/mp3")
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher: Piper -> Google Cloud -> espeak
+# ---------------------------------------------------------------------------
+
+
+def generate_target_audio(
+    text: str,
+    settings: dict,
+    *,
+    warn_fn: WarnFn | None = None,
+    google_api_key: str | None = None,
+    piper_voices: dict[str, str] | None = None,
+) -> AudioResult:
+    """Generate target pronunciation audio with graceful degradation.
+
+    Priority: Piper (offline) -> Google Cloud (if ``google_api_key`` and online)
+    -> espeak (last resort). The configured ``tts_engine`` selects the preferred
+    engine but fallbacks always apply.
+    """
+    if warn_fn is None:
+        warn_fn = _default_warn
+
+    text_no_punct = text.translate(str.maketrans("", "", string.punctuation))
+    voice = str(settings.get("voice", "pt-br"))
+    locale = VOICE_LOCALE_NORMALIZATION.get(voice, "pt-BR")
+    use_wav = bool(settings.get("use_wav_audio", False))
+    rate = 0.75 if settings.get("gtts_slow", False) else 1.0
+    engine = str(settings.get("tts_engine", "piper"))
+
+    def _espeak() -> AudioResult:
+        return speak_text(
+            text_no_punct,
+            voice=voice,
+            speed=int(settings.get("speed", 140)),
+            pitch=int(settings.get("pitch", 35)),
+        )
+
+    def _google() -> AudioResult:
+        return speak_text_google_cloud(
+            text_no_punct, lang=locale, use_wav=use_wav, speaking_rate=rate,
+            api_key=google_api_key,
+        )
+
+    def _piper() -> AudioResult:
+        return synthesize_piper(text_no_punct, locale=locale, voices=piper_voices,
+                                use_wav=use_wav)
+
+    # If the user explicitly forces espeak, honour it directly.
+    if engine == "espeak":
+        return _espeak()
+
+    # Default path: Piper first, then Google Cloud (if configured), then espeak.
+    try:
+        return _piper()
+    except PiperUnavailable as e:
+        warn_fn(f"Piper unavailable ({e}); trying Google Cloud TTS")
+
+    if google_api_key:
+        try:
+            return _google()
+        except Exception as e:  # noqa: BLE001 - degrade to espeak on any failure
+            warn_fn(f"Google Cloud TTS unavailable ({str(e)[:80]}); using espeak")
+
+    return _espeak()

--- a/desktop/miolingo_desktop/data/__init__.py
+++ b/desktop/miolingo_desktop/data/__init__.py
@@ -1,1 +1,27 @@
-"""Local SQLite storage layer + migrations. Populated from Milestone 2 onward."""
+"""Local SQLite storage layer + migrations.
+
+Public API:
+- ``Database`` — opens the SQLite file, applies migrations, hands out a
+  connection. Path resolves via ``MIOLINGO_DB_PATH`` or the macOS app-support
+  directory (``paths.default_db_path``).
+- ``SettingsRepository`` / ``PracticeRepository`` / ``VocabularyRepository`` —
+  typed CRUD over the sync-ready tables (UUID PKs, timestamps, soft-delete).
+"""
+
+from .database import Database, utcnow_iso
+from .paths import app_support_dir, default_db_path
+from .repositories import (
+    PracticeRepository,
+    SettingsRepository,
+    VocabularyRepository,
+)
+
+__all__ = [
+    "Database",
+    "utcnow_iso",
+    "app_support_dir",
+    "default_db_path",
+    "SettingsRepository",
+    "PracticeRepository",
+    "VocabularyRepository",
+]

--- a/desktop/miolingo_desktop/data/database.py
+++ b/desktop/miolingo_desktop/data/database.py
@@ -1,0 +1,54 @@
+"""SQLite connection management + first-run initialisation.
+
+Opens (creating parent dirs as needed) the local SQLite database, applies
+migrations, and hands out connections with sensible pragmas:
+- ``row_factory = sqlite3.Row`` so repositories return dict-like rows.
+- WAL journal mode for better concurrent read/write (UI thread reads while a
+  worker writes).
+- ``foreign_keys = ON`` for integrity.
+
+A single ``Database`` instance is shared by the repositories. It is intentionally
+thin — no ORM (see DECISIONS.md).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .migrations import apply_migrations
+from .paths import default_db_path
+
+
+def utcnow_iso() -> str:
+    """Current UTC time as an ISO-8601 string (the timestamp format used in the DB)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds")
+
+
+class Database:
+    """Owns the SQLite connection and runs migrations on open."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else default_db_path()
+        if str(self.path) != ":memory:":
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        if str(self.path) != ":memory:":
+            self._conn.execute("PRAGMA journal_mode = WAL")
+        apply_migrations(self._conn)
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "Database":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/desktop/miolingo_desktop/data/migrations.py
+++ b/desktop/miolingo_desktop/data/migrations.py
@@ -1,0 +1,104 @@
+"""Versioned SQLite schema migrations.
+
+A deliberately tiny migration runner keyed on SQLite's ``PRAGMA user_version``
+(chosen over alembic/yoyo to avoid a heavy dependency for a single local file —
+see DECISIONS.md). Each migration is an ``(version, sql)`` pair applied in order
+inside a transaction; ``user_version`` is bumped as each succeeds, so
+``apply_migrations`` is idempotent and safe to run on every launch.
+
+Schema design (sync-ready, per SPEC §6 / DECISIONS.md):
+- **UUID text primary keys** (``id``) so rows merge across devices without
+  autoincrement collisions.
+- ``created_at`` / ``updated_at`` ISO-8601 UTC timestamps on every table.
+- ``deleted_at`` soft-delete (NULL = live); reads filter it out by default.
+- A nullable ``user_id`` column anticipates the future batch sync to Matthew's
+  remote DB (v1 leaves it NULL — single local user, no auth).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+# Each entry: (target_user_version, SQL executed to reach it).
+MIGRATIONS: list[tuple[int, str]] = [
+    (
+        1,
+        """
+        CREATE TABLE IF NOT EXISTS settings (
+            id          TEXT PRIMARY KEY,
+            user_id     TEXT,
+            key         TEXT NOT NULL UNIQUE,
+            value       TEXT,
+            created_at  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL,
+            deleted_at  TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS practice_attempts (
+            id                TEXT PRIMARY KEY,
+            user_id           TEXT,
+            language_code     TEXT NOT NULL,
+            target_phrase     TEXT NOT NULL,
+            recognized_phrase TEXT,
+            similarity_score  REAL NOT NULL,
+            perfect_match     INTEGER NOT NULL DEFAULT 0,
+            target_phonemes   TEXT,
+            user_phonemes     TEXT,
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL,
+            deleted_at        TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_attempts_lang_created
+            ON practice_attempts (language_code, created_at);
+
+        CREATE TABLE IF NOT EXISTS vocabulary (
+            id                   TEXT PRIMARY KEY,
+            user_id              TEXT,
+            language_code        TEXT NOT NULL,
+            source_language_code TEXT,
+            word                 TEXT NOT NULL,
+            display_word         TEXT,
+            translation          TEXT,
+            ipa                  TEXT,
+            source_name          TEXT,
+            context_before       TEXT,
+            context_line         TEXT,
+            context_after        TEXT,
+            url                  TEXT,
+            times_seen           INTEGER NOT NULL DEFAULT 1,
+            first_seen_at        TEXT,
+            last_seen_at         TEXT,
+            created_at           TEXT NOT NULL,
+            updated_at           TEXT NOT NULL,
+            deleted_at           TEXT
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_vocab_unique_word
+            ON vocabulary (language_code, word);
+        """,
+    ),
+]
+
+
+def current_version(conn: sqlite3.Connection) -> int:
+    """Return the database's current ``user_version``."""
+    return int(conn.execute("PRAGMA user_version").fetchone()[0])
+
+
+def apply_migrations(conn: sqlite3.Connection) -> int:
+    """Apply any pending migrations in order. Returns the resulting version."""
+    version = current_version(conn)
+    for target, sql in MIGRATIONS:
+        if target <= version:
+            continue
+        # executescript manages its own transaction (it COMMITs any pending one
+        # first), so we don't wrap it in ``with conn:``. We bump user_version in
+        # the same script-driven sequence and commit explicitly afterwards.
+        try:
+            conn.executescript(sql)
+            conn.execute(f"PRAGMA user_version = {target}")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        version = target
+    return version

--- a/desktop/miolingo_desktop/data/paths.py
+++ b/desktop/miolingo_desktop/data/paths.py
@@ -1,0 +1,40 @@
+"""Resolve the on-disk location of the local SQLite database.
+
+The DB lives in the macOS app-support directory by default
+(``~/Library/Application Support/Miolingo/miolingo.db``). Tests and packaging
+override the location via ``MIOLINGO_DB_PATH`` (or by passing an explicit path
+to the repositories), so nothing here is hard-coded into call sites.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+APP_DIR_NAME = "Miolingo"
+DB_FILENAME = "miolingo.db"
+
+
+def app_support_dir() -> Path:
+    """Return the per-user application-support directory for Miolingo.
+
+    macOS: ``~/Library/Application Support/Miolingo``. Other platforms get a
+    sensible fallback (XDG-ish) so the code stays cross-platform-clean even
+    though v1 ships macOS only.
+    """
+    if sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    elif os.name == "nt":  # pragma: no cover - Windows is a non-goal for v1
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+    else:  # pragma: no cover - Linux is a non-goal for v1
+        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / APP_DIR_NAME
+
+
+def default_db_path() -> Path:
+    """Resolve the DB path: ``$MIOLINGO_DB_PATH`` if set, else app-support dir."""
+    env = os.environ.get("MIOLINGO_DB_PATH")
+    if env:
+        return Path(env)
+    return app_support_dir() / DB_FILENAME

--- a/desktop/miolingo_desktop/data/repositories.py
+++ b/desktop/miolingo_desktop/data/repositories.py
@@ -1,0 +1,336 @@
+"""Typed repository classes over the SQLite tables.
+
+Each repository wraps a :class:`~miolingo_desktop.data.database.Database` and
+exposes plain methods returning plain dicts/values — no Qt, no Streamlit. Data
+shapes mirror the source app's ``app_mysql`` / ``vocab`` so the ported core
+logic fits without translation.
+
+Sync-ready invariants enforced here:
+- every insert gets a UUID ``id`` and ``created_at``/``updated_at`` timestamps;
+- deletes are **soft** (set ``deleted_at``); reads exclude soft-deleted rows
+  unless ``include_deleted=True``;
+- ``updated_at`` is refreshed on every mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterable
+from typing import Any
+
+from .database import Database, utcnow_iso
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+class SettingsRepository:
+    """Key/value app settings persistence (mirrors config.load/save_settings)."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def get(self, key: str, default: Any = None) -> Any:
+        row = self._db.connection.execute(
+            "SELECT value FROM settings WHERE key = ? AND deleted_at IS NULL",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return default
+        return json.loads(row["value"]) if row["value"] is not None else None
+
+    def set(self, key: str, value: Any) -> None:
+        now = utcnow_iso()
+        encoded = json.dumps(value)
+        conn = self._db.connection
+        with conn:
+            existing = conn.execute(
+                "SELECT id FROM settings WHERE key = ?", (key,)
+            ).fetchone()
+            if existing is None:
+                conn.execute(
+                    "INSERT INTO settings (id, key, value, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (_new_id(), key, encoded, now, now),
+                )
+            else:
+                conn.execute(
+                    "UPDATE settings SET value = ?, updated_at = ?, deleted_at = NULL "
+                    "WHERE key = ?",
+                    (encoded, now, key),
+                )
+
+    def get_all(self) -> dict[str, Any]:
+        rows = self._db.connection.execute(
+            "SELECT key, value FROM settings WHERE deleted_at IS NULL"
+        ).fetchall()
+        return {
+            r["key"]: (json.loads(r["value"]) if r["value"] is not None else None)
+            for r in rows
+        }
+
+    def update_many(self, settings: dict[str, Any]) -> None:
+        for key, value in settings.items():
+            self.set(key, value)
+
+
+# ---------------------------------------------------------------------------
+# Practice attempts (history)
+# ---------------------------------------------------------------------------
+
+
+class PracticeRepository:
+    """Practice attempt history (mirrors app_mysql.save_practice/get_user_progress)."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def save_attempt(
+        self,
+        *,
+        language_code: str,
+        target_phrase: str,
+        recognized_phrase: str | None,
+        similarity_score: float,
+        perfect_match: bool,
+        target_phonemes: str = "",
+        user_phonemes: str = "",
+    ) -> str:
+        """Insert a practice attempt and return its new id."""
+        now = utcnow_iso()
+        attempt_id = _new_id()
+        conn = self._db.connection
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO practice_attempts (
+                    id, language_code, target_phrase, recognized_phrase,
+                    similarity_score, perfect_match, target_phonemes, user_phonemes,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    attempt_id,
+                    language_code,
+                    target_phrase,
+                    recognized_phrase,
+                    float(similarity_score),
+                    1 if perfect_match else 0,
+                    target_phonemes,
+                    user_phonemes,
+                    now,
+                    now,
+                ),
+            )
+        return attempt_id
+
+    def save_from_result(self, language_code: str, result: dict[str, Any]) -> str:
+        """Persist a ``practice_word_from_audio`` result dict.
+
+        Maps the core pipeline's ``similarity`` (0..1) to a 0..100 score to match
+        the source app's stored convention.
+        """
+        return self.save_attempt(
+            language_code=language_code,
+            target_phrase=result.get("target", ""),
+            recognized_phrase=result.get("recognized", ""),
+            similarity_score=round(float(result.get("similarity", 0.0)) * 100, 2),
+            perfect_match=bool(result.get("exact_match", False)),
+            target_phonemes=result.get("correct_phonemes_normalized", "") or "",
+            user_phonemes=result.get("user_phonemes_normalized", "") or "",
+        )
+
+    def list_history(
+        self,
+        *,
+        language_code: str | None = None,
+        limit: int = 50,
+        include_deleted: bool = False,
+    ) -> list[dict[str, Any]]:
+        clauses = []
+        params: list[Any] = []
+        if not include_deleted:
+            clauses.append("deleted_at IS NULL")
+        if language_code is not None:
+            clauses.append("language_code = ?")
+            params.append(language_code)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(limit)
+        rows = self._db.connection.execute(
+            f"SELECT * FROM practice_attempts{where} ORDER BY created_at DESC LIMIT ?",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def soft_delete(self, attempt_id: str) -> None:
+        now = utcnow_iso()
+        conn = self._db.connection
+        with conn:
+            conn.execute(
+                "UPDATE practice_attempts SET deleted_at = ?, updated_at = ? WHERE id = ?",
+                (now, now, attempt_id),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+class VocabularyRepository:
+    """Per-language vocabulary tracker (mirrors src/vocab.py shapes)."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def capture(
+        self,
+        *,
+        language_code: str,
+        word: str,
+        display_word: str | None = None,
+        source_language_code: str | None = None,
+        translation: str | None = None,
+        ipa: str | None = None,
+        source_name: str | None = None,
+        context_before: str | None = None,
+        context_line: str | None = None,
+        context_after: str | None = None,
+        url: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert a word, or bump ``times_seen`` if it already exists.
+
+        First encounter wins for translation/ipa/source/context — existing
+        non-null fields are never overwritten (matches the source upsert).
+        Returns ``{"id", "created"}``.
+        """
+        now = utcnow_iso()
+        conn = self._db.connection
+        with conn:
+            existing = conn.execute(
+                "SELECT * FROM vocabulary WHERE language_code = ? AND word = ?",
+                (language_code, word),
+            ).fetchone()
+
+            if existing is None:
+                vocab_id = _new_id()
+                conn.execute(
+                    """
+                    INSERT INTO vocabulary (
+                        id, language_code, source_language_code, word, display_word,
+                        translation, ipa, source_name,
+                        context_before, context_line, context_after, url,
+                        times_seen, first_seen_at, last_seen_at, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+                    """,
+                    (
+                        vocab_id, language_code, source_language_code, word,
+                        display_word or word, translation, ipa, source_name,
+                        context_before, context_line, context_after, url,
+                        now, now, now, now,
+                    ),
+                )
+                return {"id": vocab_id, "created": True}
+
+            # Resurrect a soft-deleted row on re-capture; bump counters; fill NULLs.
+            conn.execute(
+                """
+                UPDATE vocabulary SET
+                    times_seen = times_seen + 1,
+                    last_seen_at = ?,
+                    updated_at = ?,
+                    deleted_at = NULL,
+                    translation    = COALESCE(translation, ?),
+                    ipa            = COALESCE(ipa, ?),
+                    source_name    = COALESCE(source_name, ?),
+                    context_before = COALESCE(NULLIF(context_before, ''), ?),
+                    context_line   = COALESCE(NULLIF(context_line, ''), ?),
+                    context_after  = COALESCE(NULLIF(context_after, ''), ?),
+                    url            = COALESCE(NULLIF(url, ''), ?)
+                WHERE id = ?
+                """,
+                (
+                    now, now, translation, ipa, source_name,
+                    context_before, context_line, context_after, url,
+                    existing["id"],
+                ),
+            )
+            return {"id": existing["id"], "created": False}
+
+    def get(self, vocab_id: str) -> dict[str, Any] | None:
+        row = self._db.connection.execute(
+            "SELECT * FROM vocabulary WHERE id = ?", (vocab_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    def update(self, vocab_id: str, **fields: Any) -> None:
+        """Update editable fields (translation, ipa, context, etc.)."""
+        allowed = {
+            "display_word", "translation", "ipa", "source_name",
+            "context_before", "context_line", "context_after", "url",
+            "source_language_code",
+        }
+        sets = {k: v for k, v in fields.items() if k in allowed}
+        if not sets:
+            return
+        now = utcnow_iso()
+        assignments = ", ".join(f"{k} = ?" for k in sets)
+        params = [*sets.values(), now, vocab_id]
+        conn = self._db.connection
+        with conn:
+            conn.execute(
+                f"UPDATE vocabulary SET {assignments}, updated_at = ? WHERE id = ?",
+                params,
+            )
+
+    def list(
+        self,
+        *,
+        language_code: str,
+        sort: str = "alpha",
+        search: str = "",
+        include_deleted: bool = False,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        order = {
+            "alpha": "word ASC",
+            "recent": "last_seen_at DESC",
+            "oldest": "first_seen_at ASC",
+        }.get(sort, "word ASC")
+
+        clauses = ["language_code = ?"]
+        params: list[Any] = [language_code]
+        if not include_deleted:
+            clauses.append("deleted_at IS NULL")
+        if search:
+            clauses.append("(word LIKE ? OR translation LIKE ?)")
+            like = f"%{search}%"
+            params.extend([like, like])
+        params.append(limit)
+
+        rows = self._db.connection.execute(
+            f"SELECT * FROM vocabulary WHERE {' AND '.join(clauses)} "
+            f"ORDER BY {order} LIMIT ?",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def soft_delete(self, vocab_id: str) -> None:
+        now = utcnow_iso()
+        conn = self._db.connection
+        with conn:
+            conn.execute(
+                "UPDATE vocabulary SET deleted_at = ?, updated_at = ? WHERE id = ?",
+                (now, now, vocab_id),
+            )
+
+    def export_csv_rows(self, *, language_code: str) -> Iterable[dict[str, Any]]:
+        """Yield rows suitable for CSV export (live rows only)."""
+        yield from self.list(language_code=language_code, limit=100000)

--- a/desktop/miolingo_desktop/main.py
+++ b/desktop/miolingo_desktop/main.py
@@ -1,37 +1,47 @@
 """PySide6 entry point for the Miolingo desktop app.
 
-Milestone 0: an empty-but-runnable main window. Later milestones add the
-Practice / History / Vocabulary / Statistics / Settings views.
+Opens the main window with a tab bar; Milestone 3 wires the Quick Practice
+vertical slice. History / Vocabulary / Statistics / Settings tabs are added in
+later milestones.
 """
 
 from __future__ import annotations
 
 import sys
 
-from PySide6.QtWidgets import QApplication, QLabel, QMainWindow
+from PySide6.QtWidgets import QApplication, QMainWindow, QTabWidget
 
 from . import APP_NAME, __version__
+from .core.controller import PracticeController
+from .data import Database
+from .ui.practice_view import PracticeView
 
 
 class MainWindow(QMainWindow):
     """The application's top-level window.
 
-    Kept deliberately minimal in M0 — it must construct without a display
-    (``QT_QPA_PLATFORM=offscreen``) so it can be smoke-tested headlessly.
+    Owns the SQLite ``Database`` and the ``PracticeController`` shared by views.
+    Constructs without a display (``QT_QPA_PLATFORM=offscreen``) so it can be
+    smoke-tested headlessly; the DB path may be overridden via ``MIOLINGO_DB_PATH``.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, db: Database | None = None) -> None:
         super().__init__()
         self.setWindowTitle(APP_NAME)
         self.resize(1024, 720)
 
-        placeholder = QLabel(
-            f"{APP_NAME} desktop — scaffold (v{__version__})\n"
-            "Practice, History, Vocabulary, and Statistics arrive in later milestones."
-        )
-        placeholder.setObjectName("scaffoldPlaceholder")
-        placeholder.setContentsMargins(24, 24, 24, 24)
-        self.setCentralWidget(placeholder)
+        self.db = db if db is not None else Database()
+        self.controller = PracticeController(self.db)
+
+        self.tabs = QTabWidget()
+        self.tabs.setObjectName("mainTabs")
+        self.practice_view = PracticeView(self.controller)
+        self.tabs.addTab(self.practice_view, "Quick Practice")
+        self.setCentralWidget(self.tabs)
+
+    def closeEvent(self, event: object) -> None:  # noqa: N802 - Qt override
+        self.db.close()
+        super().closeEvent(event)  # type: ignore[arg-type]
 
 
 def create_app(argv: list[str] | None = None) -> QApplication:

--- a/desktop/miolingo_desktop/main.py
+++ b/desktop/miolingo_desktop/main.py
@@ -14,7 +14,9 @@ from PySide6.QtWidgets import QApplication, QMainWindow, QTabWidget
 from . import APP_NAME, __version__
 from .core.controller import PracticeController
 from .data import Database
+from .ui.history_view import HistoryView
 from .ui.practice_view import PracticeView
+from .ui.settings_view import SettingsView
 
 
 class MainWindow(QMainWindow):
@@ -36,8 +38,18 @@ class MainWindow(QMainWindow):
         self.tabs = QTabWidget()
         self.tabs.setObjectName("mainTabs")
         self.practice_view = PracticeView(self.controller)
+        self.history_view = HistoryView(self.controller)
+        self.settings_view = SettingsView(self.controller)
         self.tabs.addTab(self.practice_view, "Quick Practice")
+        self.tabs.addTab(self.history_view, "History")
+        self.tabs.addTab(self.settings_view, "Settings")
+        self.tabs.currentChanged.connect(self._on_tab_changed)
         self.setCentralWidget(self.tabs)
+
+    def _on_tab_changed(self, index: int) -> None:
+        # Refresh History when it becomes visible so new attempts show up.
+        if self.tabs.widget(index) is self.history_view:
+            self.history_view.refresh()
 
     def closeEvent(self, event: object) -> None:  # noqa: N802 - Qt override
         self.db.close()

--- a/desktop/miolingo_desktop/ui/history_view.py
+++ b/desktop/miolingo_desktop/ui/history_view.py
@@ -1,0 +1,69 @@
+"""History view — past practice attempts from SQLite (Milestone 4).
+
+A read-only table (date, language, target, heard, score, match) populated from
+``PracticeRepository`` via the controller. ``refresh()`` re-queries, so the view
+stays current after new attempts and across app restarts (rows are persisted).
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QHeaderView,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..core.controller import PracticeController
+
+_COLUMNS = ["Date", "Language", "Target", "Heard", "Score", "Match"]
+
+
+class HistoryView(QWidget):
+    """Lists past practice attempts."""
+
+    def __init__(self, controller: PracticeController, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+
+        root = QVBoxLayout(self)
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setObjectName("historyRefreshButton")
+        self.refresh_button.clicked.connect(self.refresh)
+        root.addWidget(self.refresh_button)
+
+        self.table = QTableWidget(0, len(_COLUMNS))
+        self.table.setObjectName("historyTable")
+        self.table.setHorizontalHeaderLabels(_COLUMNS)
+        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        root.addWidget(self.table)
+
+        self.refresh()
+
+    def refresh(self) -> None:
+        rows = self._controller.recent_history(limit=200)
+        self.table.setRowCount(len(rows))
+        for r, row in enumerate(rows):
+            score = row.get("similarity_score")
+            score_text = f"{float(score):.1f}%" if score is not None else ""
+            match_text = "perfect" if row.get("perfect_match") else ""
+            values = [
+                str(row.get("created_at", "")),
+                str(row.get("language_code", "")),
+                str(row.get("target_phrase", "")),
+                str(row.get("recognized_phrase", "")),
+                score_text,
+                match_text,
+            ]
+            for c, value in enumerate(values):
+                item = QTableWidgetItem(value)
+                item.setData(Qt.UserRole, row.get("id"))
+                self.table.setItem(r, c, item)
+
+    def row_count(self) -> int:
+        """Convenience for tests."""
+        return self.table.rowCount()

--- a/desktop/miolingo_desktop/ui/practice_view.py
+++ b/desktop/miolingo_desktop/ui/practice_view.py
@@ -1,0 +1,259 @@
+"""Quick Practice view — the vertical-slice UI (Milestone 3).
+
+Flow: pick language -> category -> file -> phrase, play target audio (Piper via
+the TTS dispatcher), record the user's attempt, transcribe + score off the UI
+thread, show the result, and persist it via the controller.
+
+All blocking work (TTS synth, mic capture, transcription) runs on a
+``QThreadPool`` worker so the UI never freezes. The view holds no business
+logic — it delegates to ``PracticeController`` (core, UI-free).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtCore import Qt, QThreadPool, QUrl
+from PySide6.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..core.audio_capture import record_wav
+from ..core.controller import PracticeController
+from ..core.tts import generate_target_audio
+from .workers import Worker
+
+
+class PracticeView(QWidget):
+    """The Quick Practice tab."""
+
+    def __init__(self, controller: PracticeController, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+        self._pool = QThreadPool.globalInstance()
+        self._phrases: list[dict] = []
+        self._player = None  # lazily created (QtMultimedia is optional)
+        self._audio_out = None
+        self._temp_audio: Path | None = None
+
+        self._build_ui()
+        self._load_languages()
+
+    # -- UI construction ---------------------------------------------------
+
+    def _build_ui(self) -> None:
+        root = QVBoxLayout(self)
+
+        selectors = QHBoxLayout()
+        self.language_combo = QComboBox()
+        self.language_combo.setObjectName("languageCombo")
+        self.category_combo = QComboBox()
+        self.category_combo.setObjectName("categoryCombo")
+        self.file_combo = QComboBox()
+        self.file_combo.setObjectName("fileCombo")
+        selectors.addWidget(QLabel("Language:"))
+        selectors.addWidget(self.language_combo)
+        selectors.addWidget(QLabel("Category:"))
+        selectors.addWidget(self.category_combo)
+        selectors.addWidget(QLabel("Set:"))
+        selectors.addWidget(self.file_combo)
+        root.addLayout(selectors)
+
+        self.phrase_list = QListWidget()
+        self.phrase_list.setObjectName("phraseList")
+        root.addWidget(self.phrase_list, stretch=1)
+
+        actions = QHBoxLayout()
+        self.play_button = QPushButton("Play target audio")
+        self.play_button.setObjectName("playButton")
+        self.record_button = QPushButton("Record && score")
+        self.record_button.setObjectName("recordButton")
+        actions.addWidget(self.play_button)
+        actions.addWidget(self.record_button)
+        root.addLayout(actions)
+
+        self.progress = QProgressBar()
+        self.progress.setObjectName("progressBar")
+        self.progress.setRange(0, 0)  # indeterminate
+        self.progress.hide()
+        root.addWidget(self.progress)
+
+        self.status_label = QLabel("")
+        self.status_label.setObjectName("statusLabel")
+        root.addWidget(self.status_label)
+
+        self.result_label = QLabel("")
+        self.result_label.setObjectName("resultLabel")
+        self.result_label.setWordWrap(True)
+        self.result_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        root.addWidget(self.result_label)
+
+        self.language_combo.currentTextChanged.connect(self._on_language_changed)
+        self.category_combo.currentTextChanged.connect(self._on_category_changed)
+        self.file_combo.currentTextChanged.connect(self._on_file_changed)
+        self.play_button.clicked.connect(self.play_target_audio)
+        self.record_button.clicked.connect(self.record_and_score)
+
+    # -- population --------------------------------------------------------
+
+    def _load_languages(self) -> None:
+        self.language_combo.clear()
+        self.language_combo.addItems(self._controller.available_languages())
+
+    def _on_language_changed(self, lang: str) -> None:
+        self.category_combo.clear()
+        if not lang:
+            return
+        categories = self._controller.language_categories(lang)
+        self.category_combo.addItems(sorted(categories.keys()))
+
+    def _on_category_changed(self, category: str) -> None:
+        self.file_combo.clear()
+        lang = self.language_combo.currentText()
+        if not lang or not category:
+            return
+        categories = self._controller.language_categories(lang)
+        self.file_combo.addItems(categories.get(category, []))
+
+    def _on_file_changed(self, filename: str) -> None:
+        self.phrase_list.clear()
+        self._phrases = []
+        lang = self.language_combo.currentText()
+        category = self.category_combo.currentText()
+        if not (lang and category and filename):
+            return
+        try:
+            self._phrases = self._controller.phrases_for(lang, category, filename)
+        except Exception as e:  # noqa: BLE001 - bad file shouldn't crash the UI
+            self.status_label.setText(f"Could not load set: {e}")
+            return
+        for phrase in self._phrases:
+            text = phrase.get("text", "")
+            trans = phrase.get("translation")
+            label = f"{text}  —  {trans}" if trans else text
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, phrase)
+            self.phrase_list.addItem(item)
+        if self.phrase_list.count():
+            self.phrase_list.setCurrentRow(0)
+
+    # -- selection helpers -------------------------------------------------
+
+    def selected_phrase_text(self) -> str | None:
+        item = self.phrase_list.currentItem()
+        if item is None:
+            return None
+        phrase = item.data(Qt.UserRole)
+        return phrase.get("text") if isinstance(phrase, dict) else None
+
+    def _set_busy(self, busy: bool, message: str = "") -> None:
+        self.progress.setVisible(busy)
+        self.play_button.setDisabled(busy)
+        self.record_button.setDisabled(busy)
+        self.status_label.setText(message)
+
+    # -- actions -----------------------------------------------------------
+
+    def play_target_audio(self) -> None:
+        text = self.selected_phrase_text()
+        if not text:
+            self.status_label.setText("Select a phrase first.")
+            return
+        settings = self._controller.effective_settings()
+        self._set_busy(True, "Synthesizing audio...")
+        worker = Worker(generate_target_audio, text, settings)
+        worker.signals.finished.connect(self._on_audio_ready)
+        worker.signals.error.connect(self._on_worker_error)
+        self._pool.start(worker)
+
+    def _on_audio_ready(self, payload: object) -> None:
+        self._set_busy(False)
+        try:
+            audio_bytes, _fmt = payload  # type: ignore[misc]
+        except Exception:
+            self.status_label.setText("No audio produced.")
+            return
+        if not audio_bytes:
+            self.status_label.setText("No audio produced (TTS unavailable offline?).")
+            return
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+        tmp.write(audio_bytes)
+        tmp.close()
+        self._temp_audio = Path(tmp.name)
+        if not self._ensure_player():
+            self.status_label.setText("Audio playback unavailable (QtMultimedia missing).")
+            return
+        self._player.setSource(QUrl.fromLocalFile(tmp.name))
+        self._player.play()
+
+    def _ensure_player(self) -> bool:
+        """Lazily construct the media player; QtMultimedia is an optional module."""
+        if self._player is not None:
+            return True
+        try:
+            from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
+        except Exception:  # noqa: BLE001 - QtMultimedia not bundled
+            return False
+        self._player = QMediaPlayer(self)
+        self._audio_out = QAudioOutput(self)
+        self._player.setAudioOutput(self._audio_out)
+        return True
+
+    def record_and_score(self) -> None:
+        text = self.selected_phrase_text()
+        if not text:
+            self.status_label.setText("Select a phrase first.")
+            return
+        language = self.language_combo.currentText()
+        settings = self._controller.effective_settings()
+        duration = float(settings.get("duration", 3))
+        self._set_busy(True, "Recording...")
+
+        def _capture_and_score(progress_fn=None) -> dict[str, Any] | None:
+            if progress_fn:
+                progress_fn("Recording...")
+            audio_bytes = record_wav(duration=duration)
+            if progress_fn:
+                progress_fn("Transcribing...")
+            return self._controller.run_practice(
+                target_text=text,
+                audio_bytes=audio_bytes,
+                language=language,
+                progress_fn=progress_fn,
+            )
+
+        worker = Worker(_capture_and_score, pass_progress=True)
+        worker.signals.progress.connect(self.status_label.setText)
+        worker.signals.finished.connect(self._on_score_ready)
+        worker.signals.error.connect(self._on_worker_error)
+        self._pool.start(worker)
+
+    def _on_score_ready(self, result: object) -> None:
+        self._set_busy(False)
+        if not isinstance(result, dict):
+            self.result_label.setText("No result.")
+            return
+        pct = round(float(result.get("similarity", 0.0)) * 100, 1)
+        verdict = "perfect" if result.get("exact_match") else f"edits: {result.get('edit_distance')}"
+        self.result_label.setText(
+            f"Target: {result.get('target', '')}\n"
+            f"Heard:  {result.get('recognized', '')}\n"
+            f"Score:  {pct}%  ({verdict})\n"
+            f"Target IPA: {result.get('correct_ipa', '')}\n"
+            f"Your IPA:   {result.get('user_ipa', '')}"
+        )
+        self.status_label.setText("Saved to history.")
+
+    def _on_worker_error(self, message: str) -> None:
+        self._set_busy(False)
+        self.status_label.setText(f"Error: {message}")

--- a/desktop/miolingo_desktop/ui/settings_view.py
+++ b/desktop/miolingo_desktop/ui/settings_view.py
@@ -1,0 +1,111 @@
+"""Settings view — language, voice, Whisper model, scoring, TTS (Milestone 4).
+
+A form bound to the ``SettingsRepository`` via the controller. Values load from
+stored settings (over defaults) on construction and persist immediately on
+``save()``; ``effective_settings()`` restores them on relaunch. Option lists
+come from ``core.config`` so the UI holds no domain choices itself.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFormLayout,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..core import config
+from ..core.controller import PracticeController
+
+
+class SettingsView(QWidget):
+    """Edit and persist user settings."""
+
+    def __init__(self, controller: PracticeController, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._controller = controller
+
+        root = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.source_language_combo = QComboBox()
+        self.source_language_combo.setObjectName("settingsSourceLanguage")
+        self.source_language_combo.addItems(config.SOURCE_LANGUAGE_OPTIONS)
+
+        self.voice_combo = QComboBox()
+        self.voice_combo.setObjectName("settingsVoice")
+        self.voice_combo.setEditable(True)
+        # Populate with the union of all configured voices.
+        all_voices: list[str] = []
+        for name in config.LANGUAGE_CONFIG:
+            for v in config.voices_for_language(name):
+                if v not in all_voices:
+                    all_voices.append(v)
+        self.voice_combo.addItems(all_voices)
+
+        self.whisper_combo = QComboBox()
+        self.whisper_combo.setObjectName("settingsWhisperModel")
+        self.whisper_combo.addItems(config.WHISPER_MODEL_SIZES)
+
+        self.tts_combo = QComboBox()
+        self.tts_combo.setObjectName("settingsTtsEngine")
+        self.tts_combo.addItems(config.TTS_ENGINES)
+
+        self.algorithm_combo = QComboBox()
+        self.algorithm_combo.setObjectName("settingsAlgorithm")
+        self.algorithm_combo.addItems(config.COMPARISON_ALGORITHMS)
+
+        self.duration_spin = QSpinBox()
+        self.duration_spin.setObjectName("settingsDuration")
+        self.duration_spin.setRange(1, 30)
+
+        form.addRow("Source language:", self.source_language_combo)
+        form.addRow("Voice:", self.voice_combo)
+        form.addRow("Whisper model size:", self.whisper_combo)
+        form.addRow("TTS engine:", self.tts_combo)
+        form.addRow("Scoring algorithm:", self.algorithm_combo)
+        form.addRow("Recording seconds:", self.duration_spin)
+        root.addLayout(form)
+
+        self.save_button = QPushButton("Save settings")
+        self.save_button.setObjectName("settingsSaveButton")
+        self.save_button.clicked.connect(self.save)
+        root.addWidget(self.save_button)
+
+        self.load()
+
+    def load(self) -> None:
+        """Populate widgets from effective (stored over default) settings."""
+        s = self._controller.effective_settings()
+        self._set_combo(self.source_language_combo, str(s.get("source_language", "English")))
+        self._set_combo(self.voice_combo, str(s.get("voice", "pt-br")))
+        self._set_combo(self.whisper_combo, str(s.get("whisper_model_size", "medium")))
+        self._set_combo(self.tts_combo, str(s.get("tts_engine", "piper")))
+        self._set_combo(
+            self.algorithm_combo, str(s.get("comparison_algorithm", "edit_distance"))
+        )
+        self.duration_spin.setValue(int(s.get("duration", 3)))
+
+    def save(self) -> None:
+        """Persist the current form values to SQLite."""
+        self._controller.settings_repo.update_many(
+            {
+                "source_language": self.source_language_combo.currentText(),
+                "voice": self.voice_combo.currentText(),
+                "whisper_model_size": self.whisper_combo.currentText(),
+                "tts_engine": self.tts_combo.currentText(),
+                "comparison_algorithm": self.algorithm_combo.currentText(),
+                "duration": self.duration_spin.value(),
+            }
+        )
+
+    @staticmethod
+    def _set_combo(combo: QComboBox, value: str) -> None:
+        idx = combo.findText(value)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+        elif combo.isEditable():
+            combo.setEditText(value)

--- a/desktop/miolingo_desktop/ui/workers.py
+++ b/desktop/miolingo_desktop/ui/workers.py
@@ -1,0 +1,55 @@
+"""Qt worker plumbing to run blocking work off the UI thread.
+
+Whisper transcription, TTS synthesis, and mic capture all block; running them on
+the GUI thread would freeze the UI (the exact failure SPEC §7 forbids). These
+``QRunnable`` workers run on a ``QThreadPool`` and report back via signals, so
+the event loop stays responsive and the view shows progress.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from PySide6.QtCore import QObject, QRunnable, Signal
+
+
+class WorkerSignals(QObject):
+    """Signals emitted by :class:`Worker` (a QObject so they're thread-safe)."""
+
+    progress = Signal(str)
+    finished = Signal(object)  # the function's return value
+    error = Signal(str)
+
+
+class Worker(QRunnable):
+    """Run ``fn(*args, **kwargs)`` on a thread-pool thread.
+
+    When ``pass_progress=True``, a ``progress_fn`` keyword is injected that emits
+    the ``progress`` signal (so long-running work can report status). The return
+    value is delivered via ``finished``; any exception via ``error``.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        pass_progress: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__()
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+        self.pass_progress = pass_progress
+        self.signals = WorkerSignals()
+
+    def run(self) -> None:  # noqa: D401 - Qt entry point
+        try:
+            if self.pass_progress:
+                self.kwargs.setdefault("progress_fn", self.signals.progress.emit)
+            result = self.fn(*self.args, **self.kwargs)
+        except Exception as e:  # noqa: BLE001 - report any failure to the UI
+            self.signals.error.emit(str(e))
+            return
+        self.signals.finished.emit(result)

--- a/desktop/pyproject.toml
+++ b/desktop/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "PySide6>=6.6",
     "openai-whisper>=20231117",
     "soundfile>=0.13.1",
+    "sounddevice>=0.4.6",
     "numpy>=2.0.2",
     "piper-tts>=1.2.0",
 ]

--- a/desktop/tests/fixtures/scoring_parity.json
+++ b/desktop/tests/fixtures/scoring_parity.json
@@ -1,0 +1,10 @@
+{
+  "_doc": "Regression fixtures locking the ported scoring to known-good output. Each case: (user_phonemes_normalized, correct_phonemes_normalized) -> [exact_match, similarity, edit_distance]. Values use the edit-distance algorithm copied verbatim from src/scoring/comparison.py. Only cases with hand-verifiable, certain values are hardcoded here; the companion test ALSO cross-checks the ported algorithm against an independent reference Levenshtein over a broader (incl. multi-edit / unicode) set, so parity is provable without trusting hand-computed edit distances. Audio->phoneme extraction is covered by manual tests (needs espeak + a recording).",
+  "cases": [
+    {"user": "bcurz", "correct": "bcurz", "exact": true, "similarity": 1.0, "distance": 0},
+    {"user": "bcur", "correct": "bcurz", "exact": false, "similarity": 0.8, "distance": 1},
+    {"user": "kat", "correct": "kut", "exact": false, "similarity": 0.6666666666666667, "distance": 1},
+    {"user": "", "correct": "abc", "exact": false, "similarity": 0.0, "distance": 3},
+    {"user": "obrigadu", "correct": "obrigado", "exact": false, "similarity": 0.875, "distance": 1}
+  ]
+}

--- a/desktop/tests/unit/test_audio_capture.py
+++ b/desktop/tests/unit/test_audio_capture.py
@@ -1,0 +1,27 @@
+"""Tests for audio capture helpers."""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from miolingo_desktop.core import audio_capture
+
+
+def test_encode_wav_roundtrip() -> None:
+    samples = (0.2 * np.sin(np.linspace(0, 6.28, 1600))).astype("float32")
+    wav = audio_capture.encode_wav(samples, sample_rate=16000)
+    assert wav[:4] == b"RIFF"
+    back, sr = sf.read(io.BytesIO(wav))
+    assert sr == 16000
+    assert len(back) == len(samples)
+
+
+@pytest.mark.manual
+def test_record_wav_live() -> None:
+    """Live mic capture — requires a microphone; excluded from the pre-PR run."""
+    wav = audio_capture.record_wav(duration=0.5)
+    assert wav[:4] == b"RIFF"

--- a/desktop/tests/unit/test_config.py
+++ b/desktop/tests/unit/test_config.py
@@ -1,0 +1,31 @@
+"""Tests for ported config + the desktop default-setting overrides."""
+
+from __future__ import annotations
+
+from miolingo_desktop.core import config
+
+
+def test_default_whisper_model_is_medium() -> None:
+    assert config.DEFAULT_SETTINGS["whisper_model_size"] == "medium"
+
+
+def test_default_tts_engine_is_piper() -> None:
+    assert config.DEFAULT_SETTINGS["tts_engine"] == "piper"
+
+
+def test_default_settings_returns_fresh_copy() -> None:
+    a = config.default_settings()
+    a["voice"] = "mutated"
+    b = config.default_settings()
+    assert b["voice"] != "mutated"
+
+
+def test_get_language_code() -> None:
+    assert config.get_language_code("English") == "en"
+    assert config.get_language_code("Portuguese") == "pt"
+    assert config.get_language_code("Klingon") == "klingon"
+
+
+def test_language_config_covers_supported_languages() -> None:
+    codes = {cfg["code"] for cfg in config.LANGUAGE_CONFIG.values()}
+    assert {"en", "pt", "fr", "de", "es", "it", "nl"} <= codes

--- a/desktop/tests/unit/test_config.py
+++ b/desktop/tests/unit/test_config.py
@@ -29,3 +29,16 @@ def test_get_language_code() -> None:
 def test_language_config_covers_supported_languages() -> None:
     codes = {cfg["code"] for cfg in config.LANGUAGE_CONFIG.values()}
     assert {"en", "pt", "fr", "de", "es", "it", "nl"} <= codes
+
+
+def test_voices_for_language_dedupes() -> None:
+    voices = config.voices_for_language("Portuguese")
+    assert "pt-br" in voices
+    assert len(voices) == len(set(voices))
+    assert config.voices_for_language("Klingon") == []
+
+
+def test_option_lists_present() -> None:
+    assert "medium" in config.WHISPER_MODEL_SIZES
+    assert config.TTS_ENGINES[0] == "piper"
+    assert "edit_distance" in config.COMPARISON_ALGORITHMS

--- a/desktop/tests/unit/test_controller.py
+++ b/desktop/tests/unit/test_controller.py
@@ -1,0 +1,65 @@
+"""Integration tests for the UI-free PracticeController.
+
+Drives the full record(stub)->transcribe(stub)->score->save flow and asserts a
+row lands in SQLite — the M3 acceptance check, headless and model-free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core import practice
+from miolingo_desktop.core.controller import PracticeController
+from miolingo_desktop.data import Database
+
+
+@pytest.fixture
+def controller(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PracticeController:
+    # Deterministic phonemes so scoring doesn't need espeak.
+    monkeypatch.setattr(
+        practice, "get_phonemes", lambda text, voice="": "abc" if text == "ola" else "abd"
+    )
+    monkeypatch.setattr(practice, "get_ipa", lambda text, voice="": "[x]")
+    db = Database(tmp_path / "ctrl.db")
+    yield PracticeController(db)
+    db.close()
+
+
+def test_effective_settings_merges_defaults(controller: PracticeController) -> None:
+    settings = controller.effective_settings()
+    assert settings["whisper_model_size"] == "medium"  # default
+    controller.settings_repo.set("whisper_model_size", "base")
+    assert controller.effective_settings()["whisper_model_size"] == "base"  # stored wins
+
+
+def test_run_practice_scores_and_persists(controller: PracticeController) -> None:
+    result = controller.run_practice(
+        target_text="ola",
+        audio_bytes=b"fake-wav-bytes",
+        language="Portuguese",
+        transcribe_fn=lambda *a, **k: "olha",
+    )
+    assert result is not None
+    assert "attempt_id" in result
+    assert result["target"] == "ola"
+
+    history = controller.recent_history(language="Portuguese")
+    assert len(history) == 1
+    assert history[0]["target_phrase"] == "ola"
+    assert history[0]["language_code"] == "pt"
+
+
+def test_recent_history_filters_language(controller: PracticeController) -> None:
+    controller.run_practice(
+        target_text="ola", audio_bytes=b"x", language="Portuguese",
+        transcribe_fn=lambda *a, **k: "ola",
+    )
+    assert controller.recent_history(language="French") == []
+    assert len(controller.recent_history()) == 1
+
+
+def test_available_languages_nonempty(controller: PracticeController) -> None:
+    langs = controller.available_languages()
+    assert "pt" in langs

--- a/desktop/tests/unit/test_core_purity.py
+++ b/desktop/tests/unit/test_core_purity.py
@@ -1,0 +1,40 @@
+"""Guardrail test: the ported ``core/`` package must be UI-framework-free.
+
+It walks every ``.py`` file under ``miolingo_desktop/core/`` and asserts no
+module imports ``streamlit`` or ``PySide6``. This is a hard project rule
+(``desktop/CLAUDE.md`` §1) — keeping core decoupled is what makes it headlessly
+testable and reusable.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import miolingo_desktop.core as core_pkg
+
+CORE_DIR = Path(core_pkg.__file__).resolve().parent
+FORBIDDEN_ROOTS = {"streamlit", "PySide6", "PyQt5", "PyQt6"}
+
+
+def _imported_roots(source: str) -> set[str]:
+    roots: set[str] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                roots.add(node.module.split(".")[0])
+    return roots
+
+
+def test_core_has_no_ui_framework_imports() -> None:
+    offenders: dict[str, set[str]] = {}
+    for py_file in CORE_DIR.rglob("*.py"):
+        roots = _imported_roots(py_file.read_text(encoding="utf-8"))
+        bad = roots & FORBIDDEN_ROOTS
+        if bad:
+            offenders[py_file.name] = bad
+    assert not offenders, f"UI-framework imports found in core/: {offenders}"

--- a/desktop/tests/unit/test_db_paths.py
+++ b/desktop/tests/unit/test_db_paths.py
@@ -1,0 +1,29 @@
+"""Tests for DB path resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.data import paths
+
+
+def test_default_db_path_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "custom.db"
+    monkeypatch.setenv("MIOLINGO_DB_PATH", str(target))
+    assert paths.default_db_path() == target
+
+
+def test_default_db_path_app_support(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIOLINGO_DB_PATH", raising=False)
+    p = paths.default_db_path()
+    assert p.name == "miolingo.db"
+    assert p.parent.name == "Miolingo"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific path")
+def test_app_support_dir_on_macos() -> None:
+    p = paths.app_support_dir()
+    assert "Library/Application Support/Miolingo" in str(p)

--- a/desktop/tests/unit/test_history_settings_views.py
+++ b/desktop/tests/unit/test_history_settings_views.py
@@ -1,0 +1,102 @@
+"""Qt tests for History + Settings views (offscreen)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core.controller import PracticeController
+from miolingo_desktop.data import Database
+from miolingo_desktop.main import create_app
+from miolingo_desktop.ui.history_view import HistoryView
+from miolingo_desktop.ui.settings_view import SettingsView
+
+
+@pytest.fixture
+def controller(tmp_path: Path) -> PracticeController:
+    db = Database(tmp_path / "m4.db")
+    yield PracticeController(db)
+    db.close()
+
+
+def _seed(controller: PracticeController) -> None:
+    controller.practice_repo.save_attempt(
+        language_code="pt", target_phrase="ola", recognized_phrase="ola",
+        similarity_score=100.0, perfect_match=True,
+    )
+    controller.practice_repo.save_attempt(
+        language_code="fr", target_phrase="bonjour", recognized_phrase="bonsoir",
+        similarity_score=72.5, perfect_match=False,
+    )
+
+
+def test_history_renders_seeded_rows(qtbot, controller: PracticeController) -> None:
+    create_app([])
+    _seed(controller)
+    view = HistoryView(controller)
+    qtbot.addWidget(view)
+    assert view.row_count() == 2
+    # Newest first; columns populated.
+    assert view.table.item(0, 1).text() in {"pt", "fr"}
+    assert "%" in view.table.item(0, 4).text()
+
+
+def test_history_refresh_picks_up_new_rows(qtbot, controller: PracticeController) -> None:
+    create_app([])
+    view = HistoryView(controller)
+    qtbot.addWidget(view)
+    assert view.row_count() == 0
+    _seed(controller)
+    view.refresh()
+    assert view.row_count() == 2
+
+
+def test_history_persists_across_restart(qtbot, tmp_path: Path) -> None:
+    create_app([])
+    path = tmp_path / "persist.db"
+    db1 = Database(path)
+    PracticeController(db1).practice_repo.save_attempt(
+        language_code="pt", target_phrase="ola", recognized_phrase="ola",
+        similarity_score=100.0, perfect_match=True,
+    )
+    db1.close()
+
+    db2 = Database(path)
+    view = HistoryView(PracticeController(db2))
+    qtbot.addWidget(view)
+    assert view.row_count() == 1
+    db2.close()
+
+
+def test_settings_round_trip(qtbot, controller: PracticeController) -> None:
+    create_app([])
+    view = SettingsView(controller)
+    qtbot.addWidget(view)
+    view._set_combo(view.whisper_combo, "base")
+    view._set_combo(view.tts_combo, "espeak")
+    view.duration_spin.setValue(7)
+    view.save()
+
+    stored = controller.effective_settings()
+    assert stored["whisper_model_size"] == "base"
+    assert stored["tts_engine"] == "espeak"
+    assert stored["duration"] == 7
+
+
+def test_settings_restored_on_relaunch(qtbot, tmp_path: Path) -> None:
+    create_app([])
+    path = tmp_path / "settings.db"
+    db1 = Database(path)
+    c1 = PracticeController(db1)
+    v1 = SettingsView(c1)
+    qtbot.addWidget(v1)
+    v1._set_combo(v1.whisper_combo, "small")
+    v1.save()
+    db1.close()
+
+    db2 = Database(path)
+    v2 = SettingsView(PracticeController(db2))
+    qtbot.addWidget(v2)
+    assert v2.whisper_combo.currentText() == "small"
+    db2.close()

--- a/desktop/tests/unit/test_import_header.py
+++ b/desktop/tests/unit/test_import_header.py
@@ -1,0 +1,28 @@
+"""Tests for the ported language-pair header parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from miolingo_desktop.core.import_header import is_header_line, parse_header
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["(pt, en)", "# (pt, en)", "(  FR  ,  EN  )", "(de,nl)"],
+)
+def test_is_header_line_true(line: str) -> None:
+    assert is_header_line(line) is True
+
+
+@pytest.mark.parametrize(
+    "line",
+    ["bonjour | hello", "", "# a comment", "(toolongcode, en)", "(pt)"],
+)
+def test_is_header_line_false(line: str) -> None:
+    assert is_header_line(line) is False
+
+
+def test_parse_header() -> None:
+    assert parse_header("(FR, EN)") == ("fr", "en")
+    assert parse_header("not a header") is None

--- a/desktop/tests/unit/test_materials.py
+++ b/desktop/tests/unit/test_materials.py
@@ -1,0 +1,100 @@
+"""Tests for language-materials discovery and loading.
+
+These run against the real bundled ``language_materials/`` tree (located via
+``get_data_dir()``), asserting structural invariants rather than exact
+filenames so they stay stable as content evolves. A synthetic temp tree
+exercises the parser edge cases deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core import materials
+
+
+def test_get_data_dir_exists() -> None:
+    data_dir = materials.get_data_dir()
+    assert data_dir.exists(), f"language_materials not found at {data_dir}"
+    assert data_dir.name == "language_materials"
+
+
+def test_available_languages_includes_core_set() -> None:
+    langs = set(materials.get_available_languages())
+    # The bundled content always ships at least these.
+    assert {"pt", "fr", "de", "es", "it", "nl"} <= langs
+
+
+def test_language_structure_has_phrases_or_words() -> None:
+    structure = materials.get_language_structure("pt")
+    assert structure, "expected non-empty structure for pt"
+    assert any(k in structure for k in ("phrases", "words"))
+
+
+def test_get_data_dir_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    materials.get_data_dir.cache_clear()
+    monkeypatch.setenv("MIOLINGO_MATERIALS_DIR", str(tmp_path))
+    try:
+        assert materials.get_data_dir() == tmp_path
+    finally:
+        materials.get_data_dir.cache_clear()
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_load_phrase_file_txt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    materials.get_data_dir.cache_clear()
+    monkeypatch.setenv("MIOLINGO_MATERIALS_DIR", str(tmp_path))
+    try:
+        f = tmp_path / "fr" / "phrases" / "phr-01.txt"
+        _write(
+            f,
+            "# a comment\n(fr, en)\nbonjour | hello | [bɔ̃ʒuʁ]\nmerci | thank you\nau revoir\n",
+        )
+        rows = materials.load_phrase_file(str(f))
+        assert len(rows) == 3  # comment + header line filtered out
+        assert rows[0] == {"text": "bonjour", "translation": "hello", "ipa": "[bɔ̃ʒuʁ]"}
+        assert rows[1] == {"text": "merci", "translation": "thank you", "ipa": None}
+        assert rows[2] == {"text": "au revoir", "translation": None, "ipa": None}
+    finally:
+        materials.get_data_dir.cache_clear()
+
+
+def test_load_phrase_file_rejects_path_traversal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    materials.get_data_dir.cache_clear()
+    monkeypatch.setenv("MIOLINGO_MATERIALS_DIR", str(tmp_path / "data"))
+    try:
+        (tmp_path / "data").mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("nope", encoding="utf-8")
+        with pytest.raises(ValueError):
+            materials.load_phrase_file(str(outside))
+    finally:
+        materials.get_data_dir.cache_clear()
+
+
+def test_load_unified_phrase_file(tmp_path: Path) -> None:
+    f = tmp_path / "u.json"
+    doc = {
+        "meta": {"languages": ["fr", "en"]},
+        "phrases": [
+            {"text": {"fr": "chat", "en": "cat"}, "ipa": {"fr": "ʃa"}},
+            {"text": {"en": "only english"}},  # skipped: no fr
+        ],
+    }
+    f.write_text(json.dumps(doc), encoding="utf-8")
+    rows = list(materials.load_unified_phrase_file(str(f), "fr", "en"))
+    assert rows == [{"text": "chat", "translation": "cat", "ipa": "ʃa"}]
+
+
+def test_format_language_name() -> None:
+    assert materials.format_language_name("fr") == "French"
+    assert materials.format_language_name("xx") == "XX"

--- a/desktop/tests/unit/test_practice_pipeline.py
+++ b/desktop/tests/unit/test_practice_pipeline.py
@@ -1,0 +1,83 @@
+"""Tests for the practice orchestration pipeline (headless, no models/espeak).
+
+The transcriber is injected via ``transcribe_fn`` and phoneme extraction is
+monkeypatched, so the full pipeline (trim -> transcribe -> phonemes -> score ->
+assemble -> on_result) runs deterministically with no Whisper model or espeak
+binary. A real audio->score run is a manual test (needs a mic + model).
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from miolingo_desktop.core import practice
+
+
+def _make_wav(seconds: float = 0.5, sr: int = 16000) -> bytes:
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False)
+    tone = 0.3 * np.sin(2 * np.pi * 220 * t)
+    buf = io.BytesIO()
+    sf.write(buf, tone, sr, format="WAV")
+    return buf.getvalue()
+
+
+def test_trim_silence_returns_bytes() -> None:
+    wav = _make_wav()
+    trimmed, original = practice.trim_silence(wav)
+    assert isinstance(trimmed, bytes)
+    assert original == wav
+
+
+def test_trim_silence_handles_garbage() -> None:
+    trimmed, original = practice.trim_silence(b"not audio")
+    assert trimmed == b"not audio"
+    assert original == b"not audio"
+
+
+def test_practice_pipeline_scores_and_calls_on_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Deterministic phonemes: target and recognised differ by one symbol.
+    monkeypatch.setattr(
+        practice, "get_phonemes", lambda text, voice="": "abc" if text == "ola" else "abd"
+    )
+    monkeypatch.setattr(practice, "get_ipa", lambda text, voice="": "[x]")
+
+    captured: dict = {}
+    result = practice.practice_word_from_audio(
+        "ola",
+        _make_wav(),
+        {"voice": "pt-br", "comparison_algorithm": "edit_distance"},
+        language="Portuguese",
+        on_result=captured.update,
+        transcribe_fn=lambda *a, **k: "olha",
+    )
+
+    assert result is not None
+    assert result["target"] == "ola"
+    assert result["recognized"] == "olha"
+    assert result["exact_match"] is False
+    assert result["edit_distance"] == 1
+    assert result["similarity"] == pytest.approx(2 / 3)
+    # on_result received the same dict.
+    assert captured["target"] == "ola"
+
+
+def test_practice_pipeline_returns_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*a, **k):
+        raise RuntimeError("transcription exploded")
+
+    errors: list[str] = []
+    result = practice.practice_word_from_audio(
+        "ola",
+        _make_wav(),
+        {"voice": "pt-br"},
+        transcribe_fn=_boom,
+        error_fn=errors.append,
+    )
+    assert result is None
+    assert errors and "exploded" in errors[0]

--- a/desktop/tests/unit/test_practice_view.py
+++ b/desktop/tests/unit/test_practice_view.py
@@ -1,0 +1,96 @@
+"""Qt smoke + threading tests for the Practice vertical slice (offscreen).
+
+- The view constructs, populates language/category/file/phrase widgets, and
+  exposes the selected phrase.
+- The Worker runs its callable on a NON-GUI thread (proves transcription won't
+  freeze the UI — SPEC §7), reports progress, and delivers the result.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core.controller import PracticeController
+from miolingo_desktop.data import Database
+from miolingo_desktop.main import MainWindow, create_app
+from miolingo_desktop.ui.practice_view import PracticeView
+from miolingo_desktop.ui.workers import Worker
+
+
+@pytest.fixture
+def controller(tmp_path: Path) -> PracticeController:
+    db = Database(tmp_path / "view.db")
+    yield PracticeController(db)
+    db.close()
+
+
+def test_practice_view_constructs_and_populates(qtbot, controller: PracticeController) -> None:
+    create_app([])
+    view = PracticeView(controller)
+    qtbot.addWidget(view)
+    # Languages loaded from bundled materials.
+    assert view.language_combo.count() > 0
+    # Selecting a language populates categories; a category populates files.
+    view.language_combo.setCurrentText("pt")
+    assert view.category_combo.count() > 0
+    if view.file_combo.count():
+        # A loaded set yields selectable phrases (or at least no crash).
+        assert isinstance(view.selected_phrase_text(), (str, type(None)))
+
+
+def test_main_window_has_practice_tab(qtbot, tmp_path: Path) -> None:
+    create_app([])
+    db = Database(tmp_path / "main.db")
+    window = MainWindow(db=db)
+    qtbot.addWidget(window)
+    assert window.tabs.count() >= 1
+    assert window.tabs.tabText(0) == "Quick Practice"
+
+
+def test_worker_runs_off_gui_thread(qtbot) -> None:
+    create_app([])
+    main_thread = threading.get_ident()
+    captured: dict = {}
+
+    def _work(progress_fn=None):
+        if progress_fn:
+            progress_fn("working")
+        captured["thread"] = threading.get_ident()
+        return "done"
+
+    results: list = []
+    progresses: list = []
+    worker = Worker(_work, pass_progress=True)
+    worker.signals.finished.connect(results.append)
+    worker.signals.progress.connect(progresses.append)
+
+    from PySide6.QtCore import QThreadPool
+
+    with qtbot.waitSignal(worker.signals.finished, timeout=5000):
+        QThreadPool.globalInstance().start(worker)
+
+    assert results == ["done"]
+    assert progresses == ["working"]
+    # The work ran on a different thread than the GUI/main thread.
+    assert captured["thread"] != main_thread
+
+
+def test_worker_reports_error(qtbot) -> None:
+    create_app([])
+
+    def _boom():
+        raise RuntimeError("kaboom")
+
+    errors: list = []
+    worker = Worker(_boom)
+    worker.signals.error.connect(errors.append)
+
+    from PySide6.QtCore import QThreadPool
+
+    with qtbot.waitSignal(worker.signals.error, timeout=5000):
+        QThreadPool.globalInstance().start(worker)
+
+    assert errors and "kaboom" in errors[0]

--- a/desktop/tests/unit/test_scoring.py
+++ b/desktop/tests/unit/test_scoring.py
@@ -1,0 +1,64 @@
+"""Unit tests for the ported scoring/comparison logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from miolingo_desktop.core.comparison import (
+    compare_phonemes,
+    compare_phonemes_edit_distance,
+    get_edit_operations,
+    levenshtein_distance,
+)
+
+
+@pytest.mark.parametrize(
+    ("s1", "s2", "expected"),
+    [
+        ("", "", 0),
+        ("abc", "abc", 0),
+        ("abc", "abd", 1),
+        ("kitten", "sitting", 3),
+        ("", "abc", 3),
+        ("abc", "", 3),
+        ("flaw", "lawn", 2),
+    ],
+)
+def test_levenshtein_distance(s1: str, s2: str, expected: int) -> None:
+    assert levenshtein_distance(s1, s2) == expected
+    # Distance is symmetric.
+    assert levenshtein_distance(s2, s1) == expected
+
+
+def test_compare_phonemes_exact_match() -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance("bõʒuʁ", "bõʒuʁ")
+    assert exact is True
+    assert similarity == 1.0
+    assert distance == 0
+
+
+def test_compare_phonemes_partial() -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance("bõʒu", "bõʒuʁ")
+    assert exact is False
+    assert distance == 1
+    assert similarity == pytest.approx(1.0 - 1 / 5)
+
+
+def test_compare_phonemes_empty_reference() -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance("abc", "")
+    assert exact is False
+    assert similarity == 0.0
+    assert distance == 3
+
+
+def test_compare_phonemes_unknown_algorithm_falls_back() -> None:
+    # Unknown algorithm must behave exactly like edit_distance (source parity).
+    a = compare_phonemes("abc", "abd", algorithm="positional")
+    b = compare_phonemes_edit_distance("abc", "abd")
+    assert a == b
+
+
+def test_get_edit_operations_roundtrip() -> None:
+    ops = get_edit_operations("cat", "cut")
+    kinds = [op[0] for op in ops]
+    assert kinds == ["match", "substitute", "match"]

--- a/desktop/tests/unit/test_scoring_parity.py
+++ b/desktop/tests/unit/test_scoring_parity.py
@@ -1,0 +1,79 @@
+"""Scoring parity regression.
+
+Two layers of protection that the ported scoring matches the source app:
+
+1. Hardcoded fixtures (``tests/fixtures/scoring_parity.json``) with certain,
+   hand-verifiable expected outputs.
+2. A cross-check of the ported edit-distance against an INDEPENDENT reference
+   Levenshtein implementation over a broad set (including multi-edit and
+   unicode phoneme strings). This proves the algorithm is correct without
+   trusting hand-computed edit distances for tricky cases.
+
+SPEC acceptance: "the score produced by the ported scoring code matches the
+source app's output for a fixed (audio, reference) fixture set." Audio->phoneme
+extraction needs espeak + a real recording (a manual test); the pure scoring
+layer — where parity is deterministically provable headlessly — is locked here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.core.comparison import compare_phonemes_edit_distance
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "scoring_parity.json"
+
+
+def _ref_levenshtein(a: str, b: str) -> int:
+    """Independent reference implementation (different code path than the port)."""
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i]
+        for j, cb in enumerate(b, 1):
+            curr.append(
+                min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + (0 if ca == cb else 1))
+            )
+        prev = curr
+    return prev[-1]
+
+
+def _load_cases() -> list[dict]:
+    with open(FIXTURE, encoding="utf-8") as f:
+        return json.load(f)["cases"]
+
+
+@pytest.mark.parametrize("case", _load_cases())
+def test_fixture_parity(case: dict) -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance(
+        case["user"], case["correct"]
+    )
+    assert exact is case["exact"]
+    assert distance == case["distance"]
+    assert similarity == pytest.approx(case["similarity"])
+
+
+@pytest.mark.parametrize(
+    ("user", "correct"),
+    [
+        ("bõʒuʁ", "bõʒuʁ"),
+        ("bõʒu", "bõʒuʁ"),
+        ("saudʒi", "saʊde"),
+        ("ɐ̃tɐ̃u", "ɐ̃tɐ̃w"),
+        ("obrigadu", "obrigado"),
+        ("", ""),
+        ("abc", ""),
+    ],
+)
+def test_ported_matches_independent_reference(user: str, correct: str) -> None:
+    exact, similarity, distance = compare_phonemes_edit_distance(user, correct)
+    expected_distance = _ref_levenshtein(user, correct)
+    assert distance == expected_distance
+    assert exact is (user == correct)
+    if len(correct) == 0:
+        assert similarity == 0.0
+    else:
+        max_len = max(len(user), len(correct))
+        assert similarity == pytest.approx(1.0 - expected_distance / max_len)

--- a/desktop/tests/unit/test_storage.py
+++ b/desktop/tests/unit/test_storage.py
@@ -1,0 +1,219 @@
+"""Tests for the SQLite storage layer: migrations + repository CRUD round-trips.
+
+Each test uses a temp-file DB (not in-memory) so restart-persistence and WAL
+behaviour are exercised the way the real app uses them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miolingo_desktop.data import (
+    Database,
+    PracticeRepository,
+    SettingsRepository,
+    VocabularyRepository,
+)
+from miolingo_desktop.data.migrations import MIGRATIONS, current_version
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Database:
+    database = Database(tmp_path / "test.db")
+    yield database
+    database.close()
+
+
+# ---- migrations -----------------------------------------------------------
+
+
+def test_migration_applies_to_latest_version(db: Database) -> None:
+    latest = max(v for v, _ in MIGRATIONS)
+    assert current_version(db.connection) == latest
+
+
+def test_migration_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "idem.db"
+    Database(path).close()
+    # Re-open: migrations must not error or duplicate schema.
+    db2 = Database(path)
+    latest = max(v for v, _ in MIGRATIONS)
+    assert current_version(db2.connection) == latest
+    db2.close()
+
+
+def test_db_created_on_first_run(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "dir" / "miolingo.db"
+    assert not path.exists()
+    Database(path).close()
+    assert path.exists()
+
+
+# ---- settings -------------------------------------------------------------
+
+
+def test_settings_round_trip(db: Database) -> None:
+    repo = SettingsRepository(db)
+    assert repo.get("voice", "default") == "default"
+    repo.set("voice", "pt-br")
+    repo.set("whisper_model_size", "medium")
+    assert repo.get("voice") == "pt-br"
+    assert repo.get_all()["whisper_model_size"] == "medium"
+
+
+def test_settings_persist_across_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "persist.db"
+    db1 = Database(path)
+    SettingsRepository(db1).set("voice", "fr-fr")
+    db1.close()
+
+    db2 = Database(path)
+    assert SettingsRepository(db2).get("voice") == "fr-fr"
+    db2.close()
+
+
+def test_settings_update_overwrites(db: Database) -> None:
+    repo = SettingsRepository(db)
+    repo.set("voice", "a")
+    repo.set("voice", "b")
+    assert repo.get("voice") == "b"
+    # Only one live row for the key.
+    assert len(repo.get_all()) == 1
+
+
+# ---- practice attempts ----------------------------------------------------
+
+
+def test_practice_save_and_list(db: Database) -> None:
+    repo = PracticeRepository(db)
+    repo.save_attempt(
+        language_code="pt",
+        target_phrase="ola",
+        recognized_phrase="ola",
+        similarity_score=100.0,
+        perfect_match=True,
+    )
+    repo.save_attempt(
+        language_code="fr",
+        target_phrase="bonjour",
+        recognized_phrase="bonsoir",
+        similarity_score=80.0,
+        perfect_match=False,
+    )
+    all_rows = repo.list_history()
+    assert len(all_rows) == 2
+    fr_rows = repo.list_history(language_code="fr")
+    assert len(fr_rows) == 1
+    assert fr_rows[0]["target_phrase"] == "bonjour"
+    assert fr_rows[0]["perfect_match"] == 0
+
+
+def test_practice_save_from_result(db: Database) -> None:
+    repo = PracticeRepository(db)
+    result = {
+        "target": "ola",
+        "recognized": "olha",
+        "similarity": 0.6667,
+        "exact_match": False,
+        "correct_phonemes_normalized": "ola",
+        "user_phonemes_normalized": "olja",
+    }
+    repo.save_from_result("pt", result)
+    row = repo.list_history()[0]
+    assert row["target_phrase"] == "ola"
+    assert row["similarity_score"] == pytest.approx(66.67)
+    assert row["perfect_match"] == 0
+
+
+def test_practice_persists_across_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "hist.db"
+    db1 = Database(path)
+    PracticeRepository(db1).save_attempt(
+        language_code="pt", target_phrase="ola", recognized_phrase="ola",
+        similarity_score=100.0, perfect_match=True,
+    )
+    db1.close()
+    db2 = Database(path)
+    assert len(PracticeRepository(db2).list_history()) == 1
+    db2.close()
+
+
+def test_practice_soft_delete_hides_row(db: Database) -> None:
+    repo = PracticeRepository(db)
+    attempt_id = repo.save_attempt(
+        language_code="pt", target_phrase="ola", recognized_phrase="ola",
+        similarity_score=100.0, perfect_match=True,
+    )
+    repo.soft_delete(attempt_id)
+    assert repo.list_history() == []
+    assert len(repo.list_history(include_deleted=True)) == 1
+
+
+# ---- vocabulary -----------------------------------------------------------
+
+
+def test_vocab_capture_creates_then_bumps(db: Database) -> None:
+    repo = VocabularyRepository(db)
+    first = repo.capture(language_code="fr", word="chat", translation="cat")
+    assert first["created"] is True
+    second = repo.capture(language_code="fr", word="chat")
+    assert second["created"] is False
+    assert second["id"] == first["id"]
+    row = repo.get(first["id"])
+    assert row is not None
+    assert row["times_seen"] == 2
+    # First-encounter translation preserved (not overwritten by NULL).
+    assert row["translation"] == "cat"
+
+
+def test_vocab_capture_fills_null_fields_only(db: Database) -> None:
+    repo = VocabularyRepository(db)
+    rid = repo.capture(language_code="fr", word="chat")["id"]
+    repo.capture(language_code="fr", word="chat", translation="cat", ipa="ʃa")
+    row = repo.get(rid)
+    assert row["translation"] == "cat"
+    assert row["ipa"] == "ʃa"
+
+
+def test_vocab_update(db: Database) -> None:
+    repo = VocabularyRepository(db)
+    rid = repo.capture(language_code="fr", word="chat")["id"]
+    repo.update(rid, translation="kitty", url="http://x")
+    row = repo.get(rid)
+    assert row["translation"] == "kitty"
+    assert row["url"] == "http://x"
+    # Unknown fields ignored.
+    repo.update(rid, not_a_column="x")
+
+
+def test_vocab_list_search_and_sort(db: Database) -> None:
+    repo = VocabularyRepository(db)
+    repo.capture(language_code="fr", word="banane", translation="banana")
+    repo.capture(language_code="fr", word="chat", translation="cat")
+    repo.capture(language_code="de", word="hund", translation="dog")
+
+    fr = repo.list(language_code="fr")
+    assert [r["word"] for r in fr] == ["banane", "chat"]  # alpha sort
+    found = repo.list(language_code="fr", search="cat")
+    assert len(found) == 1 and found[0]["word"] == "chat"
+
+
+def test_vocab_soft_delete_and_resurrect(db: Database) -> None:
+    repo = VocabularyRepository(db)
+    rid = repo.capture(language_code="fr", word="chat")["id"]
+    repo.soft_delete(rid)
+    assert repo.list(language_code="fr") == []
+    # Re-capturing the same word resurrects the row.
+    again = repo.capture(language_code="fr", word="chat")
+    assert again["id"] == rid
+    assert len(repo.list(language_code="fr")) == 1
+
+
+def test_vocab_export_csv_rows(db: Database) -> None:
+    repo = VocabularyRepository(db)
+    repo.capture(language_code="fr", word="chat", translation="cat")
+    rows = list(repo.export_csv_rows(language_code="fr"))
+    assert len(rows) == 1
+    assert rows[0]["word"] == "chat"

--- a/desktop/tests/unit/test_tts_dispatch.py
+++ b/desktop/tests/unit/test_tts_dispatch.py
@@ -1,0 +1,67 @@
+"""Tests for the TTS dispatcher fallback order (Piper -> Google Cloud -> espeak).
+
+We don't synthesize real audio here; we verify the *selection/fallback* logic by
+monkeypatching the engine functions. Full Piper synthesis + per-voice clip tests
+land in Milestone 7.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from miolingo_desktop.core import tts
+
+
+def test_resolve_piper_voice_missing_raises() -> None:
+    with pytest.raises(tts.PiperUnavailable):
+        tts.resolve_piper_voice("pt-BR", voices={})
+
+
+def test_resolve_piper_voice_present() -> None:
+    assert tts.resolve_piper_voice("pt-BR", voices={"pt-BR": "pt_BR-faber"}) == "pt_BR-faber"
+
+
+def test_dispatch_prefers_piper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts, "synthesize_piper", lambda *a, **k: (b"PIPER", "audio/wav"))
+    out = tts.generate_target_audio("ola", {"tts_engine": "piper", "voice": "pt-br"})
+    assert out == (b"PIPER", "audio/wav")
+
+
+def test_dispatch_falls_back_to_google_when_piper_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_piper(*a, **k):
+        raise tts.PiperUnavailable("no voice")
+
+    monkeypatch.setattr(tts, "synthesize_piper", _no_piper)
+    monkeypatch.setattr(
+        tts, "speak_text_google_cloud", lambda *a, **k: (b"GOOGLE", "audio/mp3")
+    )
+    out = tts.generate_target_audio(
+        "ola", {"tts_engine": "piper", "voice": "pt-br"}, google_api_key="key"
+    )
+    assert out == (b"GOOGLE", "audio/mp3")
+
+
+def test_dispatch_falls_back_to_espeak_when_no_piper_no_google(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_piper(*a, **k):
+        raise tts.PiperUnavailable("no voice")
+
+    monkeypatch.setattr(tts, "synthesize_piper", _no_piper)
+    monkeypatch.setattr(tts, "speak_text", lambda *a, **k: (b"ESPEAK", "audio/wav"))
+    # No google_api_key -> skip Google, go straight to espeak.
+    out = tts.generate_target_audio("ola", {"tts_engine": "piper", "voice": "pt-br"})
+    assert out == (b"ESPEAK", "audio/wav")
+
+
+def test_dispatch_explicit_espeak(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts, "speak_text", lambda *a, **k: (b"ESPEAK", "audio/wav"))
+    out = tts.generate_target_audio("ola", {"tts_engine": "espeak", "voice": "pt-br"})
+    assert out == (b"ESPEAK", "audio/wav")
+
+
+def test_google_cloud_requires_api_key() -> None:
+    with pytest.raises(ValueError):
+        tts.speak_text_google_cloud.__wrapped__("hi", api_key=None)


### PR DESCRIPTION
## Milestone 4 — History + Settings

Adds the History and Settings tabs on top of the M3 vertical slice.

> **Stacking:** based on **M3** (#126) ← M2 (#125) ← M1 (#124) ← M0 (#123). Merge in order. Includes a merge of the M1 config.py fix (see note below).

### What changed
- `ui/history_view.py` — read-only `QTableWidget` (date, language, target, heard, score, match) from `PracticeRepository`; `refresh()` re-queries and runs when the History tab is shown (restart-persistent rows appear).
- `ui/settings_view.py` — form bound to `SettingsRepository`: source language, voice, Whisper model size, TTS engine, scoring algorithm, recording seconds. Loads effective settings on construct, persists on Save, restored on relaunch.
- `core/config.py` — Settings-UI option lists + `voices_for_language()` (UI holds no choices).
- `main.py` — History + Settings tabs; refresh History on tab change.

### Acceptance
- Attempts from M3 show in History across restarts ✅ (tests)
- Settings persist + restore ✅ (tests)

### Heads-up: `.gitignore` fix folded in
A repo-root `.gitignore` `config.*` pattern had silently excluded `desktop/miolingo_desktop/core/config.py` from M1–M3. That's now fixed (negation in `desktop/.gitignore` + the file tracked) and merged down the stack (M1 PR #124 updated; M2 #125, M3 #126 re-pushed). Without it the package wouldn't import. Please re-pull the stack.

### Test plan
```bash
source /Users/matthew/Software/working/miolingo/venv/bin/activate
pip install -e "desktop[dev]"
cd desktop && QT_QPA_PLATFORM=offscreen pytest -q && ruff check . && mypy miolingo_desktop
```

> ⚠️ **Tests authored but NOT executed in-sandbox** (see `desktop/QUESTIONS.md`). Run via CI/locally before merge.