### PR TITLE
spec/walk: viewProjections recognises the bare "view" port (add now shows on bare agents)

### DIFF
--- a/spec/tests/walk_test.wls
+++ b/spec/tests/walk_test.wls
@@ -36,6 +36,17 @@ assert["every readyInput is a value-carrying input (has a binder)",
 assert["the canonical VS input ports are present",
   SubsetQ[ToString /@ portName /@ First /@ ri, {"add", "set_filter", "set_sort", "import_bulk"}]];
 
+(* regression: viewProjections must pick up the BARE agent's "view" port, not
+   only the composition-relabelled "{Agent}View" (vSView/pSView). A literal
+   "View" suffix test silently dropped "view", so the data view was empty when
+   driving a bare agent (e.g. walkUI[call["VS", ...]]) and add never showed. *)
+assert["viewProjections finds the bare \"view\" port (case-insensitive)",
+  KeyExistsQ[viewProjections[transNamed, call["VS", signedIn, {}, alpha, none, none]], "view"]];
+assert["after add on a bare VS agent, the view projection shows the entry",
+  Map[Identity, viewProjections[transNamed,
+      Last[supplyValue[byName[transNamed, call["VS", signedIn, {}, alpha, none, none], "add"],
+                       <|"word" -> "souris"|>]]]["view"]]["count"] === 1];
+
 Print[hr]; Print["2. supplyValue : slot binder (load_material on PS) inserts cleanly"]; Print[hr];
 lm  = byName[transNamed, call["PS", {}, 0, none, none], "load_material"];
 phr = {<|"text" -> "chat", "translation" -> "cat"|>};

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -113,13 +113,16 @@ walkResolve[tf_, s_, vis[nm_, val_]] := Module[{t = walkResolve[tf, s, vis[nm]]}
 
 (* viewProjections[tf, s] : the published read-only projections at s, as
    <|"portName" -> projectionValue|>. A view port is an OUTPUT (label[...])
-   whose name ends in "View" (vSView, pSView), carrying param[projection]. *)
+   carrying param[projection] whose name is a read-only view: the bare agent's
+   "view" port, OR a composition-relabelled "{Agent}View" (vSView, pSView).
+   Matched case-insensitively on the "view" suffix so BOTH forms are picked up
+   (the bare "view" was previously dropped by a literal "View" test). *)
 viewProjections[tf_, s_] := Association[
   (ToString[portName[First[#]]] ->
      First[Cases[First[#], param[p_] :> p, Infinity], None]) & /@
   Select[readyTransitions[tf, s],
     MatchQ[First[#], label[_, param[_]]] &&
-    StringEndsQ[ToString[portName[First[#]]], "View"] &]];
+    StringEndsQ[ToLowerCase[ToString[portName[First[#]]]], "view"] &]];
 
 (* dataView[tf, s] : the state's DATA through the compaction grid — one
    linearizeGrid per published projection. The "visual data compression".


### PR DESCRIPTION
**The reason `add` "didn't show up"** when driving a bare agent (`walkUI[call["VS", …]]`): `viewProjections` filtered view ports with `StringEndsQ[name, "View"]` (capital V). That matches the composition-relabelled `vSView`/`pSView`, but **not** the bare agent's `view` port — so the data view was empty and a captured entry never displayed.

`mioCore` worked because it relabels `view → vSView`; my substrate tests only used `mioCore`, so they missed the bare-`view` case — precisely the UI gap you flagged ("your tests pass but it doesn't work").

**Fix:** match case-insensitively on the `view` suffix, so `view`, `vSView`, `pSView` are all picked up.

**Verification:**
- After `add`: the view projection shows `count 1`, entries `{souris}` on **both** bare `VS` (`transNamed`) and `mioCore` (`transVP`); the rendered `dataView` contains the entry.
- **Regression test** added to `walk_test`: `viewProjections` finds the bare `view` port, and `add` on a bare `VS` agent shows the entry (so this gap can't recur silently).
- Full headless suite green.

Note: my tests verify `dataView[tf, state]` *output*; the live `walkUI` `Dynamic` re-renders `dataView[tf, cur]` on each step (tracked symbol `cur`), so with the projection now found, the step should display. If it still doesn't update live after merging, that points to a `Dynamic` re-render issue (notebook-side) rather than this — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)