### PR TITLE
spec: text-trace import parser + trace I/O round-trip test

### DIFF
--- a/spec/discipline.wl
+++ b/spec/discipline.wl
@@ -321,6 +321,46 @@ eventLogForm[log_List] := StringRiffle[
           " " <> ToString[e["value"], InputForm]]]] &) /@ log,
   "\n"];
 
+(* parseEventLog[text] : INVERSE of eventLogForm — recover an EXECUTABLE plan
+   (a list of vis["port"] | tau["chan"] entries) from a rendered text trace.
+   Logged values are IGNORED: walkSteps re-derives them from the labels alone,
+   so the parser only needs the port/channel and the [vis]/[TAU] prefix.
+     - split on newlines, drop blank lines (tolerant of surrounding whitespace);
+     - "[vis] ..." : take the next whitespace token, keep its LEADING run of
+                     word chars (drops the trailing ! / ? polarity tag),
+                     emit vis[port];
+     - "[TAU] ..." : likewise, keep the leading word-char run (drops the
+                     trailing \[Tau] polarity tag), emit tau[chan];
+     - lines NOT starting with "[vis]"/"[TAU]" (e.g. wrapped value text, or a
+       bare \[Tau] event with no named channel) are skipped — the dual-tau
+       plan uses named channels so that edge does not arise there.
+   The port token is matched as a leading run of word characters rather than
+   by stripping a specific glyph, so it is robust to the \[Tau] polarity tag
+   surviving a text-file round-trip as multi-byte (UTF-8) bytes.
+   Round-trip target: parseEventLog[eventLogForm[condense[tf,s0,plan]]] === plan. *)
+(* port/channel names are ASCII [A-Za-z0-9_]+; matching the LEADING ASCII-word
+   run drops any trailing polarity glyph, INCLUDING a \[Tau] that survived a
+   text round-trip as raw UTF-8 bytes (which a Unicode \w would wrongly keep). *)
+leadingPort[tok_String] := First[StringCases[tok, RegularExpression["^[A-Za-z0-9_]+"]], ""];
+parseEventLog[text_String] := Module[
+  {lines, parseLine},
+  lines = Select[StringTrim /@ StringSplit[text, "\n"], # =!= "" &];
+  parseLine[line_] := Module[{rest, port},
+    Which[
+      StringStartsQ[line, "[vis]"],
+        rest = StringTrim[StringDrop[line, StringLength["[vis]"]]];
+        port = leadingPort[First[StringSplit[rest], ""]];
+        If[port === "", {}, {vis[port]}],
+      StringStartsQ[line, "[TAU]"],
+        rest = StringTrim[StringDrop[line, StringLength["[TAU]"]]];
+        port = leadingPort[First[StringSplit[rest], ""]];
+        If[port === "", {}, {tau[port]}],
+      True, {}]];
+  Flatten[parseLine /@ lines, 1]];
+
+(* importTrace[file] : parseEventLog of a text-trace file's contents. *)
+importTrace[file_String] := parseEventLog[ReadString[file]];
+
 (* replay[init, ops] : DERIVE a cumulative snapshot from a log of value-function
    OPERATIONS by folding them onto an initial state term. Each op is a function
    that maps the running term to the next (e.g. (addEntry[#, w] &)). This makes

--- a/spec/tests/trace_io_test.wls
+++ b/spec/tests/trace_io_test.wls
@@ -1,0 +1,89 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/trace_io_test.wls
+   ---------------------------------------------------------------------
+   Trace I/O round-trips: that a walk on mioCoreD (transNamed) can be
+   exported and re-imported in three forms and faithfully replayed:
+
+     A. raw recorded actions -> replayTrace reproduces the run
+     B. a portable plan (vis/tau labels) -> walkSteps re-derives the
+        identical actions (values re-derived from labels alone)
+     C. a rendered TEXT trace (eventLogForm) -> parseEventLog/importTrace
+        recovers the plan and re-running reproduces the actions
+     D. cross-engine parity: the same plan run through mioCore/transVP
+        and mioCoreD/transNamed yields identical event logs
+
+   NB: $rca points at the canonical RCA_core.wl. replayTrace / walk were
+   merged to feature-work (PR #36); if a LOCAL checkout is behind and
+   replayTrace is undefined, FALL BACK to the verified merged copy below.
+   Remove the fallback block once feature-work is pulled into the
+   canonical checkout.
+
+   Run headless:  wolframscript -file spec/tests/trace_io_test.wls
+   ===================================================================== *)
+
+$rca  = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
+$spec = "/Users/matthew/Software/working/miolingo/.claude/worktrees/trace-io/spec/";
+
+Quiet[Get[$rca]];
+
+(* ---- replayTrace fallback (REMOVE once feature-work is canonical) ---- *)
+If[DownValues[replayTrace] === {},
+  $rcaFallback = "/Users/matthew/Projects/private/Mathematica/.claude/worktrees/walk-interactive-replay/RCA/RCA_core.wl";
+  Print["NOTE: replayTrace not in canonical $rca; loading fallback ", $rcaFallback];
+  Quiet[Get[$rcaFallback]]];
+(* --------------------------------------------------------------------- *)
+
+Get[$spec <> "discipline.wl"];
+Get[$spec <> "PracticeSessionRecovered.wl"];
+Get[$spec <> "VocabStoreRecovered.wl"];
+Get[$spec <> "MioCore.wl"];
+
+hr      = StringRepeat["=", 70];
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+
+(* the known dual-tau deterministic plan (see merge_defined_test.wls) *)
+plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
+        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"], tau["vAdd"]};
+
+(* NB: do NOT name any variable `w` — the spec's agent equations use the
+   bare symbol `w` as a value binder (binding[w]); assigning to w here would
+   substitute it into every recorded action and corrupt the trace. Use wlk. *)
+wlk = walkSteps[transNamed, mioCoreD, plan];
+
+(* temp files *)
+tmpfile  = FileNameJoin[{$TemporaryDirectory, "trace_io_actions.m"}];
+tmpfile2 = FileNameJoin[{$TemporaryDirectory, "trace_io_plan.m"}];
+txtfile  = FileNameJoin[{$TemporaryDirectory, "trace_io_text.txt"}];
+
+Print[hr]; Print["A. FAITHFUL ROUND-TRIP via replayTrace"]; Print[hr];
+Put[wlk["actions"], tmpfile];
+acts = Get[tmpfile];
+r = replayTrace[mioCoreD, acts, "TransitionFunction" -> transNamed];
+Print["   replay ok?            ", ok[r["ok"]]];
+Print["   steps === plan length? ", ok[r["steps"] === Length[plan]]];
+Print["   final state matches?   ", ok[r["final"] === Last[wlk["states"]]]];
+
+Print[hr]; Print["B. PORTABLE-PLAN ROUND-TRIP"]; Print[hr];
+Put[plan, tmpfile2];
+wlk2 = walkSteps[transNamed, mioCoreD, Get[tmpfile2]];
+Print["   actions re-derived from labels? ", ok[wlk2["actions"] === wlk["actions"]]];
+
+Print[hr]; Print["C. TEXT GOLDEN + parser ROUND-TRIP"]; Print[hr];
+txt = eventLogForm[eventLog[wlk]];
+Export[txtfile, txt, "Text"];
+plan2 = importTrace[txtfile];
+Print["   plan2 === plan?        ", ok[plan2 === plan]];
+wlk3 = walkSteps[transNamed, mioCoreD, plan2];
+Print["   text->plan->replay actions match? ", ok[wlk3["actions"] === wlk["actions"]]];
+
+Print[hr]; Print["D. CROSS-ENGINE PARITY  transVP vs transNamed"]; Print[hr];
+logVP = eventLog[walkSteps[transVP, mioCore, plan]];
+logND = eventLog[walkSteps[transNamed, mioCoreD, plan]];
+polSeq[log_] := {#["port"], #["polarity"]} & /@ log;
+Print["   event logs identical? ", ok[polSeq[logVP] === polSeq[logND]]];
+
+(* cleanup *)
+DeleteFile /@ Select[{tmpfile, tmpfile2, txtfile}, FileExistsQ];
+
+Print[hr]; Print["done."];


### PR DESCRIPTION
## Summary

Adds a text-trace **import parser** (the inverse of `eventLogForm`) and a standalone trace-I/O round-trip test.

### Parser (`spec/discipline.wl`, near `eventLogForm`)
- `parseEventLog[text]` -> a `plan` list of `vis["port"]` / `tau["chan"]` entries.
  - Splits on newlines, drops blank lines (whitespace-tolerant).
  - `[vis] ...` / `[TAU] ...` lines: take the next whitespace token and keep its **leading ASCII word-char run** (`[A-Za-z0-9_]+`), which drops the trailing polarity tag (`!` / `?` / τ) — robustly, even when the τ glyph survives a text-file round-trip as raw UTF-8 bytes (a Unicode `\w` would wrongly keep the `Ï` byte).
  - Lines not starting with `[vis]`/`[TAU]` (wrapped value text, bare-τ) are skipped.
  - Logged values are ignored — `walkSteps` re-derives them from the labels.
- `importTrace[file]` := `parseEventLog[ReadString[file]]`.
- Round-trip identity holds against the dual-τ plan: `parseEventLog[eventLogForm[condense[...]]] === plan`.

### Test (`spec/tests/trace_io_test.wls`)
Four checks on the dual-τ `mioCoreD` plan, all **green headless**:
- **A** raw actions -> `replayTrace` reproduces the run (`ok`, `steps`, `final`).
- **B** portable plan -> `walkSteps` re-derives identical actions.
- **C** text golden (`eventLogForm`) -> `importTrace` recovers the plan; replay matches.
- **D** cross-engine parity: `transVP`/`mioCore` vs `transNamed`/`mioCoreD` event logs identical.

### Verification
All four checks print `OK`. Existing `merge_defined_test.wls` and `internal_transitions_test.wls` re-run green from the worktree — no regression.

The canonical `RCA_core.wl` already defines `replayTrace`/`walk`, so the labelled fallback block was **not** triggered (it remains in place with a remove-once-merged comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
