### PR TITLE
spec: add/vAdd register (addEntry pattern fix) + walkUI shows state & derivatives

### DIFF
--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -83,7 +83,7 @@ validateWord[_] := $Failed;
    enrich (translation/IPA via _enrich) is IO and is NOT performed here —
    it is the enrich=False path the hermetic tests use. Any translation/ipa
    already present on w (e.g. from an import line) is carried in. *)
-addEntry[entries_List, w_] := Module[
+addEntry[entries_List, w : (_String | _Association)] := Module[
   {a = If[AssociationQ[w], w, <|"word" -> w|>], v, display, key, pos},
   v = validateWord[Lookup[a, "word", ""]];
   If[v === $Failed, Return[entries]];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -161,6 +161,11 @@ traceView[trace_] := Column[{
        <|"word"->"chat","translation"->"cat"|>   (for add)
    Option "TransitionFunction" -> transVP (mioCore) | transNamed (mioCoreD).
 --------------------------------------------------------------------- *)
+(* stateDisplay[s] : compact render of a process STATE (the derivative) — where
+   you are / where a transition leads — via the engine's foldAgentDisplay. This
+   is the CCS term, complementing dataView's published data projections. *)
+stateDisplay[s_] := If[agentDefs =!= <||>, foldAgentDisplay[normalizeSC[s]], Short[s, 3]];
+
 Options[walkUI] = {"TransitionFunction" -> transVP};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"]},
@@ -168,6 +173,9 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
         Framed[Column[{
+
+          Style["Current state \[LongDash] where you are (process term)", Bold, 13],
+          Pane[stateDisplay[cur], {Automatic, 140}, Scrollbars -> Automatic],
 
           Style["Data view \[LongDash] published projections", Bold, 13],
           dataView[tf, cur],
@@ -179,7 +187,8 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
               Map[Function[tr,
                 With[{act = First[tr], nm = ToString[portName[First[tr]]]},
                   Row[{
-                    Button[showAction[act],
+                    Tooltip[
+                     Button[showAction[act],
                       Module[{taken},
                         taken = If[valueInputQ[act] && KeyExistsQ[inVals, nm] &&
                                    inVals[nm] =!= Null && inVals[nm] =!= "",
@@ -189,6 +198,11 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                         cur = Last[taken]; inVals = <||>],
                       Appearance -> "Frameless",
                       ActiveStyle -> {Background -> RGBColor[0.9, 0.95, 1.0]}],
+                     (* hover: the derivative this transition leads to (symbolic,
+                        i.e. before any supplied value — so e.g. add's collapse to
+                        entries {} is visible here) *)
+                     Column[{Style["\[RightArrow] goes to:", Bold, GrayLevel[0.4]],
+                             stateDisplay[Last[tr]]}]],
                     If[valueInputQ[act],
                       Row[{Spacer[6],
                            Style["\[LeftArrow] " <> ToString[First[inputBinderOf[act]]] <> " = ",


### PR DESCRIPTION
Two changes, both surfaced by driving `walkUI`.

## 1. `add`/`vAdd` now register a supplied value (`VocabStoreFunctions.wl`)

The capture ports never registered through the simulator. Cause: `addEntry`'s second argument was `w_` — matches **anything**. `walkUI` derives every transition just to *display* the rows, and that derivation runs while the binder `w` is still free; the old `addEntry[{}, w]` fired then, hit the `validateWord[_] -> $Failed` clause, and returned the list unchanged — collapsing **before** a value could be supplied. `substVv` then had no binder left to fill.

`addEntry`'s docstring already says `w` is "a String or an Association with `word`". Tightening the pattern to `w : (_String | _Association)` makes a free symbol **not match**, so the derivative keeps `addEntry[entries, w]` symbolic until the user supplies a value — exactly the discipline `importInto[entries, f_Association]` already followed (which is why `import_bulk` worked). Then `substVv` lands the value and `addEntry` computes.

- `add`/`vAdd` register on both `mioCore` (`transVP`) and `mioCoreD` (`transNamed`): `vSView count -> 1`, entry present.
- Valid strings/assocs still add; invalid (multi-word) and word-less (`<|text->…|>`) payloads still no-op via `validateWord`.
- Full suite green. (Same loose-pattern class affects `deleteFrom`/`autofillIn` `id_` — noted as follow-up.)

## 2. `walkUI` shows the current state and each transition's derivative (`walk.wl`)

Orientation was missing — only data projections + trace, no view of *where you are* in the LTS.
- `stateDisplay[s]` — compact CCS process-term render (`foldAgentDisplay о normalizeSC`).
- a **"Current state — where you are"** panel (scroll-bounded) at the top.
- a **Tooltip** on each transition — *"→ goes to: …"* — previewing the derivative it leads to.

## Verification
- Full headless suite green (8 files).
- `add(souris)` registers on `mioCore` and `mioCoreD` (checked via the `vSView` projection).
- GUI rendering is notebook-side (`walkUI[mioCore]`; `walkUI[mioCoreD, "TransitionFunction" -> transNamed]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)