### PR TITLE
spec: make add show up — restore VS loop + editingRow + vocabView entries_List

### DIFF
--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -293,8 +293,12 @@ practiseList[entries_List, filter_] :=
 
 (* --- vocabView[auth, entries, sort, filter, editing] : the read-only view
    projection (what list_vocab + the tab publish). A projection f, never raw
-   state: emits a summary Association the skin renders. *)
-vocabView[auth_, entries_, sort_, filter_, editing_] := <|
+   state: emits a summary Association the skin renders.
+   entries_List (not entries_): like sessionView[phrases_List], this keeps the
+   WHOLE projection symbolic in a held mu-term derivation until the entries value
+   lands, then computes consistently — otherwise Length[<symbol>] froze count to
+   0 while the entries field got the real list (the count-stuck-at-0 display bug). *)
+vocabView[auth_, entries_List, sort_, filter_, editing_] := <|
   "auth" -> auth,
   "count" -> Length[entries],
   "sort" -> sort,

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -72,33 +72,33 @@ defineAgent["VSAuthed", {entries, sort, filter, editing},
   if[Length[entries] == 0,
     choice[
       precede[coLabel["add", binding[w]],
-        call["VSAuthed", addEntry[entries, w], sort, filter, editing]],
+        call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
       choice[
         precede[coLabel["vAdd", binding[w]],
-          call["VSAuthed", addEntry[entries, w], sort, filter, editing]],
+          call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
         choice[
           precede[coLabel["import_bulk", binding[f]],
-            call["VSAuthed", importInto[entries, f], sort, filter, editing]],
+            call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
           choice[
             precede[coLabel["set_sort", binding[s]],
-              call["VSAuthed", entries, s, filter, editing]],
+              call["VS", signedIn, entries, s, filter, editing]],
             precede[coLabel["set_filter", binding[q]],
-              call["VSAuthed", entries, sort, filterBy[q], editing]]]]]],
+              call["VS", signedIn, entries, sort, filterBy[q], editing]]]]]],
     choice[
       precede[coLabel["add", binding[w]],
-        call["VSAuthed", addEntry[entries, w], sort, filter, editing]],
+        call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
       choice[
         precede[coLabel["vAdd", binding[w]],
-          call["VSAuthed", addEntry[entries, w], sort, filter, editing]],
+          call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
         choice[
           precede[coLabel["import_bulk", binding[f]],
-            call["VSAuthed", importInto[entries, f], sort, filter, editing]],
+            call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
           choice[
             precede[coLabel["set_sort", binding[s]],
-              call["VSAuthed", entries, s, filter, editing]],
+              call["VS", signedIn, entries, s, filter, editing]],
             choice[
               precede[coLabel["set_filter", binding[q]],
-                call["VSAuthed", entries, sort, filterBy[q], editing]],
+                call["VS", signedIn, entries, sort, filterBy[q], editing]],
               call["VSNonEmpty", entries, sort, filter, editing]]]]]]]]
 
 

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -34,7 +34,7 @@
      entries : the collection (list)
      sort    : ordering value (alpha | recent | oldest)
      filter  : none | filterBy[q]
-     editing : none | editing[id]   (which row is in inline edit-mode)
+     editing : none | editingRow[id]   (which row is in inline edit-mode)
 
    RECOVERED READY SETS (analysis only; derived from the guards below,
    not explicit channels in the process):
@@ -45,7 +45,7 @@
                                                   update_notes, autofill,
                                                   begin_edit
      VS[signedIn, ne, _,filterBy,none] +search  : + practise_filtered
-     VS[signedIn, ne, _,_,editing[id]] Editing  : per-row -> update,
+     VS[signedIn, ne, _,_,editingRow[id]] Editing  : per-row -> update,
                                                   cancel_edit (no delete/
                                                   begin_edit); export stays
 
@@ -148,7 +148,7 @@ defineAgent["VSEntryActions", {entries, sort, filter},
         precede[coLabel["autofill", binding[id]],
           call["VS", signedIn, autofillIn[entries, id], sort, filter, none]],
         precede[coLabel["begin_edit", binding[id]],
-          call["VS", signedIn, entries, sort, filter, editing[id]]]]]]]
+          call["VS", signedIn, entries, sort, filter, editingRow[id]]]]]]]
 
 
 (* --- per-entry actions WHILE editing a row --- *)


### PR DESCRIPTION
Three fixes so `add` (and the edit flow) register *and display* in the simulator, after the VS guard-partitioned refactor (`942a515`/`4a4963d`). The entry was always being captured in the state; these restore the projections/structure that make it visible and the edit flow work.

## 1. `VSAuthed` CRUD-in successors loop back to `VS` (`50262de`) — *the "add isn't showing up" fix*
The refactor changed `add`/`vAdd`/`import_bulk`/`set_sort`/`set_filter` to loop to `call["VSAuthed", …]` (4-arg) instead of `call["VS", signedIn, …]` (5-arg). `VSAuthed` has **no `view!` summand**, so after any CRUD-in action `vSView` dropped out of the ready set — the entry was captured but the projection that displays it was no longer offered. Reverted the loop target to `VS` (the guard-partitioned structure is kept; only the target changes). Contradicted the refactor's own "ready sets identical to pre-refactor" invariant; `walk_test` caught it.

## 2. Restore `editingRow[id]` (`8d33b5f`) — re-fixes `7685fcf`
The refactor reverted the inline-edit tag `editingRow[id]` → `editing[id]`. The tag head clashing with the `editing` binder broke edit-mode two ways: `update` silently no-ops (`updateEntry` matches `editingRow[id_]`), and the mu-term capture `editing[id] /. editing->none → none[id]` returns. Restored `editingRow[id]`.

## 3. `vocabView` takes `entries_List` (`12798bf`) — count-freeze on `transVP`
Unrestricted `entries_` let `Length[entries]` evaluate on the still-symbolic mu-binding in a held projection → `count` froze at 0 while `entries` got the real list. Restrict to `entries_List` (parallel to `sessionView[phrases_List]`). Supersedes branch `claude/vocabview-count-freeze`.

## Verification
- `add` on **`mioCore`** (`transVP`): after `add`, `vSView` offered, `count = 1`, entries `{souris}`.
- edit flow: `begin_edit(1)` → `editingRow[1]`; `update(translation->dog)` actually changes the entry (cat→dog); `cancel_edit` → none, no capture.
- Full headless suite green (8 files), `walk_test` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)