### PR TITLE
spec/walk: interactive Dynamic harness — drive the spec, supply real values, see computed data

### DIFF
--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -260,11 +260,14 @@ exportCsv[entries_List] := StringRiffle[
               correctly jumps to the front via its bumped last_seq)
      oldest : first_seq ASC  (= first_seen_at ASC)
    first_seq/last_seq are vsNextSeq capture-event counters, so this matches
-   list_vocab's ORDER BY without any wall-clock. *)
-sortEntries[entries_List, "alpha"]  := SortBy[entries, #["word"] &];
-sortEntries[entries_List, "recent"] := SortBy[entries, -Lookup[#, "last_seq", 0] &];
-sortEntries[entries_List, "oldest"] := SortBy[entries, Lookup[#, "first_seq", 0] &];
-sortEntries[entries_List, _]        := SortBy[entries, #["word"] &];
+   list_vocab's ORDER BY without any wall-clock.
+   The sort key is an uninterpreted Enum SYMBOL (alpha | recent | oldest), not
+   a string — matched directly, so callers pass the symbol the state carries
+   (no ToString bridge, which froze under the engine's held derivation). *)
+sortEntries[entries_List, alpha]  := SortBy[entries, #["word"] &];
+sortEntries[entries_List, recent] := SortBy[entries, -Lookup[#, "last_seq", 0] &];
+sortEntries[entries_List, oldest] := SortBy[entries, Lookup[#, "first_seq", 0] &];
+sortEntries[entries_List, _]      := SortBy[entries, #["word"] &];
 
 (* filterMatch: the DEFAULT search branch (plain text = substring on word
    OR translation, lowercased). The full vocab_search mini-language grammar
@@ -297,4 +300,4 @@ vocabView[auth_, entries_, sort_, filter_, editing_] := <|
   "sort" -> sort,
   "filter" -> filter,
   "editing" -> editing,
-  "entries" -> sortEntries[applyFilter[entries, filter], ToString[sort]]|>;
+  "entries" -> sortEntries[applyFilter[entries, filter], sort]|>;

--- a/spec/tests/functions_test.wls
+++ b/spec/tests/functions_test.wls
@@ -91,14 +91,14 @@ Print["  importInto missing header -> no-op? ",
 (* logical clock: recent/oldest order by last_seq/first_seq, bump-aware *)
 lc0 = addEntry[addEntry[{}, "alpha"], "beta"];   (* alpha older, beta newer *)
 Print["  oldest = capture order [alpha,beta]? ",
-  ok[#["word"] & /@ sortEntries[lc0, "oldest"] === {"alpha", "beta"}]];
+  ok[#["word"] & /@ sortEntries[lc0, oldest] === {"alpha", "beta"}]];
 Print["  recent = reverse [beta,alpha]? ",
-  ok[#["word"] & /@ sortEntries[lc0, "recent"] === {"beta", "alpha"}]];
+  ok[#["word"] & /@ sortEntries[lc0, recent] === {"beta", "alpha"}]];
 lc1 = addEntry[lc0, "alpha"];                    (* re-capture alpha: bump *)
 Print["  recent after re-capturing alpha -> [alpha,beta]? ",
-  ok[#["word"] & /@ sortEntries[lc1, "recent"] === {"alpha", "beta"}]];
+  ok[#["word"] & /@ sortEntries[lc1, recent] === {"alpha", "beta"}]];
 Print["  oldest unchanged after bump -> [alpha,beta]? ",
-  ok[#["word"] & /@ sortEntries[lc1, "oldest"] === {"alpha", "beta"}]];
+  ok[#["word"] & /@ sortEntries[lc1, oldest] === {"alpha", "beta"}]];
 Print["  no wall-clock keys on entries? ",
   ok[FreeQ[lc1, "first_seen_at" | "last_seen_at" | _vsNow]]];
 

--- a/spec/tests/walk_test.wls
+++ b/spec/tests/walk_test.wls
@@ -1,0 +1,84 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/walk_test.wls
+   ---------------------------------------------------------------------
+   Headless smoke test for the PURE SUBSTRATE of the walk harness
+   (spec/walk.wl): the port-input mechanic by which a human, as the open
+   environment, supplies REAL data into a ready input port and watches it
+   thread through the spec. The Dynamic widgets that sit on top are driven
+   manually in a notebook; here we prove the substrate they call.
+
+   Loads the FULL spec (MiolingoSpec.wl) so the recovered value-functions
+   (addEntry, exportCsv, ...) have bodies — otherwise inputs would thread
+   inert stubs and there would be no real data to walk through.
+
+   Run headless:  wolframscript -file spec/tests/walk_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];   (* engine + discipline + recovered + Functions + MioCore *)
+Get[$dir <> "walk.wl"];
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", lbl, " ", ok[b]]);
+byName[tf_, s_, nm_] := SelectFirst[readyTransitions[tf, s], portName[First[#]] === nm &];
+eventNamed[log_, nm_] := SelectFirst[log, ToString[#["port"]] === nm &];
+hr = StringRepeat["=", 70];
+
+Print[hr]; Print["0. full spec loaded -> value-functions compute real data"]; Print[hr];
+assert["addEntry has a body (Functions loaded)", DownValues[addEntry] =!= {}];
+assert["exportCsv of a capture yields a real data row (word 'Chat')",
+  StringContainsQ[exportCsv[addEntry[{}, <|"word" -> "Chat", "translation" -> "cat"|>]], "Chat,cat"]];
+
+Print[hr]; Print["1. readyInputs : the value-carrying ports a user can drive"]; Print[hr];
+ri = readyInputs[transVP, mioCore];
+assert["every readyInput is a value-carrying input (has a binder)",
+  AllTrue[ri, valueInputQ[First[#]] &]];
+assert["the canonical input ports are present",
+  SubsetQ[ToString /@ portName /@ First /@ ri,
+          {"add", "set_filter", "set_sort", "import_bulk", "load_material"}]];
+
+Print[hr]; Print["2. supplyValue : a string value flows into set_filter"]; Print[hr];
+sf  = byName[transVP, mioCore, "set_filter"];
+qsym = First[inputBinderOf[First[sf]]];
+sfv = supplyValue[sf, "happy"];
+assert["action becomes coLabel[set_filter, binding[\"happy\"]]",
+  MatchQ[First[sfv], coLabel[_, binding["happy"]]]];
+assert["eventOf reads the concrete value {\"happy\"}", eventOf[First[sfv]]["value"] === {"happy"}];
+assert["binder symbol no longer in successor", FreeQ[Last[sfv], qsym]];
+assert["\"happy\" threaded into successor", !FreeQ[Last[sfv], "happy"]];
+
+Print[hr]; Print["3. supplyValue : a structured value flows into add"]; Print[hr];
+ad  = byName[transVP, mioCore, "add"];
+wsym = First[inputBinderOf[First[ad]]];
+wv  = <|"word" -> "Chat", "translation" -> "cat"|>;
+adv = supplyValue[ad, wv];
+assert["word assoc threaded into successor", !FreeQ[Last[adv], wv]];
+assert["binder symbol no longer in successor", FreeQ[Last[adv], wsym]];
+assert["eventOf reads the concrete assoc value", eventOf[First[adv]]["value"] === {wv}];
+
+Print[hr]; Print["4. supplyValue is a no-op where there is nothing to supply"]; Print[hr];
+assert["value-free input (coLabel[nm]) unchanged",
+  supplyValue[{coLabel[ping], stateX}, "v"] === {coLabel[ping], stateX}];
+assert["output action unchanged",
+  supplyValue[{label[out, param[7]], stateX}, "v"] === {label[out, param[7]], stateX}];
+
+Print[hr]; Print["5. value-driven plan via walkSteps + condensed event log"]; Print[hr];
+valPlan = {vis["set_filter", "happy"], vis["add", wv]};
+symPlan = {vis["set_filter"], vis["add"]};
+valLog  = condense[transVP, mioCore, valPlan];
+symLog  = condense[transVP, mioCore, symPlan];
+assert["value plan runs to completion (not stuck)",
+  !walkSteps[transVP, mioCore, valPlan]["stuck"]];
+assert["set_filter event records \"happy\" (concrete)",
+  eventNamed[valLog, "set_filter"]["value"] === {"happy"}];
+assert["add event records the word assoc (concrete)",
+  eventNamed[valLog, "add"]["value"] === {wv}];
+assert["symbolic plan leaves set_filter value as a free symbol (contrast)",
+  MatchQ[eventNamed[symLog, "set_filter"]["value"], {_Symbol}]];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];

--- a/spec/tests/walk_test.wls
+++ b/spec/tests/walk_test.wls
@@ -3,80 +3,79 @@
    spec/tests/walk_test.wls
    ---------------------------------------------------------------------
    Headless smoke test for the PURE SUBSTRATE of the walk harness
-   (spec/walk.wl): the port-input mechanic by which a human, as the open
-   environment, supplies REAL data into a ready input port and watches it
-   thread through the spec. The Dynamic widgets that sit on top are driven
-   manually in a notebook; here we prove the substrate they call.
+   (spec/walk.wl): the port-input mechanic by which the user, as the open
+   environment, inserts a REAL value into a ready input port's binder via
+   substVv (the engine's scope-aware value substitution), so the value
+   threads into the derivative and the spec computes. The Dynamic widgets
+   on top are driven manually in a notebook.
 
-   Loads the FULL spec (MiolingoSpec.wl) so the recovered value-functions
-   (addEntry, exportCsv, ...) have bodies — otherwise inputs would thread
-   inert stubs and there would be no real data to walk through.
+   The user supplies the value; the simulator does NOT validate it — the
+   spec's own functions judge it if/when the term is concrete. So these
+   tests check the INSERTION mechanism (correct placement, scope-respect,
+   data preserved), not data validity.
+
+   Loads the FULL spec (MiolingoSpec.wl) so the value-functions have bodies.
 
    Run headless:  wolframscript -file spec/tests/walk_test.wls
    ===================================================================== *)
 
 $dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
-Get[$dir <> "MiolingoSpec.wl"];   (* engine + discipline + recovered + Functions + MioCore *)
+Get[$dir <> "MiolingoSpec.wl"];
 Get[$dir <> "walk.wl"];
 
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 allOk = True;
 assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", lbl, " ", ok[b]]);
 byName[tf_, s_, nm_] := SelectFirst[readyTransitions[tf, s], portName[First[#]] === nm &];
-eventNamed[log_, nm_] := SelectFirst[log, ToString[#["port"]] === nm &];
 hr = StringRepeat["=", 70];
 
-Print[hr]; Print["0. full spec loaded -> value-functions compute real data"]; Print[hr];
-assert["addEntry has a body (Functions loaded)", DownValues[addEntry] =!= {}];
-assert["exportCsv of a capture yields a real data row (word 'Chat')",
-  StringContainsQ[exportCsv[addEntry[{}, <|"word" -> "Chat", "translation" -> "cat"|>]], "Chat,cat"]];
-
 Print[hr]; Print["1. readyInputs : the value-carrying ports a user can drive"]; Print[hr];
-ri = readyInputs[transVP, mioCore];
+ri = readyInputs[transNamed, call["VS", signedIn, ent, alpha, none, none]];
 assert["every readyInput is a value-carrying input (has a binder)",
   AllTrue[ri, valueInputQ[First[#]] &]];
-assert["the canonical input ports are present",
-  SubsetQ[ToString /@ portName /@ First /@ ri,
-          {"add", "set_filter", "set_sort", "import_bulk", "load_material"}]];
+assert["the canonical VS input ports are present",
+  SubsetQ[ToString /@ portName /@ First /@ ri, {"add", "set_filter", "set_sort", "import_bulk"}]];
 
-Print[hr]; Print["2. supplyValue : a string value flows into set_filter"]; Print[hr];
-sf  = byName[transVP, mioCore, "set_filter"];
-qsym = First[inputBinderOf[First[sf]]];
-sfv = supplyValue[sf, "happy"];
-assert["action becomes coLabel[set_filter, binding[\"happy\"]]",
-  MatchQ[First[sfv], coLabel[_, binding["happy"]]]];
-assert["eventOf reads the concrete value {\"happy\"}", eventOf[First[sfv]]["value"] === {"happy"}];
-assert["binder symbol no longer in successor", FreeQ[Last[sfv], qsym]];
-assert["\"happy\" threaded into successor", !FreeQ[Last[sfv], "happy"]];
+Print[hr]; Print["2. supplyValue : slot binder (load_material on PS) inserts cleanly"]; Print[hr];
+lm  = byName[transNamed, call["PS", {}, 0, none, none], "load_material"];
+phr = {<|"text" -> "chat", "translation" -> "cat"|>};
+lmv = supplyValue[lm, phr];
+assert["value inserted into the PS state slot",
+  Last[lmv] === call["PS", phr, 0, none, none]];
+assert["eventOf reads the concrete value", eventOf[First[lmv]]["value"] === {phr}];
 
-Print[hr]; Print["3. supplyValue : a structured value flows into add"]; Print[hr];
-ad  = byName[transVP, mioCore, "add"];
-wsym = First[inputBinderOf[First[ad]]];
-wv  = <|"word" -> "Chat", "translation" -> "cat"|>;
+Print[hr]; Print["3. supplyValue : data preserved on a value-function port (add)"]; Print[hr];
+ad  = byName[transNamed, call["VS", signedIn, ent, alpha, none, none], "add"];
+wv  = <|"word" -> "Chat"|>;
 adv = supplyValue[ad, wv];
-assert["word assoc threaded into successor", !FreeQ[Last[adv], wv]];
-assert["binder symbol no longer in successor", FreeQ[Last[adv], wsym]];
-assert["eventOf reads the concrete assoc value", eventOf[First[adv]]["value"] === {wv}];
+assert["binder w replaced by the value inside addEntry (data preserved)",
+  Last[adv] === call["VS", signedIn, addEntry[ent, wv], alpha, none, none]];
+assert["addEntry kept (not collapsed); entries left symbolic", !FreeQ[Last[adv], addEntry[ent, wv]]];
 
-Print[hr]; Print["4. supplyValue is a no-op where there is nothing to supply"]; Print[hr];
+Print[hr]; Print["4. substVv is SCOPE-AWARE where ReplaceAll would leak"]; Print[hr];
+(* the mu-term add derivative re-unfolds clauses that REBIND w; the supplied
+   value must NOT land in those rebound occurrences. *)
+deriv = Last[byName[transVP, mioCore, "add"]];
+assert["derivative does re-unfold clauses that rebind w (precondition)",
+  Length[Cases[deriv, binding[w], Infinity]] > 0];
+assert["substVv does NOT leak into a rebound binding",
+  Quiet[FreeQ[substVv[deriv, w -> supplied], binding[supplied]]]];
+assert["ReplaceAll WOULD leak (why we use substVv, not /.)",
+  Quiet[!FreeQ[deriv /. w -> supplied, binding[supplied]]]];
+
+Print[hr]; Print["5. supplyValue is a no-op where there is nothing to supply"]; Print[hr];
 assert["value-free input (coLabel[nm]) unchanged",
   supplyValue[{coLabel[ping], stateX}, "v"] === {coLabel[ping], stateX}];
 assert["output action unchanged",
   supplyValue[{label[out, param[7]], stateX}, "v"] === {label[out, param[7]], stateX}];
 
-Print[hr]; Print["5. value-driven plan via walkSteps + condensed event log"]; Print[hr];
-valPlan = {vis["set_filter", "happy"], vis["add", wv]};
-symPlan = {vis["set_filter"], vis["add"]};
-valLog  = condense[transVP, mioCore, valPlan];
-symLog  = condense[transVP, mioCore, symPlan];
-assert["value plan runs to completion (not stuck)",
-  !walkSteps[transVP, mioCore, valPlan]["stuck"]];
-assert["set_filter event records \"happy\" (concrete)",
-  eventNamed[valLog, "set_filter"]["value"] === {"happy"}];
-assert["add event records the word assoc (concrete)",
-  eventNamed[valLog, "add"]["value"] === {wv}];
-assert["symbolic plan leaves set_filter value as a free symbol (contrast)",
-  MatchQ[eventNamed[symLog, "set_filter"]["value"], {_Symbol}]];
+Print[hr]; Print["6. value-driven plan via walkSteps (vis[nm, val])"]; Print[hr];
+w1 = walkSteps[transNamed, call["PS", {}, 0, none, none], {vis["load_material", phr]}];
+assert["plan ran to completion (not stuck)", !w1["stuck"]];
+assert["final state carries the supplied value",
+  Last[w1["states"]] === call["PS", phr, 0, none, none]];
+assert["recorded event carries the concrete value",
+  eventOf[First[w1["actions"]]]["value"] === {phr}];
 
 Print[hr];
 Print["ALL ASSERTIONS: ", ok[allOk]];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -149,9 +149,12 @@ traceView[trace_] := Column[{
    step / back / reset. Untouched input ports step symbolically (binder
    left free), so it degrades to the plain symbolic walk.
 
-   Value entry uses InputField[..., Expression]: type a WL value, e.g.
-       "happy"                         (a string, for set_filter)
+   Value entry is a TEXT field parsed with ToExpression (so an empty field is
+   a genuinely blank box, not the literal "" / Null an Expression field shows).
+   Type a WL value, e.g.
+       "happy"                                   (a string, for set_filter)
        <|"word"->"chat","translation"->"cat"|>   (for add)
+   string values keep their quotes.
    Option "TransitionFunction" -> transVP (mioCore) | transNamed (mioCoreD).
 --------------------------------------------------------------------- *)
 Options[walkUI] = {"TransitionFunction" -> transVP};
@@ -175,8 +178,8 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                     Button[showAction[act],
                       Module[{taken},
                         taken = If[valueInputQ[act] && KeyExistsQ[inVals, nm] &&
-                                   !MatchQ[inVals[nm], Null | "" | Nothing],
-                                 supplyValue[tr, inVals[nm]], tr];
+                                   StringQ[inVals[nm]] && StringTrim[inVals[nm]] =!= "",
+                                 supplyValue[tr, ToExpression[inVals[nm]]], tr];
                         AppendTo[hist, cur];
                         AppendTo[trace, eventOf[First[taken]]];
                         cur = Last[taken]; inVals = <||>],
@@ -186,10 +189,11 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                       Row[{Spacer[6],
                            Style["\[LeftArrow] " <> ToString[First[inputBinderOf[act]]] <> " = ",
                              GrayLevel[0.5]],
-                           (* default to Nothing (a clean-empty field, not
-                              Missing[KeyAbsent] or ""); write inVals[nm] on edit *)
-                           InputField[Dynamic[Lookup[inVals, nm, Nothing], (inVals[nm] = #) &],
-                             Expression, FieldSize -> 20, ContinuousAction -> False]}],
+                           (* TEXT field: default "" renders as a blank box
+                              (an Expression field would show "" / Null / Nothing
+                              as literal text). Parsed with ToExpression on step. *)
+                           InputField[Dynamic[Lookup[inVals, nm, ""], (inVals[nm] = #) &],
+                             String, FieldSize -> 20, ContinuousAction -> False]}],
                       Nothing]}]]],
                 trans]]],
 

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -175,7 +175,7 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                     Button[showAction[act],
                       Module[{taken},
                         taken = If[valueInputQ[act] && KeyExistsQ[inVals, nm] &&
-                                   inVals[nm] =!= Null && inVals[nm] =!= "",
+                                   !MatchQ[inVals[nm], Null | "" | Nothing],
                                  supplyValue[tr, inVals[nm]], tr];
                         AppendTo[hist, cur];
                         AppendTo[trace, eventOf[First[taken]]];
@@ -186,9 +186,9 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                       Row[{Spacer[6],
                            Style["\[LeftArrow] " <> ToString[First[inputBinderOf[act]]] <> " = ",
                              GrayLevel[0.5]],
-                           (* default to "" (not Missing[KeyAbsent]) when the
-                              port has no value yet; write inVals[nm] on edit *)
-                           InputField[Dynamic[Lookup[inVals, nm, ""], (inVals[nm] = #) &],
+                           (* default to Nothing (a clean-empty field, not
+                              Missing[KeyAbsent] or ""); write inVals[nm] on edit *)
+                           InputField[Dynamic[Lookup[inVals, nm, Nothing], (inVals[nm] = #) &],
                              Expression, FieldSize -> 20, ContinuousAction -> False]}],
                       Nothing]}]]],
                 trans]]],

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -86,3 +86,112 @@ supplyValue[trans_List, val_] := Module[{binders = inputBinderOf[First[trans]]},
 --------------------------------------------------------------------- *)
 walkResolve[tf_, s_, vis[nm_, val_]] := Module[{t = walkResolve[tf, s, vis[nm]]},
   If[MissingQ[t], t, supplyValue[t, val]]];
+
+
+(* =====================================================================
+   DYNAMIC WIDGETS  (notebook front end — drive these; not headless)
+   ---------------------------------------------------------------------
+   Composable Dynamic pieces, plus walkUI[] that assembles them. Each
+   reuses the substrate above + discipline.wl's data-compaction display
+   (linearizeGrid) + the engine's action rendering (showAction). They need
+   a notebook front end to render; loading this file headlessly only
+   DEFINES them (a useful syntax check).
+   ===================================================================== *)
+
+(* viewProjections[tf, s] : the published read-only projections at s, as
+   <|"portName" -> projectionValue|>. A view port is an OUTPUT (label[...])
+   whose name ends in "View" (vSView, pSView), carrying param[projection]. *)
+viewProjections[tf_, s_] := Association[
+  (ToString[portName[First[#]]] ->
+     First[Cases[First[#], param[p_] :> p, Infinity], None]) & /@
+  Select[readyTransitions[tf, s],
+    MatchQ[First[#], label[_, param[_]]] &&
+    StringEndsQ[ToString[portName[First[#]]], "View"] &]];
+
+(* dataView[tf, s] : the state's DATA through the compaction grid — one
+   linearizeGrid per published projection. The "visual data compression". *)
+dataView[tf_, s_] := Module[{projs = viewProjections[tf, s]},
+  If[projs === <||>,
+    Style["(no view ports ready)", Italic, GrayLevel[0.5]],
+    Column[KeyValueMap[
+      Function[{nm, p},
+        Column[{Style[nm, Bold, Darker[Blue]], linearizeGrid[p]}, Spacings -> 0.4]],
+      projs], Spacings -> 1]]];
+
+(* traceView[traceDyn] : condensed event-log rendering of the trace held in
+   the Dynamic-tracked symbol passed by reference, + a Copy button. *)
+SetAttributes[traceView, HoldFirst];
+traceView[trace_] := Column[{
+  Style["Trace (condensed event log)", Bold],
+  Pane[Dynamic[If[trace === {},
+        Style["(no steps yet)", Italic, GrayLevel[0.5]],
+        Style[eventLogForm[trace], FontFamily -> "Courier", FontSize -> 12]]],
+    {Automatic, 110}, Scrollbars -> Automatic],
+  Button["Copy trace \[SelectionPlaceholder]", CopyToClipboard[trace],
+    Enabled -> Dynamic[trace =!= {}]]}];
+
+(* ---------------------------------------------------------------------
+   walkUI[agent, opts] : the integrated harness. Drive the sim, PLAY THE
+   USER by typing a real value into any ready input port (the InputField
+   beside it), watch the data-compaction view + condensed trace update,
+   step / back / reset. Untouched input ports step symbolically (binder
+   left free), so it degrades to the plain symbolic walk.
+
+   Value entry uses InputField[..., Expression]: type a WL value, e.g.
+       "happy"                         (a string, for set_filter)
+       <|"word"->"chat","translation"->"cat"|>   (for add)
+   Option "TransitionFunction" -> transVP (mioCore) | transNamed (mioCoreD).
+--------------------------------------------------------------------- *)
+Options[walkUI] = {"TransitionFunction" -> transVP};
+walkUI[agent_, opts : OptionsPattern[]] := With[
+  {tf = OptionValue["TransitionFunction"]},
+  DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>},
+    Dynamic[
+      Module[{trans = readyTransitions[tf, cur]},
+        Framed[Column[{
+
+          Style["Data view \[LongDash] published projections", Bold, 13],
+          dataView[tf, cur],
+
+          Style["Transitions \[LongDash] click to step; type into input ports", Bold, 13],
+          If[trans === {},
+            Style["(deadlocked \[LongDash] no transitions)", Italic, GrayLevel[0.5]],
+            Column[
+              Map[Function[tr,
+                With[{act = First[tr], nm = ToString[portName[First[tr]]]},
+                  Row[{
+                    Button[showAction[act],
+                      Module[{taken},
+                        taken = If[valueInputQ[act] && KeyExistsQ[inVals, nm] &&
+                                   inVals[nm] =!= Null && inVals[nm] =!= "",
+                                 supplyValue[tr, inVals[nm]], tr];
+                        AppendTo[hist, cur];
+                        AppendTo[trace, eventOf[First[taken]]];
+                        cur = Last[taken]; inVals = <||>],
+                      Appearance -> "Frameless",
+                      ActiveStyle -> {Background -> RGBColor[0.9, 0.95, 1.0]}],
+                    If[valueInputQ[act],
+                      Row[{Spacer[6], Style["\[LeftArrow] ", GrayLevel[0.5]],
+                           InputField[Dynamic[inVals[nm]], Expression,
+                             FieldSize -> 20, ContinuousAction -> False,
+                             FieldHint -> ToString[First[inputBinderOf[act]]]]}],
+                      Nothing]}]]],
+                trans]]],
+
+          Row[{
+            Button["\[LeftArrow] Back",
+              If[hist =!= {}, cur = Last[hist]; hist = Most[hist];
+                 trace = Most[trace]; inVals = <||>],
+              Enabled -> Dynamic[hist =!= {}]],
+            Spacer[6],
+            Button["Reset \[CenterDot]", cur = agent; hist = {}; trace = {};
+               inVals = <||>]}],
+
+          traceView[trace]
+
+        }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
+      TrackedSymbols :> {cur, inVals}]]];
+
+(* NB: the engine binds `walk = interactiveVP` (an OwnValue), so we do NOT
+   reuse that name here — call walkUI[mioCore] for the richer spec harness.
+   Whether to rebind `walk` to walkUI is left until the UX settles. *)

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -183,10 +183,13 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                       Appearance -> "Frameless",
                       ActiveStyle -> {Background -> RGBColor[0.9, 0.95, 1.0]}],
                     If[valueInputQ[act],
-                      Row[{Spacer[6], Style["\[LeftArrow] ", GrayLevel[0.5]],
-                           InputField[Dynamic[inVals[nm]], Expression,
-                             FieldSize -> 20, ContinuousAction -> False,
-                             FieldHint -> ToString[First[inputBinderOf[act]]]]}],
+                      Row[{Spacer[6],
+                           Style["\[LeftArrow] " <> ToString[First[inputBinderOf[act]]] <> " = ",
+                             GrayLevel[0.5]],
+                           (* default to "" (not Missing[KeyAbsent]) when the
+                              port has no value yet; write inVals[nm] on edit *)
+                           InputField[Dynamic[Lookup[inVals, nm, ""], (inVals[nm] = #) &],
+                             Expression, FieldSize -> 20, ContinuousAction -> False]}],
                       Nothing]}]]],
                 trans]]],
 

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -60,21 +60,33 @@ readyInputs[tf_, s_] := Select[readyTransitions[tf, s], valueInputQ[First[#]] &]
 
 (* ---------------------------------------------------------------------
    supplyValue[trans, val] : THE PORT-INPUT MECHANIC.  Given a transition
-   {action, succ} whose action is coLabel[nm, binding[x]], bind x := val
-   throughout BOTH the action and the successor, so the real value flows in
-   and threads through every later state. The action becomes
-   coLabel[nm, binding[val]], from which eventOf reads the concrete value
-   for the trace automatically.
+   {action, succ} whose action is coLabel[nm, binding[x]], insert the
+   user-supplied value into the binder x of the DERIVATIVE using the engine's
+   substVv (NOT ReplaceAll): substVv is scope-aware (filterSubst drops the
+   binder when it re-enters a rebinding), so the value lands only at the genuine
+   free occurrence and does NOT leak into the re-unfolded continuation clauses
+   that rebind the same name. The action's binding is set to val too, so eventOf
+   reads the concrete value for the trace.
+
+   The value is the USER's responsibility: the simulator does NOT validate it —
+   the spec's own functions (validateWord, the _List match, ...) judge it if and
+   when the term becomes concrete. This is the deliberate blend of transition
+   function and simulator that lets the user, as the open environment, inject
+   real data while navigating the symbolic<->concrete interzone.
 
    - value-free input or non-input: returned unchanged (nothing to supply).
-   - single binder (every port in the current spec): substitute x -> val.
-   - multi-binder: val is taken as a list, zipped onto the binders.
+   - single binder (every port in the current spec): substVv x -> val.
+   - multi-binder: val is a list, zipped onto the binders.
 --------------------------------------------------------------------- *)
 supplyValue[trans_List, val_] := Module[{binders = inputBinderOf[First[trans]]},
   Which[
-    binders === {},          trans,
-    Length[binders] === 1,   trans /. First[binders] -> val,
-    True,                    trans /. MapThread[Rule, {binders, val}]]];
+    binders === {}, trans,
+    Length[binders] === 1,
+      {First[trans] /. binding[_] :> binding[val],
+       substVv[Last[trans], First[binders] -> val]},
+    True,
+      {First[trans] /. binding[__] :> (binding @@ val),
+       substVv[Last[trans], MapThread[Rule, {binders, val}]]}]];
 
 (* ---------------------------------------------------------------------
    Value-carrying plan entry: vis[nm, val] resolves the input port `nm`

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -83,7 +83,8 @@ supplyValue[trans_List, val_] := Module[{binders = inputBinderOf[First[trans]]},
     binders === {}, trans,
     Length[binders] === 1,
       {First[trans] /. binding[_] :> binding[val],
-       substVv[Last[trans], First[binders] -> val]},
+       substVv[Last[trans], {First[binders] -> val}]},   (* subst is a LIST of
+         rules: filterSubst does #[[1]] per element, so a bare rule -> ps[[1]] *)
     True,
       {First[trans] /. binding[__] :> (binding @@ val),
        substVv[Last[trans], MapThread[Rule, {binders, val}]]}]];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -121,13 +121,19 @@ viewProjections[tf_, s_] := Association[
     StringEndsQ[ToString[portName[First[#]]], "View"] &]];
 
 (* dataView[tf, s] : the state's DATA through the compaction grid — one
-   linearizeGrid per published projection. The "visual data compression". *)
+   linearizeGrid per published projection. The "visual data compression".
+   The projection comes out of the engine's held `param` with its values
+   UNEVALUATED (the recipe, e.g. sortEntries[applyFilter[...]]); Map[Identity, ·]
+   rebuilds the association forcing each value, so we linearize the COMPUTED
+   data (entries -> {} when empty, the actual rows when populated). *)
+forceProj[p_Association] := Map[Identity, p];
+forceProj[p_] := p;
 dataView[tf_, s_] := Module[{projs = viewProjections[tf, s]},
   If[projs === <||>,
     Style["(no view ports ready)", Italic, GrayLevel[0.5]],
     Column[KeyValueMap[
       Function[{nm, p},
-        Column[{Style[nm, Bold, Darker[Blue]], linearizeGrid[p]}, Spacings -> 0.4]],
+        Column[{Style[nm, Bold, Darker[Blue]], linearizeGrid[forceProj[p]]}, Spacings -> 0.4]],
       projs], Spacings -> 1]]];
 
 (* traceView[traceDyn] : condensed event-log rendering of the trace held in

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -149,12 +149,9 @@ traceView[trace_] := Column[{
    step / back / reset. Untouched input ports step symbolically (binder
    left free), so it degrades to the plain symbolic walk.
 
-   Value entry is a TEXT field parsed with ToExpression (so an empty field is
-   a genuinely blank box, not the literal "" / Null an Expression field shows).
-   Type a WL value, e.g.
-       "happy"                                   (a string, for set_filter)
+   Value entry uses InputField[..., Expression]: type a WL value, e.g.
+       "happy"                         (a string, for set_filter)
        <|"word"->"chat","translation"->"cat"|>   (for add)
-   string values keep their quotes.
    Option "TransitionFunction" -> transVP (mioCore) | transNamed (mioCoreD).
 --------------------------------------------------------------------- *)
 Options[walkUI] = {"TransitionFunction" -> transVP};
@@ -178,8 +175,8 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                     Button[showAction[act],
                       Module[{taken},
                         taken = If[valueInputQ[act] && KeyExistsQ[inVals, nm] &&
-                                   StringQ[inVals[nm]] && StringTrim[inVals[nm]] =!= "",
-                                 supplyValue[tr, ToExpression[inVals[nm]]], tr];
+                                   inVals[nm] =!= Null && inVals[nm] =!= "",
+                                 supplyValue[tr, inVals[nm]], tr];
                         AppendTo[hist, cur];
                         AppendTo[trace, eventOf[First[taken]]];
                         cur = Last[taken]; inVals = <||>],
@@ -189,11 +186,10 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                       Row[{Spacer[6],
                            Style["\[LeftArrow] " <> ToString[First[inputBinderOf[act]]] <> " = ",
                              GrayLevel[0.5]],
-                           (* TEXT field: default "" renders as a blank box
-                              (an Expression field would show "" / Null / Nothing
-                              as literal text). Parsed with ToExpression on step. *)
+                           (* default to "" (not Missing[KeyAbsent]) when the
+                              port has no value yet; write inVals[nm] on edit *)
                            InputField[Dynamic[Lookup[inVals, nm, ""], (inVals[nm] = #) &],
-                             String, FieldSize -> 20, ContinuousAction -> False]}],
+                             Expression, FieldSize -> 20, ContinuousAction -> False]}],
                       Nothing]}]]],
                 trans]]],
 

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -1,0 +1,88 @@
+(* =====================================================================
+   spec/walk.wl — interactive walk harness for the miolingo spec.
+   ---------------------------------------------------------------------
+   `walk` lets a human live with the spec as it evolves: drive the
+   simulation, PLAY THE USER by entering real data into input ports as
+   they become ready, see each state through the data-compaction views
+   (linearize / condensed event log), and record/replay traces — built
+   from Wolfram `Dynamic`.
+
+   This file is loaded ON TOP OF a loaded spec (engine + discipline +
+   MioCore); it assumes transVP/transNamed, the coLabel/binding action
+   grammar, and discipline.wl's data-view helpers are already present.
+   In a notebook:
+       Get[".../spec/MiolingoSpec.wl"];   (* engine + spec *)
+       Get[".../spec/walk.wl"];           (* this file *)
+       walkUI[mioCore]                     (* drive it *)
+
+   THIS SECTION — the PURE SUBSTRATE — is headless-testable (see
+   spec/tests/walk_test.wls). The Dynamic widgets that sit on top of it
+   are added once the substrate mechanic is proven.
+
+   ACTION GRAMMAR (from discipline.wl:254-267):
+     label[nm, param[v]]        output (visible), carries value v
+     coLabel[nm, binding[x]]    input  (visible), BINDS x  <- user supplies here
+     coLabel[nm]                input  (visible), no value
+     tag[Tau, ch, subst] / Tau  internal
+   ===================================================================== *)
+
+(* ---------------------------------------------------------------------
+   readyTransitions[tf, s] : the enabled transitions at state s as a list
+   of {action, successor}.  Normalises the engine's optional 3-tuple form
+   ({action, succ, _}) to a 2-list, matching interactiveVP (RCA_core.wl:
+   1471-1473) so the widgets and tests share one shape.
+--------------------------------------------------------------------- *)
+readyTransitions[tf_, s_] := Module[{raw = tf[s]},
+  If[raw =!= {} && Length[raw[[1]]] >= 3,
+     {#[[1]], #[[2]]} & /@ raw,
+     raw]];
+
+(* ---------------------------------------------------------------------
+   inputBinderOf[action] : the binder symbol(s) an input action introduces,
+   i.e. the free variable(s) a supplied value must replace. {} for outputs,
+   taus, and value-free inputs (coLabel[nm]).
+--------------------------------------------------------------------- *)
+inputBinderOf[coLabel[_, binding[x_]]]  := {x};
+inputBinderOf[coLabel[_, binding[x__]]] := {x};   (* multi-binder (none in
+                                                     the current spec) *)
+inputBinderOf[_] := {};
+
+(* valueInputQ[action] : True iff this is an input port that BINDS a value
+   (so the walk must let the user supply one). *)
+valueInputQ[a_] := inputBinderOf[a] =!= {};
+
+(* ---------------------------------------------------------------------
+   readyInputs[tf, s] : the ready transitions that are value-carrying input
+   ports — the places where the human, as the open environment, supplies
+   real data.  These are exactly the rows the GUI gives an input field.
+--------------------------------------------------------------------- *)
+readyInputs[tf_, s_] := Select[readyTransitions[tf, s], valueInputQ[First[#]] &];
+
+(* ---------------------------------------------------------------------
+   supplyValue[trans, val] : THE PORT-INPUT MECHANIC.  Given a transition
+   {action, succ} whose action is coLabel[nm, binding[x]], bind x := val
+   throughout BOTH the action and the successor, so the real value flows in
+   and threads through every later state. The action becomes
+   coLabel[nm, binding[val]], from which eventOf reads the concrete value
+   for the trace automatically.
+
+   - value-free input or non-input: returned unchanged (nothing to supply).
+   - single binder (every port in the current spec): substitute x -> val.
+   - multi-binder: val is taken as a list, zipped onto the binders.
+--------------------------------------------------------------------- *)
+supplyValue[trans_List, val_] := Module[{binders = inputBinderOf[First[trans]]},
+  Which[
+    binders === {},          trans,
+    Length[binders] === 1,   trans /. First[binders] -> val,
+    True,                    trans /. MapThread[Rule, {binders, val}]]];
+
+(* ---------------------------------------------------------------------
+   Value-carrying plan entry: vis[nm, val] resolves the input port `nm`
+   (delegating to discipline.wl's existing string-name resolver, so the
+   matching convention is shared) and supplies `val` into its binder.
+   ADDITIVE downvalue on walkResolve — lets the existing walkSteps run a
+   value-driven plan, e.g.
+       walkSteps[transVP, mioCore, {vis["set_filter", "happy"], vis["add", w]}]
+--------------------------------------------------------------------- *)
+walkResolve[tf_, s_, vis[nm_, val_]] := Module[{t = walkResolve[tf, s, vis[nm]]},
+  If[MissingQ[t], t, supplyValue[t, val]]];


### PR DESCRIPTION
## What

`walk` lets a human live with the spec as it evolves: drive the simulation, **play the user** by typing real values into input ports as they become ready, watch the data-compaction views, and record traces — built from Wolfram `Dynamic`. New file **`spec/walk.wl`** (substrate + widgets) and **`spec/tests/walk_test.wls`** (headless substrate test), plus one spec-level bugfix the walk surfaced.

### Substrate (headless-testable)
- **`supplyValue[trans, val]`** — the port-input mechanic: insert a user value into an input transition's binder via the engine's **`substVv`** (scope-aware — does *not* leak into re-unfolded clauses that rebind the name, which `ReplaceAll` would). No validation: the value is the user's responsibility; the spec's own functions judge it. This is the deliberate blend of transition function + simulator that lets the user inject real data across the symbolic↔concrete interzone.
- `readyTransitions` / `inputBinderOf` / `valueInputQ` / `readyInputs`, and a value-carrying plan entry `vis[nm, val]` so the existing `walkSteps` runs value-driven plans.

### Dynamic widgets (notebook-driven; manually verified)
- `viewProjections` / `dataView` — the published `view!` projections (`vSView`/`pSView`) rendered through `linearizeGrid`, showing the **computed** data (`entries -> {}` empty, real rows when populated).
- `traceView`, and `walkUI[agent, opts]` — the integrated harness (clickable transitions, inline input fields on value-carrying ports, Back/Reset, condensed trace). Works on `mioCore` (`transVP`) and `mioCoreD` (`transNamed`).

### Spec fix surfaced by driving the walk (kept in this PR by request)
- **`sortEntries` matches the sort Enum symbol, not a string key.** The walk exposed a frozen `"sort"` in a projection: `sortEntries` matched strings (`"alpha"`…), so `vocabView` bridged the sort **symbol** `alpha` via `ToString[sort]`, which froze under the engine's held derivation. Fixed at the function level — `sortEntries` matches `alpha | recent | oldest` directly, `vocabView` drops `ToString`. (`VocabStoreFunctions.wl`, `functions_test.wls` updated.)

## Notes
- `walkUI` is a notebook GUI (can't be exercised headlessly); the substrate it sits on is covered by `walk_test.wls`.
- **Known altitude limit:** value-function input ports (e.g. `add`) collapse during derivation on a concrete-`{}` state (`addEntry[{}, w]` fires on the free binder before you supply), so they want a data-preserving state; slot ports (`load_material`, `set_filter`, …) supply cleanly. Inherent to the symbolic↔concrete boundary, documented in the source.

## Verification
- `spec/tests/walk_test.wls` — substrate: slot insert, data-preserving insert, `substVv` scope-correctness (vs `ReplaceAll`), no-op cases, value-driven `walkSteps` plan. All green.
- Full headless suite green (`functions_test`, `composition_test`, `data_view_test`, `internal_transitions_test`, `merge_defined_test`, `trace_io_test`, `walk_test`).
- `walkUI` driven live in a notebook: supplying a phrases queue to `load_material` threads the value into PS and `pSView` computes `total -> 1` with the item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)