### PR TITLE
spec/g2p: espeak grapheme-to-phoneme bridge — first external service run live

### DIFF
--- a/spec/g2p.wl
+++ b/spec/g2p.wl
@@ -1,0 +1,46 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   spec/g2p.wl — espeak grapheme-to-phoneme bridge
+   ---------------------------------------------------------------------
+   The FIRST external service made to run FOR REAL inside the spec: a
+   WolframScript -> espeak bridge (RunProcess) that turns a written word
+   into its IPA transcription. This is the IO mechanism behind the espeak
+   half of the `enrichOracle` (the "ipa" it would produce); ASR
+   (recognisePhonemes, audio -> phonemes) is a DIFFERENT service, not this.
+
+   Standalone and pure-WL (no engine needed). It is NOT yet wired into the
+   agents: whether to consume it as a PURE LIVE ORACLE (a function the spec
+   calls) or to model espeak as a CCS SERVICE AGENT (a process with
+   request/reply ports, synchronised on a channel) is an open architectural
+   decision — the per-service stub->live promotion keeps the port signature
+   invariant either way (see spec/docs/co-development.md).
+
+   NB: the binary is `espeak` (NOT espeak-ng).
+   ===================================================================== *)
+
+espeakAvailableQ::usage =
+  "espeakAvailableQ[] is True iff the `espeak` binary is callable.";
+espeakG2P::usage =
+  "espeakG2P[word, voice:\"en\"] gives espeak's IPA transcription of word \
+(grapheme->phoneme) via RunProcess, or $Failed if espeak is unavailable / \
+errors. Output includes stress marks (ˈ ˌ); espeakG2Pplain strips them. The \
+binary is `espeak`, not espeak-ng.";
+espeakG2Pplain::usage =
+  "espeakG2Pplain[word, voice:\"en\"] is espeakG2P with stress marks (ˈ ˌ) \
+removed — matching the spec's stress-free ipa style (e.g. \"ʃa\").";
+
+espeakAvailableQ[] :=
+  Quiet[TrueQ[RunProcess[{"espeak", "--version"}]["ExitCode"] === 0]];
+
+espeakG2P[word_String, voice_String : "en"] := Module[{res},
+  res = Quiet[RunProcess[{"espeak", "-q", "--ipa", "-v", voice, word}]];
+  If[AssociationQ[res] && res["ExitCode"] === 0,
+     (* RunProcess hands back stdout as raw bytes; decode UTF-8 so the IPA is
+        proper Unicode (ʃ ˈ a), not the byte sequence {202,131,203,136,97}. *)
+     StringTrim[FromCharacterCode[ToCharacterCode[res["StandardOutput"]], "UTF-8"]],
+     $Failed]];
+
+espeakG2Pplain[word_String, voice_String : "en"] :=
+  With[{ipa = espeakG2P[word, voice]},
+    If[StringQ[ipa], StringDelete[ipa, "ˈ" | "ˌ"], ipa]];

--- a/spec/tests/g2p_test.wls
+++ b/spec/tests/g2p_test.wls
@@ -1,0 +1,54 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/g2p_test.wls
+   ---------------------------------------------------------------------
+   The espeak G2P bridge (spec/g2p.wl) runs for real: a written word ->
+   its IPA. Robust assertions (key phonemes present, not exact strings,
+   so it survives espeak version drift). Skips cleanly if espeak is absent
+   (the bridge degrades to $Failed; this is an external-service spike).
+
+   Run headless:  wolframscript -file spec/tests/g2p_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "g2p.wl"];
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+hr = StringRepeat["=", 70];
+
+Print[hr];
+If[!espeakAvailableQ[],
+  Print["espeak not available on this machine — SKIPPING (bridge -> $Failed)."];
+  Print["  espeakG2P[\"chat\"] = ", InputForm[espeakG2P["chat"]]];
+  Print[hr]; Exit[0]];
+
+Print["espeak G2P bridge runs for real"]; Print[hr];
+Print["   espeak version: ", StringTrim[RunProcess[{"espeak", "--version"}]["StandardOutput"]]];
+
+(* IPA chars built from codepoints (ASCII source, so encoding-proof) — the
+   bridge returns proper Unicode, so we match against decoded chars:
+   esh = ʃ (U+0283), rr = ʁ (U+0281), stress = ˈ (U+02C8) *)
+esh = FromCharacterCode[643]; rr = FromCharacterCode[641]; stress = FromCharacterCode[712];
+
+assert["fr chat -> non-empty IPA containing ʃ",
+  StringQ[espeakG2P["chat", "fr"]] && StringContainsQ[espeakG2P["chat", "fr"], esh]];
+assert["fr souris -> contains ʁ",
+  StringContainsQ[espeakG2P["souris", "fr"], rr]];
+assert["en chat -> non-empty IPA",
+  StringQ[espeakG2P["chat", "en"]] && espeakG2P["chat", "en"] =!= ""];
+assert["bridge decodes UTF-8 (ʃ is one char U+0283, not two bytes)",
+  MemberQ[ToCharacterCode[espeakG2P["chat", "fr"]], 643]];
+assert["espeakG2Pplain strips the stress mark (no ˈ)",
+  !StringContainsQ[espeakG2Pplain["chat", "fr"], stress]];
+assert["plain fr chat is the spec-style ipa (ʃ kept, no stress)",
+  StringContainsQ[espeakG2Pplain["chat", "fr"], esh]];
+
+Print["   (fr chat codepoints = ", ToCharacterCode[espeakG2P["chat", "fr"]],
+      " ; plain = ", ToCharacterCode[espeakG2Pplain["chat", "fr"]], ")"];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];


### PR DESCRIPTION
The espeak spike's de-risk + IO mechanism: a WolframScript→`espeak` bridge that turns a written word into its IPA — **the first external service made to run for real inside the spec.**

## What
- `spec/g2p.wl` — `espeakG2P[word, voice]` (raw IPA, with stress), `espeakG2Pplain` (stress stripped, spec-style), `espeakAvailableQ`. Standalone, pure-WL (`RunProcess`); **not yet wired into the agents.** `::usage` on all.
- `spec/tests/g2p_test.wls` — verifies the live call (`fr chat → ʃˈa`, `souris → suʁˈi`), asserting via **codepoints** (encoding-proof) and **skipping cleanly if espeak is absent**.

## Bug caught & fixed
`RunProcess` returns espeak's stdout as raw **UTF-8 bytes**, so the IPA came back as `{202,131,…}` rather than decoded characters; the bridge now `FromCharacterCode[…, "UTF-8"]`-decodes → proper Unicode (`fr chat → {643,712,97}` = `ʃ ˈ a`).

## Open (for review — the architectural part)
Whether to consume espeak as a **pure live oracle** (a function the spec calls) or to model it as a **CCS service agent** (request/reply ports, synchronised on a channel — the framing in `co-development.md`). The per-service stub→live promotion keeps the port signature invariant either way, so this bridge stands regardless. I have a lean (below) but it's your call.

Also flagged: espeak returns decoded Unicode while the spec's *source* ipa literals read byte-form under wolframscript — to reconcile when wiring.

Binary is `espeak`, not espeak-ng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)