### PR TITLE
spec: compose Helm into mioCore + per-port panel view (3 view ports)

### DIFF
--- a/spec/HelmFunctions.wl
+++ b/spec/HelmFunctions.wl
@@ -32,7 +32,15 @@ helmTrainingNames = <|
   "de" -> "German", "es" -> "Spanish", "it" -> "Italian"|>;
 trainingNameOf[code_] := Lookup[helmTrainingNames, ToString[code], ToString[code]];
 
-helmView[source_, target_, tts_, speed_] := <|
+(* target_String (not target_): the SAME held-until-concrete discipline as
+   vocabView[entries_List] / sessionView[phrases_List]. In merge[], buildSystem
+   expands Helm into a mu-term EAGERLY; an unrestricted target_ lets helmView
+   fire while `target` is still the formal binder SYMBOL, so trainingNameOf[target]
+   collapses to trainingNameOf["target"] -> "target" BEFORE substitution puts the
+   real "fr" in (the language-stuck-on-the-binder bug, surfaced by composing Helm
+   into mioCore). Gating on target_String keeps the whole projection symbolic
+   until the concrete code lands, then computes consistently. *)
+helmView[source_, target_String, tts_, speed_] := <|
   "source"   -> source,                  (* native language NAME *)
   "target"   -> target,                  (* target language CODE *)
   "language" -> trainingNameOf[target],  (* target's training-map name *)

--- a/spec/HelmRecovered.wl
+++ b/spec/HelmRecovered.wl
@@ -26,11 +26,14 @@
      set_speed     ONLY when tts === espeak  (the wpm slider shows only for
                    espeak in sidebar.py — a genuine guard)
 
-   COMPOSITION (decision — see helm-recovery / the PR): Helm is STANDALONE.
-   No control guard in VS/PS reads the language (it is passive data the oracles
-   consume, like the logical clock), so Helm is not synced into mioCore; its
-   projection feeds the oracles at their boundary. Promote to a synced agent
-   only if a guard ever comes to depend on a setting.
+   COMPOSITION (updated 2026-06-01): Helm is composed into mioCore as a PURE
+   PARALLEL agent — NO control guard in VS/PS reads the language (it is passive
+   data the oracles consume, like the logical clock), so there is no restricted
+   channel: Helm rides alongside, contributing its helmView projection and its
+   set_* inputs to the system ready set. (Originally kept standalone for exactly
+   that reason; merging it in costs nothing and surfaces its viewport beside
+   pSView/vSView.) If a guard ever comes to depend on a setting, add the
+   corresponding restricted sync at that point.
 
    LEAF agent (every branch loops back to Helm) — no sub-agent expansion.
    LOAD ORDER: RCA_core.wl, discipline.wl, then this (+ HelmFunctions.wl).

--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -26,19 +26,31 @@
      vAdd  : PS.capture_vocab(word)  --vAdd!(word)-->   VS adds the word
      pLoad : VS.practise_filtered    --pLoad!(phrases)--> PS loads them
 
-   LOAD ORDER: RCA_core.wl, discipline.wl, PracticeSessionRecovered.wl,
-   VocabStoreRecovered.wl, then this file. Initial state: Practice with no
-   material; VocabStore signed-in, empty.
+   Helm is composed in as a PURE PARALLEL agent (2026-06-01): NO control guard
+   in PS/VS reads the language, so there is no new restricted channel — Helm
+   just rides alongside, contributing its helmView projection (the source/target
+   pair the oracles read) and its set_source/set_target/set_tts/set_speed inputs
+   to the system's ready set. Its `view` relabels to helmView (third view port,
+   beside pSView/vSView). Standalone was only justified WHILE nothing synced on
+   the language; composing it in costs nothing and surfaces its viewport.
 
-   VERIFIED on the engine (2026-05-31): transVP[mioCore] external ready set is
-   {add, import_bulk, load_material, pSView, set_filter, set_sort, vSView}
-   — no bare `view` clash; vAdd/pLoad restricted (internal tau).
+   LOAD ORDER: RCA_core.wl, discipline.wl, PracticeSessionRecovered.wl,
+   VocabStoreRecovered.wl, HelmRecovered.wl, then this file. Initial state:
+   Practice with no material; VocabStore signed-in, empty; Helm English/fr,
+   google TTS, 250 wpm.
+
+   VERIFIED on the engine (2026-06-01): transVP[mioCore] external ready set is
+   {add, helmView, import_bulk, load_material, pSView, set_filter, set_source,
+   set_sort, set_target, set_tts, vSView} — three view ports, no bare `view`
+   clash; vAdd/pLoad restricted (internal tau). (set_speed appears once tts is
+   set to espeak.)
    ===================================================================== *)
 
 mioCore =
   merge[
     {"PS" -> call["PS", {}, 0, none, none],
-     "VS" -> call["VS", signedIn, {}, alpha, none, none]},
+     "VS" -> call["VS", signedIn, {}, alpha, none, none],
+     "Helm" -> call["Helm", "English", "fr", google, 250]},
     {label["vAdd"], label["pLoad"]}];
 
 (* Compact call-based twin (mergeDefined): same composition, but stepped with
@@ -50,5 +62,6 @@ mioCore =
 mioCoreD =
   mergeDefined[
     {"PS" -> call["PS", {}, 0, none, none],
-     "VS" -> call["VS", signedIn, {}, alpha, none, none]},
+     "VS" -> call["VS", signedIn, {}, alpha, none, none],
+     "Helm" -> call["Helm", "English", "fr", google, 250]},
     {label["vAdd"], label["pLoad"]}];

--- a/spec/MiolingoSpec.wl
+++ b/spec/MiolingoSpec.wl
@@ -44,8 +44,12 @@ loadRecoveredBase[];
    downvalues only. See spec/docs/function-recovery.md. *)
 mioGet["VocabStoreFunctions.wl"];
 mioGet["PracticeSessionFunctions.wl"];
-mioGet["MioCore.wl"];
-(* Helm — session/language settings (the source/target pair the oracles read).
-   Standalone (not composed into mioCore): no control guard reads the language. *)
-mioGet["HelmRecovered.wl"];
+(* Helm value-functions. HelmRecovered (the AGENT) is already loaded by
+   loadRecoveredBase[]; here we only add its function bodies. helmView MUST be
+   defined BEFORE MioCore: mioCore = merge[...] eagerly buildSystems each agent
+   into a mu-term, computing helmView["English","fr",...] with the concrete
+   initial values at that point. (mioCoreD defers to step time and tolerates
+   either order; mioCore needs it now.) Helm is composed as a PURE PARALLEL
+   agent — no control guard reads the language, so no restricted sync. *)
 mioGet["HelmFunctions.wl"];
+mioGet["MioCore.wl"];

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -57,12 +57,41 @@ Location: `/spec/interaction-forms.md`. Governed by: human designer.
 |---|---|---|---|
 | Practice Session | `PracticeSession` | Stateful agent — tight interaction loop | High — **recovered** (PS) |
 | Vocabulary Manager | `VocabStore` | Stateful agent — CRUD with IPA | High — **recovered** (VS) |
-| Session / language | `Helm` | Stateful agent — finite-choice settings; **owns the (source, target) language pair** | **recovered** |
+| Session / language | `Helm` | Stateful agent — finite-choice settings; **owns the (source, target) language pair** | **recovered + composed** ‡ |
 | Stats Display † | (projection of `PracticeSession`/`VocabStore`) | Read-only view port — **not** a standalone agent | Medium |
 | History Browser † | (projection of a session/store agent) | Read-only view port — **not** a standalone agent | Medium |
 | Mode Navigation | `ModeSelector` | Stateful agent — finite-choice | Low |
 
 Correction from the previous draft: the read-only "displays" are most likely *view ports on* the stateful agents (a published `view!` projection rendered by a skin), not agents in their own right. Promote one to a standalone agent only if it genuinely owns state; otherwise it is a presentation of another agent's projection. Decide this deliberately per component.
+
+**‡ Helm and how the language reaches its consumers.** Helm is composed into
+`mioCore` as a **pure parallel** agent (no restricted sync): it *owns* the
+`(source, target, tts, speed)` tuple and *publishes* it as `helmView`, exactly
+mirroring `language_state.py` (the sidebar is the sole owner; everyone else
+reads via `read_source_lang` / `read_target_code` / `read_training_lang`). That
+owner→reader split **is** the `view!` discipline.
+
+Crucially, VS and PS do **not** receive the language through any port. No
+**control guard** in VS/PS branches on it (logical-clock precedent: a value no
+guard reads is *data*, not control), so it is not threaded as a sync. It
+reaches the vocab/practice sides **indirectly, through the oracle boundary**:
+the g2p/IPA, translation/enrich and TTS oracles (live oracles, not modelled
+agents) read `helmView` for the `(source, target)` pair, and the *result* of
+that — an IPA string, a translation, audio — enters VS/PS baked into the value
+of an ordinary input port (`add` already carries an `ipa`; `load_material`
+already carries translations). The language selects *which* oracle output,
+upstream of the port.
+
+The honest gap: today that oracle→`helmView` read is **implicit** (test data
+carries pre-baked `ipa`/`translation` values, correct by fiat). Making it
+explicit — the oracle call reading `(source, target)` from `helmView` — is a
+deliberate **`rig`** decision of the same shape as the external-store question
+below: does the read-edge stay *ambient* (oracle reads the projection at its
+boundary) or *enter the model* (an explicit parameter/sync)? The one place a
+setting already gates a port is `set_speed` (`if[tts === espeak, …]`) — a genuine
+**control** dependency, but on Helm's *own* state, so internal. The day a VS/PS
+port's *readiness* comes to depend on the language, **that** edge must enter the
+model as a restricted sync.
 
 **† Stats / History and the external store (a rigging issue).** Treating these as *view ports* is correct only under the current modelling assumption that each component stores its own domain data in-process. In any sensible implementation, stats and history are retrieved from an **external store**, not held by the component. Rigging that external store into the system — where the data lives, who reads/writes it, how a view port is backed by a *query* rather than in-process state — is a key **rig** concern, and the question of *how* it is done may itself need to enter the model (an external-store agent / port), not be left wholly to L3. Flagged for when stats/history (and persistence generally) are recovered.
 

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -49,7 +49,7 @@ $minEngineSha = "5bcc031";
 
 mioGet::usage = "mioGet[\"file.wl\"] Gets a spec file by name, relative to $specDir (this spec directory, derived from paths.wl's own location).";
 loadEngine::usage = "loadEngine[] Gets the RCA engine ($rca = $RCA_CORE env var, else the canonical checkout) AND asserts (git merge-base --is-ancestor) that the checkout contains $minEngineSha, aborting loudly on divergence. The shared coordinate between the spec and engine repos.";
-loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the two recovered agents (PracticeSessionRecovered.wl, VocabStoreRecovered.wl) in order — the common base every spec consumer loads first.";
+loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the three recovered agents (PracticeSessionRecovered.wl, VocabStoreRecovered.wl, HelmRecovered.wl) in order — the common base every spec consumer loads first (MioCore composes all three).";
 
 mioGet[file_String] := Get[$specDir <> file];
 
@@ -78,4 +78,5 @@ loadEngine[] := Module[{engineDir, res, exit},
 loadRecoveredBase[] := (
   mioGet["discipline.wl"];
   mioGet["PracticeSessionRecovered.wl"];
-  mioGet["VocabStoreRecovered.wl"]);
+  mioGet["VocabStoreRecovered.wl"];
+  mioGet["HelmRecovered.wl"]);   (* third recovered agent; MioCore composes it *)

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -36,8 +36,11 @@ lab[a_]     := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
 
 mu0 = transVP[mioCore];
 de0 = transNamed[mioCoreD];
-expected = {"add", "import_bulk", "load_material", "pSView",
-            "set_filter", "set_sort", "vSView"};
+(* includes Helm's ports (2026-06-01): helmView + set_source/set_target/set_tts.
+   set_speed is NOT here — it is espeak-only and the initial tts is google. *)
+expected = {"add", "helmView", "import_bulk", "load_material", "pSView",
+            "set_filter", "set_sort", "set_source", "set_target", "set_tts",
+            "vSView"};   (* sorted: "set_sort" < "set_source" (r < u) *)
 
 Print[hr]; Print["1. EXTERNAL READY-SET PARITY"]; Print[hr];
 Print["   merge       (transVP)   : ", InputForm[names[mu0]]];

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -26,6 +26,11 @@
      ps-*    : PracticeSession-only ports (load, navigate, record/score)
      sync-*  : a single cross-component synchronisation (pLoad / vAdd) —
                only meaningful in the COMPOSED system, not VS/PS alone
+     helm-*  : Helm session/language settings. Thin in ISOLATION (a lone Helm
+               just flips a field); meaningful only in the COMPOSED system,
+               where the (source, target) pair Helm owns is the data the vocab/
+               practice sides and the oracles read — so these set the pair and
+               then drive a VS/PS step across that seam.
      full-*  : an end-to-end run touching both syncs
    Add new sequences under the same prefixes.
    ===================================================================== *)
@@ -102,6 +107,22 @@ walkTests = <|
     vis["attempt_made"],
     vis["capture_vocab", "chat"],
     tau["vAdd"]},
+
+  (* --- Helm: settings tour + the espeak-only set_speed guard ---------- *)
+  "helm-settings" -> {
+    vis["set_source", "Italian"],
+    vis["set_target", "pt"],          (* language now Portuguese in helmView *)
+    vis["set_tts", espeak],           (* unlocks the wpm slider (set_speed) *)
+    vis["set_speed", 300],
+    vis["set_tts", google]},          (* set_speed disappears again *)
+
+  (* --- Helm -> VocabStore: set the language pair, THEN capture --------- *)
+  "helm-then-capture" -> {
+    vis["set_target", "pt"],          (* choose the material language code *)
+    vis["set_source", "English"],
+    vis["add", <|"word" -> "casa", "translation" -> "house"|>],
+    vis["set_sort", recent],
+    vis["export"]},
 
   (* --- full end-to-end: both syncs in one run ------------------------- *)
   "full-roundtrip" -> {

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -136,21 +136,60 @@ viewProjections[tf_, s_] := Association[
     MatchQ[First[#], label[_, param[_]]] &&
     StringEndsQ[ToLowerCase[ToString[portName[First[#]]]], "view"] &]];
 
-(* dataView[tf, s] : the state's DATA through the compaction grid — one
-   linearizeGrid per published projection. The "visual data compression".
-   The projection comes out of the engine's held `param` with its values
-   UNEVALUATED (the recipe, e.g. sortEntries[applyFilter[...]]); Map[Identity, ·]
-   rebuilds the association forcing each value, so we linearize the COMPUTED
-   data (entries -> {} when empty, the actual rows when populated). *)
+(* dataView[tf, s] : the state's DATA as one compact PANEL per published
+   projection. The "visual data compression". The projection comes out of the
+   engine's held `param` with its values UNEVALUATED (the recipe, e.g.
+   sortEntries[applyFilter[...]]); Map[Identity, ·] rebuilds the association
+   forcing each value, so we render the COMPUTED data.
+
+   Panel layout (chosen 2026-06-01): an agent's view Association is almost
+   always SCALARS + one COLLECTION (entries / history), and that collection is
+   a list of homogeneous Associations — which IS a table. So:
+     scalar keys           -> a tight "key=value" strip;
+     a list-of-Associations -> a column-headed table (columns = union of the
+                               records' keys, one row per record).
+   This is the most compact LOSSLESS form and stacks cleanly as N view ports
+   grow (pSView / vSView / helmView, then more). *)
 forceProj[p_Association] := Map[Identity, p];
 forceProj[p_] := p;
+
+(* scalarForm[v] : a value as compact display text (strings unquoted, sym[]
+   unwrapped, None spelled out). *)
+scalarForm[s_String] := s;
+scalarForm[None] := "None";
+scalarForm[v_] := ToString[v /. sym[z_] :> z];
+
+(* recordTable[rows] : a list of Associations as a column-headed Grid. Columns
+   are the union of the records' keys (so heterogeneous rows still align). *)
+recordTable[rows : {__Association}] := Module[{cols = DeleteDuplicates[Join @@ (Keys /@ rows)]},
+  Grid[
+    Prepend[
+      (Function[r, scalarForm[Lookup[r, #, ""]] & /@ cols] /@ rows),
+      (Style[ToString[#], Italic, GrayLevel[0.45]] & /@ cols)],
+    Frame -> All, FrameStyle -> GrayLevel[0.85], Alignment -> Left,
+    Spacings -> {1.2, 0.3}]];
+
+(* viewPanel[nm, p] : one agent's projection as a compact panel. *)
+tabularKeyQ[v_] := MatchQ[v, {__Association}];
+viewPanel[nm_String, p_Association] := Module[
+  {tabKeys = Select[Keys[p], tabularKeyQ[p[#]] &], scalKeys, strip, tables},
+  scalKeys = Complement[Keys[p], tabKeys];
+  strip = Row[Riffle[
+      (Row[{Style[ToString[#], GrayLevel[0.45]], "=", scalarForm[p[#]]}] & /@ scalKeys),
+      Spacer[14]]];
+  tables = recordTable[p[#]] & /@ tabKeys;
+  Framed[
+    Column[Join[{Style[nm, Bold, Darker[Blue]]}, {strip}, tables], Spacings -> 0.5],
+    RoundingRadius -> 5, FrameStyle -> GrayLevel[0.8], FrameMargins -> 8,
+    Background -> GrayLevel[0.99]]];
+viewPanel[nm_String, other_] := Framed[
+  Column[{Style[nm, Bold, Darker[Blue]], linearizeGrid[other]}, Spacings -> 0.5],
+  RoundingRadius -> 5, FrameStyle -> GrayLevel[0.8], FrameMargins -> 8];
+
 dataView[tf_, s_] := Module[{projs = viewProjections[tf, s]},
   If[projs === <||>,
     Style["(no view ports ready)", Italic, GrayLevel[0.5]],
-    Column[KeyValueMap[
-      Function[{nm, p},
-        Column[{Style[nm, Bold, Darker[Blue]], linearizeGrid[forceProj[p]]}, Spacings -> 0.4]],
-      projs], Spacings -> 1]]];
+    Column[KeyValueMap[viewPanel[#1, forceProj[#2]] &, projs], Spacings -> 0.8]]];
 
 (* traceView[traceDyn] : condensed event-log rendering of the trace held in
    the Dynamic-tracked symbol passed by reference, + a Copy button. *)


### PR DESCRIPTION
Composes Helm into the system, rebuilds the walk view as per-port panels, adds composition tests, and fixes a `helmView` bug the merge surfaced. Full headless suite green (11/11).

## 1. Helm merged into `mioCore` / `mioCoreD`
Pure parallel composition — **no** restricted sync, because no control guard in PS/VS reads the language. Helm contributes `helmView` + `set_source`/`set_target`/`set_tts` (and `set_speed` once `tts = espeak`). It becomes the **third recovered agent** in `loadRecoveredBase[]` (so anything that builds MioCore has it; `merge[]`'s eager `buildSystem` needs it defined first).

Both engines agree on the ready set:
`{add, helmView, import_bulk, load_material, pSView, set_filter, set_sort, set_source, set_target, set_tts, vSView}`

## 2. Per-port panel view (`dataView`)
A view Association is **scalars + at most one collection** (a list of homogeneous Associations = a table). New `viewPanel`/`recordTable`/`scalarForm`: scalar strip + the collection as a column-headed table, one framed panel per port. Scales as view ports grow. (Layout chosen 2026-06-01.)

## 3. `walk-tests`: `helm-*` plans
- `helm-settings` — settings tour + the espeak-only `set_speed` guard
- `helm-then-capture` — set the language pair, then drive a VS capture across the seam

Both complete on `mioCore` and `mioCoreD`.

## Bug fixed (surfaced by the merge)
`helmView`'s `language` froze to the binder symbol: `trainingNameOf[target]` fired over the **formal** `target` during eager `buildSystem` → `trainingNameOf["target"]` before substitution put `"fr"` in. Same class as `vocabView[entries_List]` / `sessionView[phrases_List]`. Fixed by gating `helmView[…, target_String, …]`. Now `French` in both engines.

## Docs
`ARCHITECTURE.md` ‡ note answers the question *how do PS/VS get the language from Helm*: they don't, through a port — no guard reads it, so it reaches them **indirectly via the oracle boundary** (the g2p/translation/TTS oracles read `helmView`; their result lands in `add`'s `ipa` / `load_material`'s translations). Making that oracle→`helmView` read explicit is a deliberate `rig` decision, the same shape as the external-store question for stats/history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)