### PR TITLE
spec/walk: Forward (redo) button — scrub Back/Forward through a run

### DIFF
--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -36,8 +36,11 @@ The panel shows, top to bottom:
   bare `view`), rendered as the *computed* data through `linearizeGrid`.
 - **Transitions** — one clickable row each; hover shows *→ goes to:* the
   derivative. Value-carrying input ports get an inline field.
-- **Back / Reset**, a **`Test:` menu + `Run test`** (see below), and the
-  **condensed trace** (with Copy).
+- **Back / Forward / Reset**, a **`Test:` menu + `Run test`** (see below), and
+  the **condensed trace** (with Copy). **Back** and **Forward** scrub a run: step
+  back through the states you've visited and forward again — handy after
+  `Run test` to watch what each step of a sequence reveals. (A fresh manual step
+  or `Run test` clears the forward/redo line.)
 
 ---
 

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -36,7 +36,7 @@ viewProjections::usage = "viewProjections[tf, s] gives <|portName -> projectionV
 dataView::usage = "dataView[tf, s] renders the state's published projections through the data-compaction grid (linearizeGrid of the computed projection).";
 traceView::usage = "traceView[traceSymbol] renders the condensed event log of a walk trace (HoldFirst) with a Copy button.";
 stateDisplay::usage = "stateDisplay[s] gives a compact render of the CCS process state s (foldAgentDisplay о normalizeSC) — where you are / where a transition leads.";
-walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests, and record a trace. Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
+walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests, step Back/Forward through a run, and record a trace. Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
 
 (* ---------------------------------------------------------------------
    readyTransitions[tf, s] : the enabled transitions at state s as a list
@@ -184,7 +184,7 @@ stateDisplay[s_] := If[agentDefs =!= <||>, foldAgentDisplay[normalizeSC[s]], Sho
 Options[walkUI] = {"TransitionFunction" -> transVP};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"]},
-  DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>,
+  DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
      testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None]},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
@@ -211,7 +211,7 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                                  supplyValue[tr, inVals[nm]], tr];
                         AppendTo[hist, cur];
                         AppendTo[trace, eventOf[First[taken]]];
-                        cur = Last[taken]; inVals = <||>],
+                        cur = Last[taken]; inVals = <||>; future = {}],
                       Appearance -> "Frameless",
                       ActiveStyle -> {Background -> RGBColor[0.9, 0.95, 1.0]}],
                      (* hover: the derivative this transition leads to (symbolic,
@@ -230,14 +230,26 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                       Nothing]}]]],
                 trans]]],
 
+          (* Back / Forward scrub the run: Back pushes the current step onto a
+             `future` stack; Forward replays it. A fresh step or Run test clears
+             `future` (you've branched off the redo line). *)
           Row[{
             Button["\[LeftArrow] Back",
-              If[hist =!= {}, cur = Last[hist]; hist = Most[hist];
-                 trace = Most[trace]; inVals = <||>],
+              If[hist =!= {},
+                AppendTo[future, {cur, Last[trace]}];
+                cur = Last[hist]; hist = Most[hist]; trace = Most[trace];
+                inVals = <||>],
               Enabled -> Dynamic[hist =!= {}]],
+            Spacer[4],
+            Button["Forward \[RightArrow]",
+              If[future =!= {},
+                Module[{f = Last[future]},
+                  AppendTo[hist, cur]; cur = f[[1]]; AppendTo[trace, f[[2]]];
+                  future = Most[future]; inVals = <||>]],
+              Enabled -> Dynamic[future =!= {}]],
             Spacer[6],
             Button["Reset \[CenterDot]", cur = agent; hist = {}; trace = {};
-               inVals = <||>]}],
+               future = {}; inVals = <||>]}],
 
           (* Run a value-carrying test sequence from walkTests — no typing:
              replays the chosen plan FROM THE INITIAL AGENT, setting the trace
@@ -249,13 +261,13 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                Button["Run test \[FilledRightTriangle]",
                  Module[{w = walkSteps[tf, agent, walkTests[testSel]]},
                    hist = Most[w["states"]]; trace = eventLog[w];
-                   cur = Last[w["states"]]; inVals = <||>],
+                   cur = Last[w["states"]]; future = {}; inVals = <||>],
                  Enabled -> Dynamic[ValueQ[walkTests] && KeyExistsQ[walkTests, testSel]]]}],
 
           traceView[trace]
 
         }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
-      TrackedSymbols :> {cur, inVals, testSel}]]];
+      TrackedSymbols :> {cur, inVals, testSel, future}]]];
 
 
 (* --- the value-carrying test sequences (walkTests), loaded relative to


### PR DESCRIPTION
`walkUI` had **Back** but no **Forward**, so after `Run test` you could step back but not re-advance. This adds a `future` redo stack:

- **Back** pushes the current step (state + trace event) onto `future` and pops `hist`.
- **Forward** replays the top of `future`.
- a fresh manual step or `Run test` **clears** `future` (you've branched off the redo line).

So you can scrub back and forward through a sequence to watch what each step reveals — pairs nicely with the `Test:` ▸ `Run test` dropdown.

Docs kept in lockstep (per your note about docs lagging): `?walkUI` mentions Back/Forward, and `walk.md`'s panel section documents the scrub.

Verified: loads clean, `walkUI` builds, full headless suite green (9 tests). GUI rendering is notebook-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)