### PR TITLE
spec: recover Helm (session/language settings) — owns the (source,target) pair

### DIFF
--- a/spec/HelmFunctions.wl
+++ b/spec/HelmFunctions.wl
@@ -1,0 +1,40 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — Helm value-functions, RECOVERED (function pass)
+   ---------------------------------------------------------------------
+   The functional bodies for the Helm agent (HelmRecovered.wl), recovered
+   from src/ui/sidebar.py + language_state.py. ADDITIVE: attaches downvalues
+   only; load AFTER the recovered agent.
+
+   helmView is the read-only projection the rest of the system reads (the
+   read_source_lang / read_target_code / read_training_lang helpers). It is
+   the espeak/translation/TTS oracles' source of the (source, target) pair:
+     g2pOracle      : voice = target (the material language code)
+     enrichOracle   : translate source -> target
+     TTS            : tts engine + speed
+   ===================================================================== *)
+
+trainingNameOf::usage =
+  "trainingNameOf[code] gives the training-map full language name for a target \
+language code (e.g. \"fr\" -> \"French\"); unknown codes pass through as their \
+own string. Recovered from the sidebar's target-code -> name mapping.";
+helmView::usage =
+  "helmView[source, target, tts, speed] is Helm's read-only session projection \
+<|source, target, language, tts, speed|> — the (source, target) language pair \
+(plus TTS engine/speed) that the rest of the system reads (it never writes it). \
+`language` is trainingNameOf[target].";
+
+(* target-code -> training-map full name (sidebar's language map; the common
+   set — unknown codes pass through, so it degrades gracefully) *)
+helmTrainingNames = <|
+  "en" -> "English", "fr" -> "French", "pt" -> "Portuguese",
+  "de" -> "German", "es" -> "Spanish", "it" -> "Italian"|>;
+trainingNameOf[code_] := Lookup[helmTrainingNames, ToString[code], ToString[code]];
+
+helmView[source_, target_, tts_, speed_] := <|
+  "source"   -> source,                  (* native language NAME *)
+  "target"   -> target,                  (* target language CODE *)
+  "language" -> trainingNameOf[target],  (* target's training-map name *)
+  "tts"      -> tts,
+  "speed"    -> speed|>;

--- a/spec/HelmRecovered.wl
+++ b/spec/HelmRecovered.wl
@@ -1,0 +1,52 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — Helm (Session / language settings), RECOVERED
+   ---------------------------------------------------------------------
+   Recovered from src/ui/sidebar.py + src/ui/language_state.py, NOT invented.
+   language_state.py is explicit that "the sidebar is the sole owner of
+   language" (it raises a tripwire if any other module writes the language
+   keys); every other module READS via read_source_lang / read_target_code /
+   read_training_lang. That is precisely the view!/afforded discipline: Helm
+   OWNS the session settings and publishes a read-only projection; VS, PS and
+   the oracles (g2pOracle/enrichOracle/TTS) READ that projection — they never
+   write it.
+
+   STATE: Helm[source, target, tts, speed]
+     source : the user's native language NAME  (e.g. "English")  — source_language
+     target : the target/material language CODE (e.g. "fr")      — material_language
+     tts    : the TTS engine                    (e.g. google | espeak)
+     speed  : speech rate (wpm)                 — only meaningful for espeak
+
+   PORTS (sidebar controls):
+     view!         always — the helmView projection everyone reads
+     set_source    set the source (native) language name
+     set_target    set the target language code (target_language mirrors it)
+     set_tts       set the TTS engine
+     set_speed     ONLY when tts === espeak  (the wpm slider shows only for
+                   espeak in sidebar.py — a genuine guard)
+
+   COMPOSITION (decision — see helm-recovery / the PR): Helm is STANDALONE.
+   No control guard in VS/PS reads the language (it is passive data the oracles
+   consume, like the logical clock), so Helm is not synced into mioCore; its
+   projection feeds the oracles at their boundary. Promote to a synced agent
+   only if a guard ever comes to depend on a setting.
+
+   LEAF agent (every branch loops back to Helm) — no sub-agent expansion.
+   LOAD ORDER: RCA_core.wl, discipline.wl, then this (+ HelmFunctions.wl).
+   ===================================================================== *)
+
+defineAgent["Helm", {source, target, tts, speed},
+  choice[
+    precede[label["view", param[helmView[source, target, tts, speed]]],
+      call["Helm", source, target, tts, speed]],
+    precede[coLabel["set_source", binding[s]],
+      call["Helm", s, target, tts, speed]],
+    precede[coLabel["set_target", binding[t]],
+      call["Helm", source, t, tts, speed]],
+    precede[coLabel["set_tts", binding[e]],
+      call["Helm", source, target, e, speed]],
+    (* the wpm slider is espeak-only in sidebar.py (tts_is_espeak guard) *)
+    if[tts === espeak,
+      precede[coLabel["set_speed", binding[w]],
+        call["Helm", source, target, tts, w]]]]]

--- a/spec/MiolingoSpec.wl
+++ b/spec/MiolingoSpec.wl
@@ -45,3 +45,7 @@ loadRecoveredBase[];
 mioGet["VocabStoreFunctions.wl"];
 mioGet["PracticeSessionFunctions.wl"];
 mioGet["MioCore.wl"];
+(* Helm — session/language settings (the source/target pair the oracles read).
+   Standalone (not composed into mioCore): no control guard reads the language. *)
+mioGet["HelmRecovered.wl"];
+mioGet["HelmFunctions.wl"];

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -55,13 +55,16 @@ Location: `/spec/interaction-forms.md`. Governed by: human designer.
 
 | Component | CCS agent family | Kind | Priority |
 |---|---|---|---|
-| Practice Session | `PracticeSession` | Stateful agent — tight interaction loop | High |
-| Vocabulary Manager | `VocabStore` | Stateful agent — CRUD with IPA | High |
-| Stats Display | (projection of `PracticeSession`/`VocabStore`) | Read-only view port — **not** a standalone agent | Medium |
-| History Browser | (projection of a session/store agent) | Read-only view port — **not** a standalone agent | Medium |
+| Practice Session | `PracticeSession` | Stateful agent — tight interaction loop | High — **recovered** (PS) |
+| Vocabulary Manager | `VocabStore` | Stateful agent — CRUD with IPA | High — **recovered** (VS) |
+| Session / language | `Helm` | Stateful agent — finite-choice settings; **owns the (source, target) language pair** | **recovered** |
+| Stats Display † | (projection of `PracticeSession`/`VocabStore`) | Read-only view port — **not** a standalone agent | Medium |
+| History Browser † | (projection of a session/store agent) | Read-only view port — **not** a standalone agent | Medium |
 | Mode Navigation | `ModeSelector` | Stateful agent — finite-choice | Low |
 
 Correction from the previous draft: the read-only "displays" are most likely *view ports on* the stateful agents (a published `view!` projection rendered by a skin), not agents in their own right. Promote one to a standalone agent only if it genuinely owns state; otherwise it is a presentation of another agent's projection. Decide this deliberately per component.
+
+**† Stats / History and the external store (a rigging issue).** Treating these as *view ports* is correct only under the current modelling assumption that each component stores its own domain data in-process. In any sensible implementation, stats and history are retrieved from an **external store**, not held by the component. Rigging that external store into the system — where the data lives, who reads/writes it, how a view port is backed by a *query* rather than in-process state — is a key **rig** concern, and the question of *how* it is done may itself need to enter the model (an external-store agent / port), not be left wholly to L3. Flagged for when stats/history (and persistence generally) are recovered.
 
 ## Execution Model
 

--- a/spec/tests/helm_test.wls
+++ b/spec/tests/helm_test.wls
@@ -1,0 +1,56 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/helm_test.wls
+   ---------------------------------------------------------------------
+   Helm (session/language settings) — the recovered agent + functions.
+   Checks the port structure (the set_speed-only-when-espeak guard), the
+   read-only helmView projection (the source/target pair the oracles read),
+   and value-driven settings changes. Helm is a STANDALONE call-based agent
+   (transNamed), not composed into mioCore.
+
+   Run headless:  wolframscript -file spec/tests/helm_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];   (* loads HelmRecovered + HelmFunctions *)
+Get[$dir <> "walk.wl"];           (* readyTransitions / supplyValue / viewProjections *)
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+ports[s_] := Sort[ToString /@ portName /@ First /@ readyTransitions[transNamed, s]];
+sup[s_, nm_, v_] := Last[supplyValue[SelectFirst[readyTransitions[transNamed, s], portName[First[#]] === nm &], v]];
+view[s_] := Map[Identity, viewProjections[transNamed, s]["view"]];
+hr = StringRepeat["=", 70];
+
+sG = call["Helm", "English", "fr", google, 250];   (* tts = google *)
+sE = call["Helm", "English", "fr", espeak, 250];    (* tts = espeak *)
+
+Print[hr]; Print["1. ports — set_speed is gated on tts === espeak"]; Print[hr];
+assert["google: view + set_source/target/tts, NO set_speed",
+  ports[sG] === {"set_source", "set_target", "set_tts", "view"}];
+assert["espeak: + set_speed appears",
+  MemberQ[ports[sE], "set_speed"]];
+assert["set_speed absent unless espeak", !MemberQ[ports[sG], "set_speed"]];
+
+Print[hr]; Print["2. helmView projection — the (source,target) pair others read"]; Print[hr];
+v = view[sG];
+assert["source / target / language / tts / speed present",
+  v["source"] === "English" && v["target"] === "fr" &&
+  v["language"] === "French" && v["tts"] === google && v["speed"] === 250];
+assert["trainingNameOf maps the target code", trainingNameOf["pt"] === "Portuguese"];
+assert["unknown code passes through", trainingNameOf["xx"] === "xx"];
+
+Print[hr]; Print["3. value-driven settings changes (no typing)"]; Print[hr];
+assert["set_target pt -> target pt, language Portuguese",
+  view[sup[sG, "set_target", "pt"]]["language"] === "Portuguese"];
+assert["set_source -> updates source",
+  view[sup[sG, "set_source", "Italian"]]["source"] === "Italian"];
+sEsp = sup[sG, "set_tts", espeak];
+assert["set_tts espeak -> set_speed now available", MemberQ[ports[sEsp], "set_speed"]];
+assert["then set_speed 300 -> speed 300", view[sup[sEsp, "set_speed", 300]]["speed"] === 300];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];


### PR DESCRIPTION
The next component (you picked Helm), recovered from `src/ui/sidebar.py` + `src/ui/language_state.py`.

## Sync structure (the pure CCS, from the Python)
`language_state.py` is explicit that **the sidebar is the sole owner of the language pair** (a tripwire warns if any other module writes it; everyone else *reads* via `read_source_lang`/`read_target_code`/`read_training_lang`). That's the spec's `view!` discipline exactly: **Helm owns the settings, others read its projection.**

- `HelmRecovered.wl` — `Helm[source, target, tts, speed]`, a leaf agent. Ports: `view!` always; `set_source`/`set_target`/`set_tts` always; **`set_speed` only when `tts === espeak`** (the wpm slider is espeak-only in `sidebar.py` — a genuine guard).
- `HelmFunctions.wl` — `helmView` (the read-only `<|source, target, language, tts, speed|>` projection the oracles read) + `trainingNameOf` (target code → training-map name).
- `tests/helm_test.wls` — the `set_speed`-gated-on-`espeak` guard, the projection, and value-driven settings changes. All green; **full suite (11 tests) green**.
- `MiolingoSpec.wl` loads Helm (agent + functions).

## Decision flagged (your call)
**Helm is standalone — not synced into `mioCore`.** No control guard in VS/PS reads the language; it's *data* the oracles consume (like the logical clock), so Helm publishes a projection that feeds `g2pOracle` (voice = target), `enrichOracle` (source→target), TTS — rather than adding an L1 sync channel. Promote to a synced agent only if a guard ever comes to depend on a setting. If you'd rather it compose, easy to change.

## Also (your external-store note)
`ARCHITECTURE.md`: Stats/History are "view ports" **only** under the current in-component-storage assumption; really they come from an **external store**, and rigging that store in may itself need to enter the model — flagged with a † note on those inventory rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)