### PR TITLE
spec/walk: drop empty columns from the entries table (long-heading fix)

### DIFF
--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -160,14 +160,28 @@ scalarForm[None] := "None";
 scalarForm[v_] := ToString[v /. sym[z_] :> z];
 
 (* recordTable[rows] : a list of Associations as a column-headed Grid. Columns
-   are the union of the records' keys (so heterogeneous rows still align). *)
-recordTable[rows : {__Association}] := Module[{cols = DeleteDuplicates[Join @@ (Keys /@ rows)]},
-  Grid[
-    Prepend[
-      (Function[r, scalarForm[Lookup[r, #, ""]] & /@ cols] /@ rows),
-      (Style[ToString[#], Italic, GrayLevel[0.45]] & /@ cols)],
-    Frame -> All, FrameStyle -> GrayLevel[0.85], Alignment -> Left,
-    Spacings -> {1.2, 0.3}]];
+   are the union of the records' keys (so heterogeneous rows align), but EMPTY
+   columns are dropped: a single freshly-added entry carries the full DB schema
+   (~14 keys, most Null), so without pruning the table is mostly empty columns
+   with long headings (the casa-row display problem). A column empty in every
+   row carries no information — dropping it is lossless. Empty cells blank, and
+   a still-wide table scrolls horizontally rather than breaking the layout. *)
+emptyCellQ[v_] := MatchQ[v, Null | "" | None | _Missing];
+cellForm[v_] := If[emptyCellQ[v], "", scalarForm[v]];
+recordTable[rows : {__Association}] := Module[
+  {allCols = DeleteDuplicates[Join @@ (Keys /@ rows)], cols},
+  cols = Select[allCols, Function[c, AnyTrue[rows, ! emptyCellQ[Lookup[#, c, Null]] &]]];
+  If[cols === {},
+    Style["(entries present, all fields empty)", Italic, GrayLevel[0.6]],
+    Pane[
+      Grid[
+        Prepend[
+          (Function[r, cellForm[Lookup[r, #, Null]] & /@ cols] /@ rows),
+          (Style[ToString[#], Italic, GrayLevel[0.45]] & /@ cols)],
+        Frame -> All, FrameStyle -> GrayLevel[0.85], Alignment -> Left,
+        Spacings -> {1.2, 0.3}],
+      {UpTo[760], Automatic}, Scrollbars -> {Automatic, False},
+      AppearanceElements -> None]]];
 
 (* viewPanel[nm, p] : one agent's projection as a compact panel. *)
 tabularKeyQ[v_] := MatchQ[v, {__Association}];


### PR DESCRIPTION
Fixes the wide/long-heading entries table you hit on the `casa` row.

A freshly-added vocab entry carries the **full DB schema** (~14 keys); for a bare word ~9 are `Null` (`ipa`, `source_name`, `url`, `context_before/line/after`, `notes`, …). The panel rendered all 14 as columns → mostly-empty table with long headings that wouldn't lay out.

**`recordTable` now drops columns empty in every row** — lossless, since an all-empty column carries no information (`casa`: 14 → 7 columns: `id, word, display_word, translation, times_seen, first_seq, last_seq`). Empty cells render blank; a still-wide table scrolls horizontally (`Pane`, `UpTo[760]`) rather than breaking the layout.

Verified on the exact `casa` entry; full headless suite green (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)