### PR TITLE
spec/walk: value-carrying test sequences + Run-test button + ?usage messages

### DIFF
--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -1,0 +1,142 @@
+# walk.md
+## The interactive `walk` harness — living with the spec as it evolves
+
+`walk` lets a human drive the executable CCS spec: step through transitions,
+**play the user** by feeding real values into input ports as they become ready,
+watch each state through the data-compaction views, and record/replay traces.
+It's built from Wolfram `Dynamic`, and it's how you *use* the spec rather than
+just read it — the human is the open environment supplying the inputs that make
+the value-functions compute.
+
+Files: **`spec/walk.wl`** (substrate + Dynamic widgets, loads `walk-tests.wl`),
+**`spec/walk-tests.wl`** (the test batch), tests in `spec/tests/walk_test.wls`
+and `spec/tests/walk_sequences_test.wls`.
+
+---
+
+## Loading and running
+
+In a notebook, from **your own checkout** (not a worktree):
+
+```wolfram
+Get[".../spec/MiolingoSpec.wl"];   (* engine + spec, in order *)
+Get[".../spec/walk.wl"];           (* the harness + walkTests *)
+
+walkUI[mioCore]                                       (* mu-term, transVP default *)
+walkUI[mioCoreD, "TransitionFunction" -> transNamed]  (* compact call form *)
+walkUI[call["VS", signedIn, {}, alpha, none, none], "TransitionFunction" -> transNamed]  (* a bare agent *)
+```
+
+`MiolingoSpec.wl` self-locates the rest (see `paths.wl`), so loading from any
+checkout works; just point the entry `Get` at the checkout you want to test.
+
+The panel shows, top to bottom:
+- **Current state** — the CCS process term (`foldAgentDisplay`), *where you are*.
+- **Data view** — the published `view!` projections (`vSView`/`pSView`, or the
+  bare `view`), rendered as the *computed* data through `linearizeGrid`.
+- **Transitions** — one clickable row each; hover shows *→ goes to:* the
+  derivative. Value-carrying input ports get an inline field.
+- **Back / Reset**, a **`Test:` menu + `Run test`** (see below), and the
+  **condensed trace** (with Copy).
+
+---
+
+## Supplying values by hand
+
+Each value-carrying input port has an `Expression` input field. Type a Wolfram
+value, **press Enter (or Tab out) to commit**, then click the row. Conventions:
+
+| port kind | type this | note |
+|---|---|---|
+| word (`add`, `capture_vocab`, `set_filter`) | `"souris"` | **quote strings** — bare `souris` is a *symbol* and `validateWord` rejects it |
+| capture payload (`add`, `vAdd`) | `<|"word"->"souris", "translation"->"mouse"|>` | needs a `"word"` key (vocab shape, not the practice `"text"`) |
+| sort (`set_sort`) | `alpha` / `recent` / `oldest` | the Enum **symbols**, unquoted |
+| id (`delete`, `autofill`, `begin_edit`) | `1` | integer |
+| import (`import_bulk`) | `<|"contents"->"(en,fr)\nsouris|mouse", "expectedTarget"->"fr"|>` | header `(src,tgt)` then `word\|translation\|ipa\|source\|url` rows; target must match |
+| phrases (`load_material`) | `{<|"text"->"chat","translation"->"cat","ipa"->"ʃa"|>}` | the practice `"text"` shape |
+
+An untouched field steps the port symbolically (binder left free).
+
+---
+
+## Test sequences — driving with no typing
+
+`walk-tests.wl` defines **`walkTests`**, an `Association` of named *plans*. A
+plan is a list of:
+
+- `vis["port"]` — a visible action with no value;
+- `vis["port", value]` — a value-carrying input, value supplied;
+- `tau["chan"]` — an internal sync (`pLoad`, `vAdd`).
+
+Run one from the GUI: pick it in the **`Test:`** menu and click **`Run test`** —
+it replays the whole plan from the initial state, setting the data view and the
+condensed trace, **with no typing**. Or headless:
+
+```wolfram
+walkSteps[transVP,   mioCore,  walkTests["full-roundtrip"]]
+walkSteps[transNamed, mioCoreD, walkTests["full-roundtrip"]]
+```
+
+### The batch (naming / classification)
+
+Kebab-case keys, prefixed by scope:
+
+| prefix | meaning | sequences |
+|---|---|---|
+| `vs-*`   | VocabStore-only ports | `vs-capture`, `vs-import`, `vs-edit` |
+| `ps-*`   | PracticeSession-only ports | `ps-navigate`, `ps-score` |
+| `sync-*` | one cross-component sync (composed-only) | `sync-pload`, `sync-vadd` |
+| `full-*` | end-to-end, both syncs | `full-roundtrip` |
+
+Together they exercise **every** VS and PS port and both syncs.
+
+### Adding a sequence
+
+Add an entry to `walkTests` under the right prefix, ≤ ~10 actions, with embedded
+values (quote strings, Enum symbols for sort, integers for ids, Associations for
+payloads). **The standing rule:** it must run to completion on *both* `mioCore`
+(`transVP`) and `mioCoreD` (`transNamed`). `tests/walk_sequences_test.wls`
+enforces this for every sequence; run it after editing the batch.
+
+---
+
+## The substrate (headless-testable)
+
+- `supplyValue[trans, val]` — insert a value into an input transition's binder
+  via the engine's scope-aware `substVv` (not `ReplaceAll`). No validation; the
+  spec's own functions judge the value.
+- `readyTransitions` / `inputBinderOf` / `valueInputQ` / `readyInputs`.
+- `vis[nm, val]` — value-carrying plan entry (an additive `walkResolve`
+  downvalue) so `walkSteps` runs value-driven plans.
+- `viewProjections` / `dataView` / `stateDisplay` / `traceView` — the displays.
+- Reused from `discipline.wl`: `walkSteps`, `eventLog`, `condense`,
+  `eventLogForm`, `linearizeGrid`, `replayTrace`.
+
+All have `::usage`, so `?walkUI`, `?supplyValue`, `?walkTests`, `?loadEngine`,
+… resolve in a notebook.
+
+---
+
+## Notes / gotchas
+
+- **Value-function ports need a real value.** `set_filter`/`set_sort`/`begin_edit`
+  drop the binder into a slot/constructor, so they visibly change a field even
+  with the binder *unsupplied* (showing `filterBy[q]`, `editingRow[id]`). `add`
+  drops it into `addEntry`, which won't compute on a bare symbol — so `add` only
+  shows a change once a valid value is supplied. (It's the honest one.)
+- **`view` vs `View`.** `viewProjections` matches the view suffix
+  case-insensitively, so both the bare agent's `view` and the relabelled
+  `vSView`/`pSView` are picked up.
+- **Syncs are composed-only.** `pLoad`/`vAdd` are restricted internal channels;
+  the `sync-*`/`full-*` sequences run on `mioCore`/`mioCoreD`, not VS/PS alone.
+- **Deferred.** A cleaner value-supply route — giving `transVP` a parameter that
+  derives an input transition *with* the substitution inline (supply-then-derive)
+  instead of precompute-then-`substVv` — is noted for the future.
+
+## Verification
+
+- `spec/tests/walk_test.wls` — the substrate (`supplyValue`, scope-correctness,
+  `viewProjections` finds the bare `view`, the value-driven plan path).
+- `spec/tests/walk_sequences_test.wls` — every `walkTests` sequence completes on
+  both compositions, and the syncs move data.
+- GUI rendering is notebook-side (it can't be exercised headlessly).

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -47,6 +47,10 @@ $rca = With[{e = Environment["RCA_CORE"]},
    and transNamed[relabel] (#35). Bump when adopting newer engine capability. *)
 $minEngineSha = "5bcc031";
 
+mioGet::usage = "mioGet[\"file.wl\"] Gets a spec file by name, relative to $specDir (this spec directory, derived from paths.wl's own location).";
+loadEngine::usage = "loadEngine[] Gets the RCA engine ($rca = $RCA_CORE env var, else the canonical checkout) AND asserts (git merge-base --is-ancestor) that the checkout contains $minEngineSha, aborting loudly on divergence. The shared coordinate between the spec and engine repos.";
+loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the two recovered agents (PracticeSessionRecovered.wl, VocabStoreRecovered.wl) in order — the common base every spec consumer loads first.";
+
 mioGet[file_String] := Get[$specDir <> file];
 
 loadEngine[] := Module[{engineDir, res, exit},

--- a/spec/tests/walk_sequences_test.wls
+++ b/spec/tests/walk_sequences_test.wls
@@ -1,0 +1,58 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/walk_sequences_test.wls
+   ---------------------------------------------------------------------
+   The standing invariant for the walk test batch (spec/walk-tests.wl):
+   EVERY named sequence in walkTests runs to completion (not stuck, all
+   actions fire) on BOTH compositions —
+       mioCore  via transVP   (mu-term)
+       mioCoreD via transNamed (call form)
+   — with its embedded values, so the GUI's "Run test" menu and walkSteps
+   both replay them with no typing. Also checks the value-carrying ports
+   actually computed (a captured word reaches the VS entries via the
+   vAdd sync; a practise relay reaches the PS queue via pLoad).
+
+   Run headless:  wolframscript -file spec/tests/walk_sequences_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];
+Get[$dir <> "walk.wl"];   (* loads walk-tests.wl -> walkTests *)
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+hr = StringRepeat["=", 70];
+
+Print[hr]; Print["walkTests batch loaded"]; Print[hr];
+assert["walkTests is defined and non-empty", AssociationQ[walkTests] && Length[walkTests] > 0];
+assert["walkTests::usage is set (?walkTests works)", StringQ[walkTests::usage]];
+assert["loadEngine::usage is set (?loadEngine works)", StringQ[loadEngine::usage]];
+assert["walkUI::usage is set", StringQ[walkUI::usage]];
+
+Print[hr]; Print["every sequence completes on BOTH mioCore and mioCoreD"]; Print[hr];
+runs[tf_, s0_, plan_] := Module[{w = walkSteps[tf, s0, plan]},
+  !w["stuck"] && Length[w["actions"]] === Length[plan]];
+Do[Module[{plan = walkTests[k]},
+   assert[StringPadRight[k, 16] <> " on mioCore (transVP)",   runs[transVP, mioCore, plan]];
+   assert[StringPadRight[k, 16] <> " on mioCoreD (transNamed)", runs[transNamed, mioCoreD, plan]]],
+  {k, Keys[walkTests]}];
+
+Print[hr]; Print["syncs actually move data across components"]; Print[hr];
+(* sync-vadd: a captured word ends up in the VS entries via vAdd *)
+vsEntriesAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan]["states"]], vp},
+  vp = Map[Identity, viewProjections[transVP, s]];
+  If[KeyExistsQ[vp, "vSView"], #["word"] & /@ vp["vSView"]["entries"], $Failed]];
+assert["sync-vadd: captured \"chat\" reaches VS entries",
+  MemberQ[vsEntriesAfter[walkTests["sync-vadd"]], "chat"]];
+(* sync-pload: the practise relay loads PS (pSView total > 0) *)
+psTotalAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan]["states"]], vp},
+  vp = Map[Identity, viewProjections[transVP, s]];
+  If[KeyExistsQ[vp, "pSView"], vp["pSView"]["total"], $Failed]];
+assert["sync-pload: practise relay loads the PS queue (total > 0)",
+  TrueQ[psTotalAfter[walkTests["sync-pload"]] > 0]];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -1,0 +1,117 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   spec/walk-tests.wl — a batch of value-carrying test SEQUENCES (plans)
+   that drive the spec through walk WITHOUT any typing into input fields.
+   ---------------------------------------------------------------------
+   A test is a PLAN: a list of plan-entries
+     vis["port"]          take a visible action by port name (no value)
+     vis["port", value]   take a value-carrying input port, supplying value
+     tau["chan"]          take an internal sync on a named channel
+   (the vocabulary of walkResolve / walkSteps, discipline.wl + walk.wl).
+
+   Run a plan with the existing machinery:
+     walkSteps[transVP,   mioCore,  walkTests["full-roundtrip"]]   (* mu-term  *)
+     walkSteps[transNamed, mioCoreD, walkTests["full-roundtrip"]]  (* call form *)
+   or load one into the GUI from walkUI's "Run test" menu.
+
+   EVERY sequence runs to completion on BOTH mioCore (transVP) and mioCoreD
+   (transNamed) — that is the standing invariant (see
+   spec/tests/walk_sequences_test.wls). Values are embedded, so nothing has
+   to be typed; string words are quoted, sort keys are the Enum symbols
+   (alpha|recent|oldest), ids are integers, payloads are Associations.
+
+   NAMING / CLASSIFICATION (kebab-case keys):
+     vs-*    : VocabStore-only ports (capture, edit, sort/filter/export)
+     ps-*    : PracticeSession-only ports (load, navigate, record/score)
+     sync-*  : a single cross-component synchronisation (pLoad / vAdd) —
+               only meaningful in the COMPOSED system, not VS/PS alone
+     full-*  : an end-to-end run touching both syncs
+   Add new sequences under the same prefixes.
+   ===================================================================== *)
+
+walkTests::usage =
+  "walkTests is an Association <|name -> plan|> of value-carrying test \
+sequences for the walk simulator. Each plan is a list of vis[\"port\"], \
+vis[\"port\", value] and tau[\"chan\"] entries; run with walkSteps[tf, s0, \
+plan] or from walkUI's \"Run test\" menu. Every sequence completes on both \
+mioCore (transVP) and mioCoreD (transNamed).";
+
+walkTests = <|
+
+  (* --- VocabStore: capture, dedup, sort, filter, export --------------- *)
+  "vs-capture" -> {
+    vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
+    vis["add", <|"word" -> "chien", "translation" -> "dog"|>],
+    vis["add", <|"word" -> "chat"|>],            (* dedup: bumps times_seen *)
+    vis["set_sort", recent],
+    vis["set_filter", "ch"],
+    vis["export"]},
+
+  (* --- VocabStore: bulk import then sort/export ----------------------- *)
+  "vs-import" -> {
+    vis["import_bulk", <|"contents" -> "(en,fr)\nsouris|mouse\nchien|dog",
+                         "expectedTarget" -> "fr"|>],
+    vis["set_sort", oldest],
+    vis["export"]},
+
+  (* --- VocabStore: the per-entry edit surface ------------------------- *)
+  "vs-edit" -> {
+    vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
+    vis["begin_edit", 1],
+    vis["update", <|"translation" -> "feline"|>],   (* in edit-mode *)
+    vis["begin_edit", 1],
+    vis["cancel_edit"],
+    vis["update_notes", <|"id" -> 1, "notes" -> "seen in a book"|>],
+    vis["autofill", 1],
+    vis["delete", 1]},
+
+  (* --- PracticeSession: load + navigate ------------------------------- *)
+  "ps-navigate" -> {
+    vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>,
+                          <|"text" -> "chien", "translation" -> "dog", "ipa" -> "ʃjɛ̃"|>,
+                          <|"text" -> "souris", "translation" -> "mouse", "ipa" -> "muʁi"|>}],
+    vis["next_item_requested"],
+    vis["next_item_requested"],
+    vis["prev_item_requested"],
+    vis["select_item", 0],
+    vis["clear_material"]},
+
+  (* --- PracticeSession: record, re-record, attempt (score) ------------ *)
+  "ps-score" -> {
+    vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
+    vis["recording_made", "audio-A"],
+    vis["clear_recording"],
+    vis["recording_made", "audio-B"],
+    vis["attempt_made"],
+    vis["capture_vocab", "souris"],
+    tau["vAdd"]},                                   (* capture relays to VS *)
+
+  (* --- sync: VS practise_filtered -> PS load (pLoad) ------------------ *)
+  "sync-pload" -> {
+    vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
+    vis["set_filter", "ch"],
+    vis["practise_filtered"],
+    tau["pLoad"],
+    vis["select_item", 0]},
+
+  (* --- sync: PS capture_vocab -> VS add (vAdd) ----------------------- *)
+  "sync-vadd" -> {
+    vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
+    vis["recording_made", "audio"],
+    vis["attempt_made"],
+    vis["capture_vocab", "chat"],
+    tau["vAdd"]},
+
+  (* --- full end-to-end: both syncs in one run ------------------------- *)
+  "full-roundtrip" -> {
+    vis["set_filter", "ch"],
+    vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
+    vis["practise_filtered"],
+    tau["pLoad"],
+    vis["recording_made", "audio"],
+    vis["attempt_made"],
+    vis["capture_vocab", "souris"],
+    tau["vAdd"]}
+
+|>;

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -26,6 +26,18 @@
      tag[Tau, ch, subst] / Tau  internal
    ===================================================================== *)
 
+(* --- usage messages (so ?name works in a notebook) ------------------- *)
+readyTransitions::usage = "readyTransitions[tf, s] gives the enabled transitions at state s as a list of {action, successor}, normalising the engine's optional 3-tuple form.";
+inputBinderOf::usage = "inputBinderOf[action] gives the binder symbol(s) an input action coLabel[nm, binding[x]] introduces (the free variables a supplied value replaces); {} for outputs, taus and value-free inputs.";
+valueInputQ::usage = "valueInputQ[action] is True iff action is an input port that binds a value (so the walk must let the user supply one).";
+readyInputs::usage = "readyInputs[tf, s] gives the ready transitions that are value-carrying input ports — the places where the user, as the open environment, supplies real data.";
+supplyValue::usage = "supplyValue[trans, val] inserts a user value into an input transition's binder via the engine's substVv (scope-aware), returning {action, derivative-with-value}. No validation: the value is the user's responsibility.";
+viewProjections::usage = "viewProjections[tf, s] gives <|portName -> projectionValue|> for the published read-only view ports at s (the bare \"view\" or a relabelled \"{Agent}View\").";
+dataView::usage = "dataView[tf, s] renders the state's published projections through the data-compaction grid (linearizeGrid of the computed projection).";
+traceView::usage = "traceView[traceSymbol] renders the condensed event log of a walk trace (HoldFirst) with a Copy button.";
+stateDisplay::usage = "stateDisplay[s] gives a compact render of the CCS process state s (foldAgentDisplay о normalizeSC) — where you are / where a transition leads.";
+walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests, and record a trace. Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
+
 (* ---------------------------------------------------------------------
    readyTransitions[tf, s] : the enabled transitions at state s as a list
    of {action, successor}.  Normalises the engine's optional 3-tuple form
@@ -172,7 +184,8 @@ stateDisplay[s_] := If[agentDefs =!= <||>, foldAgentDisplay[normalizeSC[s]], Sho
 Options[walkUI] = {"TransitionFunction" -> transVP};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"]},
-  DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>},
+  DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>,
+     testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None]},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
         Framed[Column[{
@@ -226,10 +239,28 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
             Button["Reset \[CenterDot]", cur = agent; hist = {}; trace = {};
                inVals = <||>]}],
 
+          (* Run a value-carrying test sequence from walkTests — no typing:
+             replays the chosen plan FROM THE INITIAL AGENT, setting the trace
+             to its condensed event log and the state to the final state (hist
+             keeps the intermediate states so Back walks through it). *)
+          Row[{Style["Test: ", Bold, GrayLevel[0.4]], Spacer[4],
+               PopupMenu[Dynamic[testSel], Keys[If[ValueQ[walkTests], walkTests, <||>]]],
+               Spacer[4],
+               Button["Run test \[FilledRightTriangle]",
+                 Module[{w = walkSteps[tf, agent, walkTests[testSel]]},
+                   hist = Most[w["states"]]; trace = eventLog[w];
+                   cur = Last[w["states"]]; inVals = <||>],
+                 Enabled -> Dynamic[ValueQ[walkTests] && KeyExistsQ[walkTests, testSel]]]}],
+
           traceView[trace]
 
         }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
-      TrackedSymbols :> {cur, inVals}]]];
+      TrackedSymbols :> {cur, inVals, testSel}]]];
+
+
+(* --- the value-carrying test sequences (walkTests), loaded relative to
+   this file so walkUI's "Run test" menu and walkSteps both have them. --- *)
+Get[FileNameJoin[{DirectoryName[$InputFileName], "walk-tests.wl"}]];
 
 (* NB: the engine binds `walk = interactiveVP` (an OwnValue), so we do NOT
    reuse that name here — call walkUI[mioCore] for the richer spec harness.


### PR DESCRIPTION
Test sequences that drive the spec through `walk` with **no typing** — values are embedded in the plan, so a single click replays the whole run.

## What
- **`spec/walk-tests.wl`** — `walkTests`, an Association of **8 named value-carrying plans** (`vis["port", value]` / `tau["chan"]`), classified:
  - `vs-*` — VocabStore-only (capture/dedup, import, the edit surface)
  - `ps-*` — PracticeSession-only (load/navigate, record/score)
  - `sync-*` — one cross-component sync (`pLoad`, `vAdd`) — composed-only
  - `full-*` — end-to-end, both syncs
  Together they exercise **every** VS and PS port plus both syncs. Loaded by `walk.wl` (relative).
- **`walk.wl`** — `walkUI` gains a **`Test:` PopupMenu + `Run test` button** that replays the chosen plan from the initial agent (sets state + condensed trace; no input typing). Plus `::usage` on the walk functions (`?walkUI`, `?supplyValue`, …).
- **`paths.wl`** — `::usage` on `loadEngine` / `loadRecoveredBase` / `mioGet` (so `?loadEngine` works).
- **`tests/walk_sequences_test.wls`** — the standing invariant: **every sequence completes on both `mioCore` (`transVP`) and `mioCoreD` (`transNamed`)**, and the syncs actually move data (captured word → VS entries; practise relay → PS queue).

## Usage
- GUI: `walkUI[mioCore]` → pick from `Test:` → **Run test** (no typing). Works on `mioCoreD` too via `walkUI[mioCoreD, "TransitionFunction" -> transNamed]`.
- Headless: `walkSteps[transVP, mioCore, walkTests["full-roundtrip"]]` (or `transNamed`/`mioCoreD`).

## Verification
Full headless suite green (9 tests); the 8 sequences run on both compositions; `?loadEngine`/`?walkUI`/`?walkTests` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)