### PR TITLE
Remove afforded guard normal form notes

### DIFF
--- a/spec/PracticeSessionRecovered.wl
+++ b/spec/PracticeSessionRecovered.wl
@@ -13,7 +13,7 @@
      - FREE NAVIGATION over a bounded queue (prev/next/select), not a
        linear consume-to-Finished. No deadlock end state; next/prev are
        merely DISABLED at the ends (a ready-set guard).
-     - RECORD then CHECK are two steps: Check/Remove are afforded only
+     - RECORD then CHECK are two steps: Check/Remove are available only
        when a recording exists (the Streamlit `if audio_data:` guard).
      - capture_vocab is a CROSS-COMPONENT port to VocabStore.add.
 
@@ -35,7 +35,7 @@
    bounds flip next/prev, recording-presence flips recording_made <->
    attempt_made/clear_recording, a result reveals capture_vocab.
 
-   RECOVERED READY SETS (view!, afforded! present in every mode):
+   RECOVERED READY SETS (analysis only; not explicit channels in the process):
      PS[{},      _,_,_ ]            NoMaterial : load_material
      PS[ne, p, none,    none   ]    Prompting  : +clear_material,
                                       recording_made, select, next†, prev‡
@@ -44,17 +44,26 @@
      PS[ne, p, recorded,scored ]    Evaluated  : +attempt_made,
                                       clear_recording, capture_vocab,
                                       select, next†, prev‡
-       † next afforded iff pos < Length-1   ‡ prev afforded iff pos > 0
+       † next available iff pos < Length-1   ‡ prev available iff pos > 0
    ===================================================================== *)
 
 
-(* --- top level: discipline ports + always-on load + dispatch to active *)
+(* --- top level: view + always-on load + dispatch to active --- *)
 defineAgent["PS", {phrases, pos, rec, res},
-  choice[
-    precede[label["view", param[sessionView[phrases, pos, rec, res]]],
-      call["PS", phrases, pos, rec, res]],
+  if[Length[phrases] == 0,
     choice[
-      precede[label["afforded", param[portsOf[call["PS", phrases, pos, rec, res]]]],
+      precede[label["view", param[sessionView[phrases, pos, rec, res]]],
+        call["PS", phrases, pos, rec, res]],
+      choice[
+        precede[coLabel["load_material", binding[ps]],
+          call["PS", ps, 0, none, none]],
+        (* CROSS-COMPONENT (composition refinement): receive a phrase list
+           relayed from VocabStore's "Practise these" on internal channel
+           pLoad. Restricted in the MioCore composition. *)
+        precede[coLabel["pLoad", binding[ps]],
+          call["PS", ps, 0, none, none]]]],
+    choice[
+      precede[label["view", param[sessionView[phrases, pos, rec, res]]],
         call["PS", phrases, pos, rec, res]],
       choice[
         precede[coLabel["load_material", binding[ps]],
@@ -65,64 +74,201 @@ defineAgent["PS", {phrases, pos, rec, res},
              pLoad. Restricted in the MioCore composition. *)
           precede[coLabel["pLoad", binding[ps]],
             call["PS", ps, 0, none, none]],
-          (* domain ports only when the queue is non-empty (F2: inert branches) *)
-          if[Length[phrases] == 0,
-             nil,
-             call["PSActive", phrases, pos, rec, res]]]]]]]
+          call["PSActive", phrases, pos, rec, res]]])])]
 
 
 (* --- the domain ports, reached only with a non-empty queue.
-   Each conditional port is `if[guard, precede[...], nil]` — the guard IS
-   the recovered Streamlit conditional; the branches stay inert. *)
+   Presented in guard-partitioned normal form: no afforded channel, and
+   no degenerate if[guard, P, nil] branches in the written spec. *)
 defineAgent["PSActive", {phrases, pos, rec, res},
-  choice[
-    precede[coLabel["clear_material"], call["PS", {}, 0, none, none]],
-    choice[
-      (* record — only when no recording yet *)
-      if[rec === none,
-         precede[coLabel["recording_made", binding[audio]],
-           call["PS", phrases, pos, recorded[audio], none]],
-         nil],
-      choice[
-        (* check — only when a recording exists *)
-        if[rec =!= none,
-           precede[coLabel["attempt_made"],
-             call["PS", phrases, pos, rec,
-               scored[evaluate[targetOf[phrases, pos], rec]]]],
-           nil],
+  if[rec === none,
+    if[pos < Length[phrases] - 1,
+      if[pos > 0,
         choice[
-          (* remove recording (and result) — only when a recording exists *)
-          if[rec =!= none,
-             precede[coLabel["clear_recording"],
-               call["PS", phrases, pos, none, none]],
-             nil],
+          precede[coLabel["clear_material"],
+            call["PS", {}, 0, none, none]],
           choice[
-            (* next — guarded by upper bound *)
-            if[pos < Length[phrases] - 1,
-               precede[coLabel["next_item_requested"],
-                 call["PS", phrases, pos + 1, none, none]],
-               nil],
+            precede[coLabel["recording_made", binding[audio]],
+              call["PS", phrases, pos, recorded[audio], none]],
             choice[
-              (* prev — guarded by lower bound *)
-              if[pos > 0,
-                 precede[coLabel["prev_item_requested"],
-                   call["PS", phrases, pos - 1, none, none]],
-                 nil],
+              precede[coLabel["next_item_requested"],
+                call["PS", phrases, pos + 1, none, none]],
               choice[
-                (* jump to any item the selectbox offers *)
+                precede[coLabel["prev_item_requested"],
+                  call["PS", phrases, pos - 1, none, none]],
                 precede[coLabel["select_item", binding[i]],
-                  call["PS", phrases, i, none, none]],
-                (* capture a word to vocab when a result exists.
-                   (multi-word & authenticated is a STUBBED guard
-                   refinement — isMultiWord[targetOf[...]] — deferred to
-                   the function-recovery pass; modelled here on the
-                   resolvable `result present` condition.)
-                   Cross-component: composes with VocabStore.add. *)
-                (* CROSS-COMPONENT (composition refinement): the user gives a
-                   word (capture_vocab), which is then relayed to VocabStore
-                   on internal channel vAdd. Restricted in MioCore. *)
-                if[res =!= none,
-                   precede[coLabel["capture_vocab", binding[word]],
-                     precede[label["vAdd", param[word]],
-                       call["PS", phrases, pos, rec, res]]],
-                   nil]]]]]]]]]
+                  call["PS", phrases, i, none, none]]]]]],
+        choice[
+          precede[coLabel["clear_material"],
+            call["PS", {}, 0, none, none]],
+          choice[
+            precede[coLabel["recording_made", binding[audio]],
+              call["PS", phrases, pos, recorded[audio], none]],
+            choice[
+              precede[coLabel["next_item_requested"],
+                call["PS", phrases, pos + 1, none, none]],
+              precede[coLabel["select_item", binding[i]],
+                call["PS", phrases, i, none, none]]]]],
+      if[pos > 0,
+        choice[
+          precede[coLabel["clear_material"],
+            call["PS", {}, 0, none, none]],
+          choice[
+            precede[coLabel["recording_made", binding[audio]],
+              call["PS", phrases, pos, recorded[audio], none]],
+            choice[
+              precede[coLabel["prev_item_requested"],
+                call["PS", phrases, pos - 1, none, none]],
+              precede[coLabel["select_item", binding[i]],
+                call["PS", phrases, i, none, none]]]]],
+        choice[
+          precede[coLabel["clear_material"],
+            call["PS", {}, 0, none, none]],
+          choice[
+            precede[coLabel["recording_made", binding[audio]],
+              call["PS", phrases, pos, recorded[audio], none]],
+            precede[coLabel["select_item", binding[i]],
+              call["PS", phrases, i, none, none]]]])),
+    if[res === none,
+      if[pos < Length[phrases] - 1,
+        if[pos > 0,
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["next_item_requested"],
+                    call["PS", phrases, pos + 1, none, none]],
+                  choice[
+                    precede[coLabel["prev_item_requested"],
+                      call["PS", phrases, pos - 1, none, none]],
+                    precede[coLabel["select_item", binding[i]],
+                      call["PS", phrases, i, none, none]]]]]],
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["next_item_requested"],
+                    call["PS", phrases, pos + 1, none, none]],
+                  precede[coLabel["select_item", binding[i]],
+                    call["PS", phrases, i, none, none]]]]]),
+        if[pos > 0,
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["prev_item_requested"],
+                    call["PS", phrases, pos - 1, none, none]],
+                  precede[coLabel["select_item", binding[i]],
+                    call["PS", phrases, i, none, none]]]]]),
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                precede[coLabel["select_item", binding[i]],
+                  call["PS", phrases, i, none, none]]]]])),
+      if[pos < Length[phrases] - 1,
+        if[pos > 0,
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["capture_vocab", binding[word]],
+                    precede[label["vAdd", param[word]],
+                      call["PS", phrases, pos, rec, res]]],
+                  choice[
+                    precede[coLabel["next_item_requested"],
+                      call["PS", phrases, pos + 1, none, none]],
+                    choice[
+                      precede[coLabel["prev_item_requested"],
+                        call["PS", phrases, pos - 1, none, none]],
+                      precede[coLabel["select_item", binding[i]],
+                        call["PS", phrases, i, none, none]]]]]]],
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["capture_vocab", binding[word]],
+                    precede[label["vAdd", param[word]],
+                      call["PS", phrases, pos, rec, res]]],
+                  choice[
+                    precede[coLabel["next_item_requested"],
+                      call["PS", phrases, pos + 1, none, none]],
+                    precede[coLabel["select_item", binding[i]],
+                      call["PS", phrases, i, none, none]]]]]]),
+        if[pos > 0,
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["capture_vocab", binding[word]],
+                    precede[label["vAdd", param[word]],
+                      call["PS", phrases, pos, rec, res]]],
+                  choice[
+                    precede[coLabel["prev_item_requested"],
+                      call["PS", phrases, pos - 1, none, none]],
+                    precede[coLabel["select_item", binding[i]],
+                      call["PS", phrases, i, none, none]]]]]]),
+          choice[
+            precede[coLabel["clear_material"],
+              call["PS", {}, 0, none, none]],
+            choice[
+              precede[coLabel["attempt_made"],
+                call["PS", phrases, pos, rec,
+                  scored[evaluate[targetOf[phrases, pos], rec]]]],
+              choice[
+                precede[coLabel["clear_recording"],
+                  call["PS", phrases, pos, none, none]],
+                choice[
+                  precede[coLabel["capture_vocab", binding[word]],
+                    precede[label["vAdd", param[word]],
+                      call["PS", phrases, pos, rec, res]]],
+                  precede[coLabel["select_item", binding[i]],
+                    call["PS", phrases, i, none, none]]]]]))))]

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -31,7 +31,7 @@
      editing : none | editing[id]   (which row is in inline edit-mode)
 
    VERIFIED on the engine (2026-05-30): ready sets track every mode.
-   RECOVERED READY SETS (view!, afforded! in every mode):
+   RECOVERED READY SETS (analysis only; not explicit channels in the process):
      VS[anon,      _, _,_,_ ]          Anon     : (none)
      VS[signedIn, {}, _,none,none]     Empty    : add, import_bulk,
                                                   set_sort, set_filter
@@ -45,65 +45,95 @@
    ===================================================================== *)
 
 
-(* --- discipline ports + auth gate --- *)
+(* --- top level: view + auth gate --- *)
 defineAgent["VS", {auth, entries, sort, filter, editing},
-  choice[
-    precede[label["view", param[vocabView[auth, entries, sort, filter, editing]]],
-      call["VS", auth, entries, sort, filter, editing]],
+  if[auth === signedIn,
     choice[
-      precede[label["afforded", param[portsOf[call["VS", auth, entries, sort, filter, editing]]]],
+      precede[label["view", param[vocabView[auth, entries, sort, filter, editing]]],
         call["VS", auth, entries, sort, filter, editing]],
-      (* AUTH gate: no domain ports until signed in *)
-      if[auth === signedIn,
-         call["VSAuthed", entries, sort, filter, editing],
-         nil]]]]
+      call["VSAuthed", entries, sort, filter, editing]],
+    precede[label["view", param[vocabView[auth, entries, sort, filter, editing]]],
+      call["VS", auth, entries, sort, filter, editing]])]
 
 
-(* --- always-available CRUD-in + non-empty dispatch (signed in) --- *)
+(* --- signed in: always-available CRUD-in, then non-empty refinement --- *)
 defineAgent["VSAuthed", {entries, sort, filter, editing},
-  choice[
-    precede[coLabel["add", binding[w]],
-      call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
+  if[Length[entries] == 0,
     choice[
-      (* CROSS-COMPONENT (composition refinement): receive a word relayed
-         from PracticeSession's capture_vocab on internal channel vAdd.
-         Restricted in MioCore. *)
-      precede[coLabel["vAdd", binding[w]],
+      precede[coLabel["add", binding[w]],
         call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
       choice[
-      precede[coLabel["import_bulk", binding[f]],
-        call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
-      choice[
-        precede[coLabel["set_sort", binding[s]],
-          call["VS", signedIn, entries, s, filter, editing]],
+        (* CROSS-COMPONENT (composition refinement): receive a word relayed
+           from PracticeSession's capture_vocab on internal channel vAdd.
+           Restricted in MioCore. *)
+        precede[coLabel["vAdd", binding[w]],
+          call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
         choice[
-          precede[coLabel["set_filter", binding[q]],
-            call["VS", signedIn, entries, sort, filterBy[q], editing]],
-          (* per-entry ops + export + practise only when non-empty *)
-          if[Length[entries] == 0,
-             nil,
-             call["VSNonEmpty", entries, sort, filter, editing]]]]]]]]
-
-
-(* --- non-empty: export, guarded practise, and the edit-mode swap --- *)
-defineAgent["VSNonEmpty", {entries, sort, filter, editing},
-  choice[
-    precede[label["export", param[exportCsv[entries]]],
-      call["VS", signedIn, entries, sort, filter, editing]],
+          precede[coLabel["import_bulk", binding[f]],
+            call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
+          choice[
+            precede[coLabel["set_sort", binding[s]],
+              call["VS", signedIn, entries, s, filter, editing]],
+            precede[coLabel["set_filter", binding[q]],
+              call["VS", signedIn, entries, sort, filterBy[q], editing]])]]],
     choice[
-      (* "Practise these" — guard: a filter is set. CROSS-COMPONENT
-         (composition refinement): on the user's click, relay the filtered
-         phrase list to PracticeSession on internal channel pLoad.
-         Restricted in MioCore. *)
-      if[filter =!= none,
-         precede[coLabel["practise_filtered"],
-           precede[label["pLoad", param[practiseList[entries, filter]]],
-             call["VS", signedIn, entries, sort, filter, editing]]],
-         nil],
-      (* per-entry actions, swapped by edit-mode *)
-      if[editing === none,
-         call["VSEntryActions", entries, sort, filter],
-         call["VSEditActions", entries, sort, filter, editing]]]]]
+      precede[coLabel["add", binding[w]],
+        call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
+      choice[
+        (* CROSS-COMPONENT (composition refinement): receive a word relayed
+           from PracticeSession's capture_vocab on internal channel vAdd.
+           Restricted in MioCore. *)
+        precede[coLabel["vAdd", binding[w]],
+          call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
+        choice[
+          precede[coLabel["import_bulk", binding[f]],
+            call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
+          choice[
+            precede[coLabel["set_sort", binding[s]],
+              call["VS", signedIn, entries, s, filter, editing]],
+            choice[
+              precede[coLabel["set_filter", binding[q]],
+                call["VS", signedIn, entries, sort, filterBy[q], editing]],
+              call["VSNonEmpty", entries, sort, filter, editing]]])])])]
+
+
+(* --- non-empty: export always; filter and edit-mode refine the branch --- *)
+defineAgent["VSNonEmpty", {entries, sort, filter, editing},
+  if[filter === none,
+    if[editing === none,
+      choice[
+        precede[label["export", param[exportCsv[entries]]],
+          call["VS", signedIn, entries, sort, filter, editing]],
+        call["VSEntryActions", entries, sort, filter]],
+      choice[
+        precede[label["export", param[exportCsv[entries]]],
+          call["VS", signedIn, entries, sort, filter, editing]],
+        call["VSEditActions", entries, sort, filter, editing]]),
+    if[editing === none,
+      choice[
+        precede[label["export", param[exportCsv[entries]]],
+          call["VS", signedIn, entries, sort, filter, editing]],
+        choice[
+          (* "Practise these" — guard: a filter is set. CROSS-COMPONENT
+             (composition refinement): on the user's click, relay the filtered
+             phrase list to PracticeSession on internal channel pLoad.
+             Restricted in MioCore. *)
+          precede[coLabel["practise_filtered"],
+            precede[label["pLoad", param[practiseList[entries, filter]]],
+              call["VS", signedIn, entries, sort, filter, editing]]],
+          call["VSEntryActions", entries, sort, filter]]],
+      choice[
+        precede[label["export", param[exportCsv[entries]]],
+          call["VS", signedIn, entries, sort, filter, editing]],
+        choice[
+          (* "Practise these" — guard: a filter is set. CROSS-COMPONENT
+             (composition refinement): on the user's click, relay the filtered
+             phrase list to PracticeSession on internal channel pLoad.
+             Restricted in MioCore. *)
+          precede[coLabel["practise_filtered"],
+            precede[label["pLoad", param[practiseList[entries, filter]]],
+              call["VS", signedIn, entries, sort, filter, editing]]],
+          call["VSEditActions", entries, sort, filter, editing]])))]
 
 
 (* --- per-entry actions when NOT editing --- *)
@@ -121,7 +151,7 @@ defineAgent["VSEntryActions", {entries, sort, filter},
         precede[coLabel["autofill", binding[id]],
           call["VS", signedIn, autofillIn[entries, id], sort, filter, none]],
         precede[coLabel["begin_edit", binding[id]],
-          call["VS", signedIn, entries, sort, filter, editing[id]]]]]]]
+          call["VS", signedIn, entries, sort, filter, editing[id]]]]]])]
 
 
 (* --- per-entry actions WHILE editing a row --- *)
@@ -130,4 +160,4 @@ defineAgent["VSEditActions", {entries, sort, filter, editing},
     precede[coLabel["update", binding[fields]],
       call["VS", signedIn, updateEntry[entries, editing, fields], sort, filter, none]],
     precede[coLabel["cancel_edit"],
-      call["VS", signedIn, entries, sort, filter, none]]]]
+      call["VS", signedIn, entries, sort, filter, none]])]

--- a/spec/docs/afforded-guard-normal-form-handoff.md
+++ b/spec/docs/afforded-guard-normal-form-handoff.md
@@ -1,0 +1,126 @@
+# Handoff: remove `afforded`, use guard-partitioned normal form
+
+## Scope
+
+This branch prepares handoff notes for continuing the recovered spec rewrite on top of `claude/spec`.
+
+Target repository: `fairflow/miolingo`  
+Target PR base: `claude/spec`  
+Working branch: `remove-afforded-guard-normal-form-notes`
+
+## Core decisions from the chat
+
+### 1. Remove `afforded` from the object-level process model
+
+`afforded` should not be represented as an explicit action/channel in the spec.
+
+Reasoning:
+- It is observational/UI-derived metadata, not a state transition.
+- It duplicates information already present in guards.
+- Any compilation from IO actions to code would also need to resolve `afforded`, which adds unnecessary complexity.
+- Enabledness/readiness can be calculated on the fly from the current process state and guards.
+
+Project principle:
+
+> `portsOf` belongs to analysis, not operational semantics.
+
+### 2. Prefer outer-guard / guard-partitioned normal form
+
+Published specs should prefer outermost `if[...]` case splits over embedded degenerate conditionals.
+
+Desired style:
+- principal state predicates are hoisted outward
+- branches contain only meaningful behaviors
+- avoid inert `nil` branches in published specs
+
+Suggested project-local term:
+- **guard-partitioned normal form**
+- or **outer-guard normal form**
+
+### 3. Avoid degenerate conditionals in written specs
+
+The user explicitly requested removal of forms like:
+- `if[c, X, nil]`
+- `if[c, nil, Y]`
+
+These may exist as desugaring internally, but should not appear in the final handoff/public spec form.
+
+### 4. Wolfram syntax correctness matters
+
+A previous draft had mismatched `if[...]` brackets.
+
+Any follow-up agent must ensure:
+- all `if[...]`, `choice[...]`, `precede[...]`, `call[...]` forms are syntactically balanced
+- bracket structure is valid Wolfram Language syntax
+- comments remain outside syntax-critical forms unless deliberately placed
+
+## Structural-congruence guidance discussed
+
+Two rewrite laws were discussed as the motivating algebraic basis:
+
+1. Choice identity:
+   - `P + 0 = P = 0 + P`
+
+2. Conditional distribution over choice:
+   - `if[c, P, Q] + R = if[c, P + R, Q + R]`
+
+These motivate hoisting guards outward until the written form is a case split over real branches, instead of sums containing `if[..., ..., nil]` fragments.
+
+## Concrete rewrite intent for the recovered agents
+
+### PracticeSessionRecovered.wl
+
+Required rewrite goals:
+- remove `afforded`
+- preserve `view`
+- preserve cross-component `pLoad` and `capture_vocab`/`vAdd`
+- preserve the queue-empty split
+- preserve the recording/no-recording split
+- preserve bounds-sensitive `next` / `prev`
+- preserve result-sensitive `capture_vocab`
+- normalize into guard-partitioned form
+- ensure fully correct Wolfram bracket matching
+
+### VocabStoreRecovered.wl
+
+Required rewrite goals:
+- remove `afforded`
+- preserve `view`
+- preserve auth gate
+- preserve empty/non-empty split
+- preserve filter-sensitive `practise_filtered`
+- preserve edit-mode split
+- preserve cross-component `vAdd` and `pLoad`
+- normalize into guard-partitioned form
+- ensure fully correct Wolfram bracket matching
+
+## Header/comment changes requested by the chat
+
+Comments should reflect that affordance is analysis-only, not an explicit channel.
+
+Examples:
+- replace phrases like `view!, afforded! in every mode`
+- with wording like `analysis only; not explicit channels in the process`
+
+## Literature-adjacent framing noted in the chat
+
+Potentially relevant concepts:
+- guarded choice
+- normal forms for process algebra terms
+- conditional process expressions
+- symbolic operational semantics
+- readiness/enabling as derived semantics rather than explicit action
+- GSOS / structured operational semantics with premises as guards
+
+No literature lookup was requested during this handoff; this is just conceptual framing captured from the discussion.
+
+## Next step for the follow-up agent
+
+1. Verify the committed rewrites parse as valid Wolfram Language.
+2. If needed, simplify duplicated branches while preserving the no-degenerate-`if` presentation goal.
+3. Open a PR from `remove-afforded-guard-normal-form-notes` to `claude/spec`.
+4. In the PR description, summarize:
+   - removed explicit `afforded`
+   - adopted guard-partitioned normal form
+   - updated comments to make readiness analysis-only
+   - preserved recovered behavior and cross-component ports


### PR DESCRIPTION
## Summary

This PR rewrites the recovered L1 specs to remove explicit `afforded` actions and present the agents in guard-partitioned normal form.

## Changes

- remove `afforded` from `PracticeSessionRecovered.wl`
- remove `afforded` from `VocabStoreRecovered.wl`
- treat readiness/affordance as analysis-only, not an explicit channel
- rewrite guards outward to avoid published degenerate conditionals
- preserve recovered cross-component ports (`pLoad`, `vAdd`)
- update header comments accordingly

## Rationale

`afforded` is derived UI/readiness information, not domain behavior. Keeping it as an explicit action complicates the model and any compilation path that resolves IO actions into code. Enabledness should be computed from state/guards, not reified as a channel.

The rewritten form also moves the specs toward a cleaner outer-guard / guard-partitioned normal form.