### PR TITLE
spec: centralise load paths + engine-divergence guard (spec/paths.wl)

### DIFF
--- a/spec/MiolingoSpec.wl
+++ b/spec/MiolingoSpec.wl
@@ -3,8 +3,8 @@
 (* =====================================================================
    MiolingoSpec.wl — single entry point: load the whole L1 spec in order.
    ---------------------------------------------------------------------
-   ONE Get loads everything:
-       Get["/Users/matthew/Software/working/miolingo/spec/MiolingoSpec.wl"]
+   ONE Get loads everything (from anywhere — it self-locates):
+       Get[".../spec/MiolingoSpec.wl"]
 
    It (re)loads the ENGINE first, then the spec files in dependency order.
    Loading the engine first is deliberate: it pins the NATIVE engine
@@ -14,7 +14,10 @@
    embedded engine would fail to step them. Getting RCA_core also resets
    agentDefs, so this is a clean full reload every time.
 
-   NB: nested Gets are fine in WL. Adjust $rca if RCA_core.wl moves.
+   Paths + engine version come from spec/paths.wl (loaded relative to this
+   file). The engine path is $RCA_CORE (env) or its canonical default, and
+   loadEngine[] aborts if the engine checkout is behind the version this
+   spec requires — see paths.wl. NB: nested Gets are fine in WL.
 
    What is loaded (and what is NOT):
      RCA_core.wl                  the CCS engine (feature-work, native)
@@ -32,16 +35,13 @@
      buildSystem[call["PS", {p1,p2}, 0, none, none]]   (* canonical mu-term *)
    ===================================================================== *)
 
-$rca   = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
-$mlspec = "/Users/matthew/Software/working/miolingo/spec/";
+Get[FileNameJoin[{DirectoryName[$InputFileName], "paths.wl"}]];
 
-Get[$rca];
-Get[$mlspec <> "discipline.wl"];
-Get[$mlspec <> "PracticeSessionRecovered.wl"];
-Get[$mlspec <> "VocabStoreRecovered.wl"];
+loadEngine[];
+loadRecoveredBase[];
 (* function-recovery pass: give the stubbed value-functions bodies recovered
    from the Python. ADDITIVE — loaded after the recovered agents, attaches
    downvalues only. See spec/docs/function-recovery.md. *)
-Get[$mlspec <> "VocabStoreFunctions.wl"];
-Get[$mlspec <> "PracticeSessionFunctions.wl"];
-Get[$mlspec <> "MioCore.wl"];
+mioGet["VocabStoreFunctions.wl"];
+mioGet["PracticeSessionFunctions.wl"];
+mioGet["MioCore.wl"];

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -1,0 +1,77 @@
+(* =====================================================================
+   spec/paths.wl — single source of truth for load paths + engine version
+   ---------------------------------------------------------------------
+   Every test (.wls) and MiolingoSpec.wl Gets THIS FIRST, located relative
+   to its own file (so it is correct in any worktree, with no hardcoded
+   absolute path to update):
+
+       (* a file IN spec/ *)
+       Get[FileNameJoin[{DirectoryName[$InputFileName], "paths.wl"}]];
+
+       (* a test in spec/tests/ *)
+       Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]],
+                         "paths.wl"}]];
+
+   It then provides:
+     $specDir            this spec directory, derived from THIS file's own
+                         location — never hardcode the spec path again
+     $rca                the engine path: the $RCA_CORE env var if set,
+                         else the canonical checkout. One place; override
+                         via the environment (e.g. a different worktree)
+     mioGet[file]        Get a spec file by name, relative to $specDir
+     loadEngine[]        Get the engine AND assert the checkout is not
+                         behind the version this spec requires — a loud
+                         failure that replaces the old hand-rolled
+                         worktree fallback
+     loadRecoveredBase[] discipline.wl + the two Recovered agents, in load
+                         order (the common base every consumer loads first)
+
+   DIVERGENCE GUARD ($minEngineSha): the engine (RCA_core.wl) is co-developed
+   in a SEPARATE repo. This records the oldest engine commit whose features
+   this spec depends on; loadEngine[] aborts if the engine checkout does not
+   contain it (instead of silently running against the wrong engine, or
+   reaching sideways into a feature worktree as the tests used to). When you
+   adopt new engine capability, bump this in the SAME spec PR that uses it —
+   that one line is the shared coordinate between the two co-developed repos,
+   so neither has to be branched in lockstep with the other.
+   ===================================================================== *)
+
+$specDir = DirectoryName[$InputFileName] <> "/";
+
+$rca = With[{e = Environment["RCA_CORE"]},
+  If[StringQ[e] && e =!= "", e,
+     "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl"]];
+
+(* Oldest engine commit this spec requires — PR #36 (walk + replayTrace),
+   which descends from native guard/choice (#33), substVv guard-ground (#34)
+   and transNamed[relabel] (#35). Bump when adopting newer engine capability. *)
+$minEngineSha = "5bcc031";
+
+mioGet[file_String] := Get[$specDir <> file];
+
+loadEngine[] := Module[{engineDir, res, exit},
+  Quiet[Get[$rca]];
+  engineDir = DirectoryName[$rca];
+  res = RunProcess[{"git", "-C", engineDir,
+                    "merge-base", "--is-ancestor", $minEngineSha, "HEAD"}];
+  exit = res["ExitCode"];
+  Which[
+    exit === 0,
+      Print["  engine OK: ", engineDir, " contains required ", $minEngineSha],
+    exit === 1,
+      (Print["*** ENGINE DIVERGENCE ***"];
+       Print["    engine checkout at ", engineDir];
+       Print["    does NOT contain required commit ", $minEngineSha,
+             " (PR #36: walk/replayTrace)."];
+       Print["    Update the engine checkout, or point $RCA_CORE at one that",
+             " has it. Aborting."];
+       Exit[1]),
+    True,
+      Print["  WARN: could not verify engine version (git exit ", exit, "): ",
+            res["StandardError"], " — proceeding unchecked."]
+  ]];
+
+loadRecoveredBase[] := (
+  mioGet["discipline.wl"];
+  mioGet["PracticeSessionRecovered.wl"];
+  mioGet["VocabStoreRecovered.wl"]);

--- a/spec/tests/composition_test.wls
+++ b/spec/tests/composition_test.wls
@@ -15,16 +15,13 @@
    so always reload the spec files after, exactly as below).
    ===================================================================== *)
 
-$rca = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
-$spec = "/Users/matthew/Software/working/miolingo/spec/";
+Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
 
 Print["Loading engine + spec (order matters: discipline before components,",
       " components before MioCore) ..."];
-Quiet[Get[$rca]];
-Get[$spec <> "discipline.wl"];
-Get[$spec <> "PracticeSessionRecovered.wl"];
-Get[$spec <> "VocabStoreRecovered.wl"];
-Get[$spec <> "MioCore.wl"];
+loadEngine[];
+loadRecoveredBase[];
+mioGet["MioCore.wl"];
 
 bar = StringRepeat["=", 64];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];

--- a/spec/tests/data_view_test.wls
+++ b/spec/tests/data_view_test.wls
@@ -20,14 +20,11 @@
    Run headless:  wolframscript -file spec/tests/data_view_test.wls
    ===================================================================== *)
 
-$rca  = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
-$spec = "/Users/matthew/Software/working/miolingo/spec/";
+Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
 
-Quiet[Get[$rca]];
-Get[$spec <> "discipline.wl"];
-Get[$spec <> "PracticeSessionRecovered.wl"];
-Get[$spec <> "VocabStoreRecovered.wl"];
-Get[$spec <> "MioCore.wl"];
+loadEngine[];
+loadRecoveredBase[];
+mioGet["MioCore.wl"];
 
 hr = StringRepeat["=", 70];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];

--- a/spec/tests/functions_test.wls
+++ b/spec/tests/functions_test.wls
@@ -1,17 +1,14 @@
 #!/usr/bin/env wolframscript
 (* function-recovery pass — golden cases for VS + PS value-functions,
    checked against behaviour stated in the Python docstrings (NOT a live DB).
-   Spec files load RELATIVE to this test's location (tests/.. = spec/), so the
-   test runs unchanged in a worktree OR after merge into the canonical spec.
-   Only the shared engine path is absolute. *)
+   Paths + engine version come from spec/paths.wl, located relative to this
+   test, so it runs unchanged in any worktree or the canonical spec. *)
 
-$wt = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
-Quiet[Get["/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl"]];
-Get[$wt <> "discipline.wl"];
-Get[$wt <> "PracticeSessionRecovered.wl"];
-Get[$wt <> "VocabStoreRecovered.wl"];
-Get[$wt <> "VocabStoreFunctions.wl"];
-Get[$wt <> "PracticeSessionFunctions.wl"];
+Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
+loadEngine[];
+loadRecoveredBase[];
+mioGet["VocabStoreFunctions.wl"];
+mioGet["PracticeSessionFunctions.wl"];
 
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 

--- a/spec/tests/internal_transitions_test.wls
+++ b/spec/tests/internal_transitions_test.wls
@@ -23,14 +23,11 @@
    Run headless:  wolframscript -file spec/tests/internal_transitions_test.wls
    ===================================================================== *)
 
-$rca  = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
-$spec = "/Users/matthew/Software/working/miolingo/spec/";
+Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
 
-Quiet[Get[$rca]];
-Get[$spec <> "discipline.wl"];
-Get[$spec <> "PracticeSessionRecovered.wl"];
-Get[$spec <> "VocabStoreRecovered.wl"];
-Get[$spec <> "MioCore.wl"];
+loadEngine[];
+loadRecoveredBase[];
+mioGet["MioCore.wl"];
 
 hr = StringRepeat["=", 70];
 isTau[a_] := MatchQ[a, tag[\[Tau], ___]] || a === \[Tau];

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -15,21 +15,18 @@
         both vAdd and pLoad internal syncs fire
      4. the visible+tau label trace agrees with merge's (transVP)
 
-   NB: $rca points at the relabel-transition-time WORKTREE (the engine
-   change is not yet merged to feature-work). After the engine PR merges,
-   revert $rca to the canonical RCA_core.wl path.
+   Engine + paths come from spec/paths.wl; loadEngine[] asserts the engine
+   checkout has the transNamed[relabel] change (#35) this test needs, via
+   the $minEngineSha guard — no more hand-pointing $rca at a worktree.
 
    Run headless:  wolframscript -file spec/tests/merge_defined_test.wls
    ===================================================================== *)
 
-$rca  = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
-$spec = "/Users/matthew/Software/working/miolingo/spec/";
+Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
 
-Quiet[Get[$rca]];
-Get[$spec <> "discipline.wl"];
-Get[$spec <> "PracticeSessionRecovered.wl"];
-Get[$spec <> "VocabStoreRecovered.wl"];
-Get[$spec <> "MioCore.wl"];
+loadEngine[];
+loadRecoveredBase[];
+mioGet["MioCore.wl"];
 
 hr = StringRepeat["=", 70];
 ok[b_]      := If[TrueQ[b], "OK", "*** FAIL ***"];

--- a/spec/tests/trace_io_test.wls
+++ b/spec/tests/trace_io_test.wls
@@ -13,31 +13,19 @@
      D. cross-engine parity: the same plan run through mioCore/transVP
         and mioCoreD/transNamed yields identical event logs
 
-   NB: $rca points at the canonical RCA_core.wl. replayTrace / walk were
-   merged to feature-work (PR #36); if a LOCAL checkout is behind and
-   replayTrace is undefined, FALL BACK to the verified merged copy below.
-   Remove the fallback block once feature-work is pulled into the
-   canonical checkout.
+   replayTrace / walk need engine PR #36; loadEngine[] (spec/paths.wl) asserts
+   the engine checkout contains it via the $minEngineSha guard and aborts with
+   a clear message if not — replacing the old hand-rolled fallback that reached
+   into a feature worktree.
 
    Run headless:  wolframscript -file spec/tests/trace_io_test.wls
    ===================================================================== *)
 
-$rca  = "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl";
-$spec = "/Users/matthew/Software/working/miolingo/.claude/worktrees/trace-io/spec/";
+Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
 
-Quiet[Get[$rca]];
-
-(* ---- replayTrace fallback (REMOVE once feature-work is canonical) ---- *)
-If[DownValues[replayTrace] === {},
-  $rcaFallback = "/Users/matthew/Projects/private/Mathematica/.claude/worktrees/walk-interactive-replay/RCA/RCA_core.wl";
-  Print["NOTE: replayTrace not in canonical $rca; loading fallback ", $rcaFallback];
-  Quiet[Get[$rcaFallback]]];
-(* --------------------------------------------------------------------- *)
-
-Get[$spec <> "discipline.wl"];
-Get[$spec <> "PracticeSessionRecovered.wl"];
-Get[$spec <> "VocabStoreRecovered.wl"];
-Get[$spec <> "MioCore.wl"];
+loadEngine[];
+loadRecoveredBase[];
+mioGet["MioCore.wl"];
 
 hr      = StringRepeat["=", 70];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];


### PR DESCRIPTION
## Why

The spec and the RCA **engine** (`RCA_core.wl`) are co-developed in **separate repos**. The spec coupled to the engine through **~14 hardcoded absolute paths across 7 files**, in three inconsistent conventions (main checkout / a named worktree / relative), with **no version check**. Consequences:

- A green test proved nothing durable — it silently depended on whatever the engine working tree happened to be.
- Divergence surfaced as a hand-rolled `$rcaFallback` block in `trace_io_test` reaching **sideways into an engine feature worktree** to find `replayTrace`.
- Every new worktree meant editing those path literals.

This targets **divergence** (the real risk) without vendoring, file moves, or branching the two repos in lockstep.

## What

New **`spec/paths.wl`** — single source of truth, `Get`-ed relative to each consumer's own `$InputFileName` (correct in any worktree, nothing to update):

- `$specDir` — derived from this file's location
- `$rca` — `$RCA_CORE` env var, else the canonical checkout
- `mioGet[f]`, `loadRecoveredBase[]` — relative spec loads
- `loadEngine[]` — `Get`s the engine **and** asserts (`git merge-base --is-ancestor`) that the checkout contains **`$minEngineSha`** (PR #36: walk/replayTrace), aborting loudly otherwise.

`$minEngineSha` is the **shared coordinate** between the two repos: bump it in the same spec PR that adopts new engine capability — no lockstep branching.

Repointed `MiolingoSpec.wl` + all 6 tests; deleted the `trace_io` fallback block. Fixes the latent `MiolingoSpec.wl` footgun (it loaded `.wl` files from **main** even when run from a worktree).

## Verification

All six headless tests pass. Guard exercised on all three branches:

| engine state | result |
|---|---|
| required commit present (ancestor) | `engine OK`, proceeds |
| valid commit, not an ancestor | `*** ENGINE DIVERGENCE ***`, **exit 1** |
| foreign / invalid sha (git exit 128) | `WARN … proceeding unchecked` |

No spec semantics changed — pure load-path + provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)