### PR TITLE
spec: logical clock for VocabStore (first_seq/last_seq, no wall-clock)

### DIFF
--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -24,14 +24,21 @@
    ===================================================================== *)
 
 
-(* --- oracles / impurity isolation -------------------------------------
-   vsNow[]   : wall-clock at capture (datetime.now, vocab.py:142). Left
-               uninterpreted: timestamps are IO, used only as opaque CSV
-               fillers here. (Comparable-time sorts noted below.)
-   vsNewId   : DB autoincrement vocab_id. Modelled DETERMINISTICALLY from
-               the current list (max existing id + 1) so the pure model is
-               testable; the real id is assigned by the store at L3. *)
-vsNewId[entries_List] := 1 + Max[Append[Cases[entries, e_ /; KeyExistsQ[e, "id"] :> e["id"]], 0]];
+(* --- derived identity + LOGICAL clock ---------------------------------
+   vsNewId    : DB autoincrement vocab_id. Modelled DETERMINISTICALLY from
+                the current list (max existing id + 1) so the pure model is
+                testable; the real id is assigned by the store at L3.
+   vsNextSeq  : the LOGICAL clock — a monotonic capture-event counter
+                derived purely from state (max last_seq + 1). It captures
+                the ONLY temporal fact miolingo actually uses: the
+                happens-before of capture events (for recent/oldest sorts).
+                NO wall-clock: no guard reads time, so the sidereal stamp
+                (datetime.now, vocab.py:142) is deliberately UNMODELLED at
+                L1 — see spec/docs/function-recovery.md §"time". Real
+                timestamps, if ever wanted, belong as annotations on stored
+                action sequences (trace coordination), not on domain state. *)
+vsNewId[entries_List]   := 1 + Max[Append[Cases[entries, e_ /; KeyExistsQ[e, "id"] :> e["id"]], 0]];
+vsNextSeq[entries_List] := 1 + Max[Append[Cases[entries, e_ /; KeyExistsQ[e, "last_seq"] :> e["last_seq"]], 0]];
 
 emptyToNull[x_]   := If[x === "" || x === Null || MissingQ[x], Null, x];
 coalesce[old_, new_] := If[old === Null || old === "" || MissingQ[old], emptyToNull[new], old];
@@ -93,12 +100,13 @@ addEntry[entries_List, w_] := Module[
       "context_before" -> emptyToNull[Lookup[a, "context_before", Null]],
       "context_line" -> emptyToNull[Lookup[a, "context_line", Null]],
       "context_after" -> emptyToNull[Lookup[a, "context_after", Null]],
-      "times_seen" -> 1, "first_seen_at" -> vsNow[], "last_seen_at" -> vsNow[],
+      "times_seen" -> 1,
+      "first_seq" -> vsNextSeq[entries], "last_seq" -> vsNextSeq[entries],
       "notes" -> Null|>],
     MapAt[
       Function[e, Module[{m = e},
-        m["times_seen"]    = m["times_seen"] + 1;
-        m["last_seen_at"]  = vsNow[];
+        m["times_seen"] = m["times_seen"] + 1;
+        m["last_seq"]   = vsNextSeq[entries];   (* advance the logical clock *)
         Scan[(m[#] = coalesce[m[#], Lookup[a, #, Null]]) &,
           {"translation", "ipa", "source_name", "url",
            "context_before", "context_line", "context_after"}];
@@ -236,20 +244,26 @@ exportCsv[entries_List] := StringRiffle[
        r["translation"], r["ipa"],
        Lookup[r, "source_language_code", Null], r["source_name"],
        r["context_before"], r["context_line"], r["context_after"],
-       Lookup[r, "times_seen", 1], r["first_seen_at"], r["last_seen_at"],
+       (* first_seen_at / last_seen_at columns kept for CSV interop with the
+          real app, but emitted empty: wall-clock is unmodelled at L1 (the
+          ordering they serve lives in first_seq/last_seq instead). *)
+       Lookup[r, "times_seen", 1], "", "",
        r["notes"], r["url"]}]]) /@ entries,
     exportCsvRow[exportCsvHeader]],
   "\n"];
 
 
 (* --- sort + filter (list_vocab order map + search; vocab.py:195) ------
-   alpha is fully recovered (by lookup key). recent/oldest order by
-   last_seen_at / first_seen_at, which are the wall-clock oracle vsNow[];
-   absent a comparable clock in the pure model they fall back to insertion
-   order (newest-last), documented as the clock-IO abstraction. *)
+   All three orders are now FAITHFUL via the logical clock (no abstraction):
+     alpha  : by lookup key (word ASC)
+     recent : last_seq DESC  (= last_seen_at DESC; a re-captured old word
+              correctly jumps to the front via its bumped last_seq)
+     oldest : first_seq ASC  (= first_seen_at ASC)
+   first_seq/last_seq are vsNextSeq capture-event counters, so this matches
+   list_vocab's ORDER BY without any wall-clock. *)
 sortEntries[entries_List, "alpha"]  := SortBy[entries, #["word"] &];
-sortEntries[entries_List, "recent"] := Reverse[entries];
-sortEntries[entries_List, "oldest"] := entries;
+sortEntries[entries_List, "recent"] := SortBy[entries, -Lookup[#, "last_seq", 0] &];
+sortEntries[entries_List, "oldest"] := SortBy[entries, Lookup[#, "first_seq", 0] &];
 sortEntries[entries_List, _]        := SortBy[entries, #["word"] &];
 
 (* filterMatch: the DEFAULT search branch (plain text = substring on word

--- a/spec/docs/function-recovery.md
+++ b/spec/docs/function-recovery.md
@@ -42,11 +42,12 @@ it as a named stub *records the recovered fact* that the operation is IO-bound.
 ### The oracles (the IO boundary, kept as stubs)
 | oracle | meaning | source |
 |---|---|---|
-| `vsNow[]` | capture wall-clock | `vocab.py:142` `datetime.now` |
 | `enrichOracle[word]` | translation + IPA enrichment | `vocab.py:70` `_enrich` (LLM + espeak) |
 | `recognisePhonemes[audio]` | ASR: audio → phoneme string | the speech-recognition step feeding `compare_phonemes` |
 
-`vsNewId[entries]` is a borderline case: the real id is a DB autoincrement (IO),
+The **wall clock** (`datetime.now`, `vocab.py:142`) was an oracle in the first
+draft but is now **eliminated**, not deferred — see §3 "time". `vsNewId[entries]`
+is a borderline case: the real id is a DB autoincrement (IO),
 but its *only* semantic requirement is uniqueness, so it is modelled
 **deterministically** as `max(existing ids)+1` — pure and testable. The store
 assigns the real id at L3; nothing in L1 depends on its value, only its
@@ -58,7 +59,7 @@ freshness.
 
 | stub (in `*Recovered.wl`) | Python source | pure core recovered | oracle / IO |
 |---|---|---|---|
-| `addEntry[entries,w]` | `capture_vocab_entry` `vocab.py:106` | upsert by lookup key: dedup, `times_seen+1`, COALESCE fill-don't-overwrite, else append | `enrichOracle` (skipped — `enrich=False` path), `vsNow`, `vsNewId` |
+| `addEntry[entries,w]` | `capture_vocab_entry` `vocab.py:106` | upsert by lookup key: dedup, `times_seen+1`, COALESCE fill-don't-overwrite, else append; stamps `first_seq`/`last_seq` (logical clock) | `enrichOracle` (skipped — `enrich=False` path); `vsNewId`/`vsNextSeq` are pure |
 | `deleteFrom[entries,id]` | `delete_vocab_entry:301` | delete by id | — |
 | `updateNotesIn[entries,idn]` | `update_vocab_notes:314` | set `notes` on id | — |
 | `updateEntry[entries,editingRow[id],fields]` | `update_vocab_entry:343` | reject non-editable keys; `display_word` must preserve lookup key; delta-merge | — |
@@ -79,17 +80,33 @@ An `entry` is an `Association` whose keys are the `vocab_entries` columns the
 domain touches, traceable to `list_vocab`'s `SELECT *` and `_render_export_csv`'s
 column list: `"id" "word"(lookup key) "display_word" "translation" "ipa"
 "source_name" "url" "context_before|line|after" "times_seen"
-"first_seen_at" "last_seen_at" "notes"`. `entries` is a `List[entry]`. `Null`
+"first_seq" "last_seq" "notes"`. (`first_seq`/`last_seq` are the logical-clock
+counters that REPLACE the schema's `first_seen_at`/`last_seen_at` wall-clock
+columns — see §"time".) `entries` is a `List[entry]`. `Null`
 encodes a Python NULL column. A practice `phrase` is `<|"text","translation",
 "ipa"|>` — exactly `vocab_as_practice_phrases`'s output, which is why
 `practiseList` (VS) directly produces a PS `phrases` queue: that is the `pLoad`
 relay made concrete.
 
 ### Documented abstractions (where the pure model is honestly weaker)
-- **Time.** `first_seen_at`/`last_seen_at` are `vsNow[]` (opaque). The `recent`/
-  `oldest` sorts therefore fall back to insertion order (newest-last) rather
-  than a real clock comparison; `alpha` is fully faithful. Recorded here, not
-  silently dropped (SPEC-RECOVERY §1).
+- **Time — LOGICAL clock, no wall clock.** No guard in the spec reads time:
+  it is passive data (stored, sorted-by, exported), never a control input. So
+  rather than model a wall clock (an async clock *agent* would force a
+  request/block/receive/resume handshake and a train of τ's to fetch a value
+  that only lands in a data field; timed CCS is for when *delay/deadline*
+  gates behaviour — it doesn't here), we keep only the one temporal fact the
+  app actually uses: the **happens-before of capture events**. That is a
+  **logical clock** — `vsNextSeq` (monotonic `max(last_seq)+1`, derived purely
+  from state, like `vsNewId`). `addEntry` stamps a new entry
+  `first_seq=last_seq=next` and, on a re-capture bump, advances `last_seq`.
+  Then `recent` = `last_seq DESC` and `oldest` = `first_seq ASC` — **fully
+  faithful** to `list_vocab`'s ordering (a re-seen old word correctly jumps to
+  "recent" via its bumped `last_seq`), with no IO. This is more faithful AND
+  cheaper than the wall clock, which is *eliminated*. The sidereal timestamp is
+  reserved for a possible future use — annotating **stored action sequences**
+  (trace coordination / replay for testing) — never domain state. `exportCsv`
+  keeps the `first_seen_at`/`last_seen_at` columns for CSV interop with the real
+  app but emits them empty.
 - **Search.** `practiseList`/`vocabView` filtering implements only the default
   branch (plain text = substring on word OR translation). The `vocab_search`
   mini-language is a separate module and a separate recovery task.

--- a/spec/tests/functions_test.wls
+++ b/spec/tests/functions_test.wls
@@ -1,9 +1,11 @@
 #!/usr/bin/env wolframscript
 (* function-recovery pass — golden cases for VS + PS value-functions,
    checked against behaviour stated in the Python docstrings (NOT a live DB).
-   Loads the WORKTREE copies directly. *)
+   Spec files load RELATIVE to this test's location (tests/.. = spec/), so the
+   test runs unchanged in a worktree OR after merge into the canonical spec.
+   Only the shared engine path is absolute. *)
 
-$wt = "/Users/matthew/Software/working/miolingo/.claude/worktrees/function-recovery/spec/";
+$wt = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
 Quiet[Get["/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl"]];
 Get[$wt <> "discipline.wl"];
 Get[$wt <> "PracticeSessionRecovered.wl"];
@@ -88,6 +90,20 @@ Print["  importInto target mismatch -> no-op? ",
 (* missing header -> no-op *)
 Print["  importInto missing header -> no-op? ",
   ok[importInto[{}, <|"contents" -> "chat|cat", "expectedTarget" -> "en"|>] === {}]];
+
+(* logical clock: recent/oldest order by last_seq/first_seq, bump-aware *)
+lc0 = addEntry[addEntry[{}, "alpha"], "beta"];   (* alpha older, beta newer *)
+Print["  oldest = capture order [alpha,beta]? ",
+  ok[#["word"] & /@ sortEntries[lc0, "oldest"] === {"alpha", "beta"}]];
+Print["  recent = reverse [beta,alpha]? ",
+  ok[#["word"] & /@ sortEntries[lc0, "recent"] === {"beta", "alpha"}]];
+lc1 = addEntry[lc0, "alpha"];                    (* re-capture alpha: bump *)
+Print["  recent after re-capturing alpha -> [alpha,beta]? ",
+  ok[#["word"] & /@ sortEntries[lc1, "recent"] === {"alpha", "beta"}]];
+Print["  oldest unchanged after bump -> [alpha,beta]? ",
+  ok[#["word"] & /@ sortEntries[lc1, "oldest"] === {"alpha", "beta"}]];
+Print["  no wall-clock keys on entries? ",
+  ok[FreeQ[lc1, "first_seen_at" | "last_seen_at" | _vsNow]]];
 
 (* practiseList: filter + shape to {text,translation,ipa} *)
 pl = practiseList[ei, none];


### PR DESCRIPTION
Replaces the wall-clock oracle in the VocabStore value-functions with a **pure logical clock**, per the discussion: time in miolingo is passive data (no guard reads it), so an async clock *agent* (request/block/receive/resume + τ's) or timed CCS would be modelling machinery for a problem we don't have. We keep only the temporal fact the app actually uses — the **happens-before of capture events**.

## Changes (`VocabStoreFunctions.wl`)
- `vsNextSeq[entries]` = `max(last_seq)+1`, derived purely from state (like `vsNewId`). `addEntry` stamps a new entry `first_seq=last_seq=next`; a re-capture bump advances `last_seq`.
- `sortEntries`: `recent` = `last_seq DESC`, `oldest` = `first_seq ASC` — now **fully faithful** to `list_vocab` (a re-seen old word correctly jumps to "recent" via its bumped `last_seq`). Previously these fell back to insertion order. `alpha` unchanged.
- `exportCsv` keeps the `first_seen_at`/`last_seen_at` columns for CSV interop but emits them empty (wall-clock unmodelled).
- `vsNow` removed. Real timestamps **reserved** for a possible future use — annotating stored *action sequences* (trace coordination / replay), never domain state.

## Docs / tests
- `function-recovery.md` §"time" rewritten: the logical clock replaces the documented insertion-order abstraction; wall clock eliminated, not deferred.
- `functions_test.wls`: +5 bump-aware ordering / no-wall-clock cases (**30 OK** headless). Spec loads are now **relative to the test location** (`tests/.. = spec/`), so the suite runs unchanged in a worktree *or* after merge into canonical — fixes a latent absolute-path trap.

Engine untouched. Not merged — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)