### PR TITLE
spec/walk: pre-fill the input field with the port's first binder symbol

### DIFF
--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -220,12 +220,16 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                      Column[{Style["\[RightArrow] goes to:", Bold, GrayLevel[0.4]],
                              stateDisplay[Last[tr]]}]],
                     If[valueInputQ[act],
-                      Row[{Spacer[6],
-                           Style["\[LeftArrow] " <> ToString[First[inputBinderOf[act]]] <> " = ",
-                             GrayLevel[0.5]],
-                           (* default to "" (not Missing[KeyAbsent]) when the
-                              port has no value yet; write inVals[nm] on edit *)
-                           InputField[Dynamic[Lookup[inVals, nm, ""], (inVals[nm] = #) &],
+                      Row[{Spacer[6], Style["\[LeftArrow] ", GrayLevel[0.5]],
+                           (* pre-fill with the port's first binder SYMBOL as the
+                              editable starting point (via inputBinderOf — a
+                              pattern match, never Part-indexing, so it is safe
+                              for any action shape; cf. issue #150). Untouched
+                              fields don't set inVals[nm], so the step stays
+                              symbolic; the user types over the symbol to supply. *)
+                           InputField[
+                             Dynamic[Lookup[inVals, nm, First[inputBinderOf[act], ""]],
+                                     (inVals[nm] = #) &],
                              Expression, FieldSize -> 20, ContinuousAction -> False]}],
                       Nothing]}]]],
                 trans]]],


### PR DESCRIPTION
The pre-fill you wanted — the input field initially shows the port's first parameter (binder) as an editable starting point.

**Done safely via `inputBinderOf`** (pattern match), not `Part`-indexing. Your `tr[[1,2,1]]` broke `walkUI` because the row `Map` covers *all* action shapes — outputs `label[_, param[_]]`, taus, arity‑0 inputs `coLabel[nm]` — where `[[1,2,1]]` doesn't exist, and `Depth > 2` can't distinguish them. `First[inputBinderOf[act], ""]` returns the binder for `coLabel[_, binding[x]]` and `""` for everything else.

Verified: `coLabel[add, binding[w]] → w`; arity‑0 / outputs / taus → `""`, no `Part` error. The `"← "` label drops the now-redundant binder name. Untouched fields don't set `inVals[nm]`, so the step stays symbolic; you type over the symbol to supply. `walkUI` builds; suite green.

The broader **multi-binder (arity 2+) limitation** — one field, one value — is recorded separately in **#150** (not for fixing; the convention is arity 0/1 + a list/Association for multi-value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)