### PR TITLE
spec: borrowed-vs-owned-data decision + maximal-progress toggle

### DIFF
--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -82,18 +82,90 @@ of an ordinary input port (`add` already carries an `ipa`; `load_material`
 already carries translations). The language selects *which* oracle output,
 upstream of the port.
 
-The honest gap: today that oracle→`helmView` read is **implicit** (test data
-carries pre-baked `ipa`/`translation` values, correct by fiat). Making it
-explicit — the oracle call reading `(source, target)` from `helmView` — is a
-deliberate **`rig`** decision of the same shape as the external-store question
-below: does the read-edge stay *ambient* (oracle reads the projection at its
-boundary) or *enter the model* (an explicit parameter/sync)? The one place a
-setting already gates a port is `set_speed` (`if[tts === espeak, …]`) — a genuine
-**control** dependency, but on Helm's *own* state, so internal. The day a VS/PS
-port's *readiness* comes to depend on the language, **that** edge must enter the
-model as a restricted sync.
+Today that oracle→`helmView` read is still **implicit** (test data carries
+pre-baked `ipa`/`translation` values, correct by fiat). Making it explicit — the
+oracle call reading `(source, target)` from `helmView` — is now a **decided**
+matter: see **Borrowed vs owned data** below. In short, the consuming action
+*pulls* the language fresh through an internal port at the point of use; it is
+**not** pushed into a VS/PS cache. The one place a setting already gates a port
+is `set_speed` (`if[tts === espeak, …]`) — a genuine **control** dependency, but
+on Helm's *own* state, so internal. The day a VS/PS port's *readiness* comes to
+depend on the language, **that** edge must enter the model as a restricted sync —
+and, being a guard over *borrowed* data, is the one case that may force a
+calculus extension (see below).
 
 **† Stats / History and the external store (a rigging issue).** Treating these as *view ports* is correct only under the current modelling assumption that each component stores its own domain data in-process. In any sensible implementation, stats and history are retrieved from an **external store**, not held by the component. Rigging that external store into the system — where the data lives, who reads/writes it, how a view port is backed by a *query* rather than in-process state — is a key **rig** concern, and the question of *how* it is done may itself need to enter the model (an external-store agent / port), not be left wholly to L3. Flagged for when stats/history (and persistence generally) are recovered.
+
+## Borrowed vs Owned Data (decision)
+
+When one component needs data another component owns — VS/PS needing Helm's
+`(source, target)` to enrich/score — the rule is:
+
+> **Own it → store it. Borrow it → fetch it fresh, at the point of use.**
+
+A component keeps the data it *owns* in its own state (VS's entries, sort,
+filter; PS's position). It **never caches data another component owns**; it reads
+that through a port, as a prefix of the action that needs it.
+
+**Why not push-to-cache.** The tempting model — Helm pushes each change into a
+VS/PS replica, which then reads locally — is **not faithfully expressible in
+pure CCS**. CCS has no priority: an offered synchronisation is declinable while
+the agent has any other transition. So with a cache, the run
+
+```
+set_target(pt) · VS.autofill[reads stale "fr"] · langToVS(pt)
+```
+
+is a legal trace — the refresh is not forced before the stale read. The very
+asynchrony that makes CCS clean removes the "write is immediately visible"
+guarantee a shared-memory framework (Streamlit) gives for free. A cache of
+borrowed data cannot be kept coherent without leaving the calculus.
+
+**The mechanism: pull-on-use, forced by prefix.** Instead, the read sits on the
+*critical path* of the consuming action:
+
+```
+Helm:  … + langRead!(source, target) · Helm        (* persistent internal read port, a self-loop *)
+VS:    autofill?(id) · langRead?(s,t) · ⟨enrichOracle[word, s, t]⟩ · VS′
+PS:    attempt_made  · langRead?(_,t) · ⟨recognisePhonemes[audio, t]⟩ · …
+```
+
+`langRead` is **restricted** in `mioCore` (an internal τ, like `vAdd`/`pLoad`).
+The consumer cannot complete the enrich/score without first taking it, and what
+it reads is necessarily Helm's *current* value — there is no local copy to be
+stale. This is **forced by sequencing, not by priority**: it is the same idiom
+`vAdd`/`pLoad` already use (a sync that is the only way for the agent to make
+progress). Helm remains the **sole owner**; oracles stay boundary functions
+(decision-A) but are now called *with* the language the read delivered.
+`espeakG2P[word, voice]` already has this shape (`voice` = the target read).
+
+**The one escape hatch.** Pull-on-use covers a *data* dependency (the value is
+needed when an action runs). It does **not** cover a *control* dependency over
+borrowed data — a guard whose ready set must change the instant Helm changes,
+with no action in flight. That genuinely needs push, i.e. a calculus extension:
+**priority / maximal progress** (Cleaveland & Hennessy; timed-process-algebra
+maximal progress) or **broadcast** (Prasad's CBS, broadcast-π). We adopt none of
+these now; they are reserved for the first borrowed-data *guard*. (`set_speed`'s
+guard reads Helm's *own* state, so it is internal, not a borrowed-data guard.)
+
+**Simulator note (a strategy, not a semantics).** The harness offers a
+**maximal-progress toggle** (`autoTau`, `walk.wl`): between the user's actions it
+auto-fires the unique enabled internal τ until the state is τ-stable (and stops,
+handing back, if ≥2 τ are ready — a real choice is never silently resolved). This
+is a *scheduling strategy over the existing LTS*, leaving the spec's transition
+relation untouched; it does not introduce priority into the language. It embodies
+the meta-agent split: the user plays the **user** (external inputs) and the
+**world** (oracle return values); the simulator plays the **system** (internal
+syncs). Every auto-fired τ is recorded in the trace and is Back-steppable.
+
+**The "data cloud".** Any datum a component reads but that is owned by *nothing
+yet modelled* (DB persistence, an oracle's internal knowledge) is, until given an
+owning agent, shown in the simulator as an explicit **incompleteness inventory** —
+a standing reminder that the simulated agents are not complete in themselves.
+Pull-on-use removes the *language* from that cloud (it now flows through a real
+port); what remains is the genuinely-external world, and it shrinks as each owner
+is modelled (the DB becoming an agent being the large remaining one — it unifies
+with the external-store note † above).
 
 ## Execution Model
 

--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -41,6 +41,17 @@ The panel shows, top to bottom:
   back through the states you've visited and forward again — handy after
   `Run test` to watch what each step of a sequence reveals. (A fresh manual step
   or `Run test` clears the forward/redo line.)
+- **Auto-advance internal syncs (maximal progress)** — a checkbox. When on, the
+  harness fires the system's internal synchronisations (`vAdd`, `pLoad`, and the
+  coming `langRead`) for you between your actions, until the state is τ-stable,
+  so you only ever click *external* ports. It's a **simulation strategy, not a
+  language change** (`autoTau` in `walk.wl`): it just chooses how to walk the
+  existing transition system. The meta-agent split — you play the *user* (and the
+  *world*, via input values); the simulator plays the *system*. Every auto-fired
+  τ is still **recorded in the trace and is Back-steppable**, so nothing is
+  hidden. If two internal syncs are ready at once (a real nondeterministic
+  choice) it **stops and hands back to you** rather than pick silently. See
+  ARCHITECTURE.md → *Borrowed vs owned data* for why this is sound.
 
 ---
 

--- a/spec/tests/maxprog_test.wls
+++ b/spec/tests/maxprog_test.wls
@@ -1,0 +1,61 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/maxprog_test.wls
+   ---------------------------------------------------------------------
+   autoTau[tf, s] — the walk harness's MAXIMAL-PROGRESS strategy. A
+   SIMULATION strategy over the existing LTS (not a language change): fire
+   the unique enabled internal tau until the state is tau-stable, stopping
+   if >= 2 taus are ready (a real choice is never silently resolved).
+
+   Checks, on BOTH mioCore (transVP) and mioCoreD (transNamed):
+     - a state with one pending internal sync (vAdd, just after capture_vocab)
+       has exactly one ready tau;
+     - autoTau fires it (one recorded event, polarity "tau", the vAdd channel)
+       and reaches a tau-stable state;
+     - autoTau is a no-op on an already tau-stable state;
+     - every fired tau is recorded with its pre-state (Back-steppable).
+
+   Run headless:  wolframscript -file spec/tests/maxprog_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];
+Get[$dir <> "walk.wl"];
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+hr = StringRepeat["=", 70];
+
+readyTaus[tf_, s_] := Select[readyTransitions[tf, s], isTauAct[First[#]] &];
+
+(* drive to just AFTER capture_vocab, BEFORE the vAdd tau *)
+plan = {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
+        vis["recording_made", "audio"], vis["attempt_made"], vis["capture_vocab", "chat"]};
+
+check[label_, tf_, s0_] := Module[{s, taus, a, stable},
+  Print[hr]; Print[label]; Print[hr];
+  s = Last[walkSteps[tf, s0, plan]["states"]];
+  taus = readyTaus[tf, s];
+  assert["exactly one tau (vAdd) pending after capture_vocab", Length[taus] === 1];
+  (* channel rep is incidental (symbol / string / label[]); match on its text *)
+  assert["that tau's channel is vAdd",
+    StringContainsQ[ToString[eventOf[First[First[taus]]]["port"]], "vAdd"]];
+  a = autoTau[tf, s];
+  assert["autoTau fired exactly one event", Length[a["events"]] === 1];
+  assert["fired event polarity is tau", First[a["events"]]["polarity"] === "tau"];
+  assert["fired event port is vAdd",
+    StringContainsQ[ToString[First[a["events"]]["port"]], "vAdd"]];
+  assert["one pre-state recorded (Back-steppable)", Length[a["states"]] === 1];
+  stable = a["state"];
+  assert["resulting state is tau-stable (no tau ready)", readyTaus[tf, stable] === {}];
+  assert["autoTau is a no-op on a tau-stable state",
+    autoTau[tf, stable]["events"] === {} && autoTau[tf, stable]["states"] === {}];];
+
+check["1. mioCore  (transVP)",   transVP,   mioCore];
+check["2. mioCoreD (transNamed)", transNamed, mioCoreD];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -113,6 +113,38 @@ walkResolve[tf_, s_, vis[nm_, val_]] := Module[{t = walkResolve[tf, s, vis[nm]]}
   If[MissingQ[t], t, supplyValue[t, val]]];
 
 
+(* ---------------------------------------------------------------------
+   autoTau[tf, s] : MAXIMAL-PROGRESS advance — a SIMULATION STRATEGY, not a
+   language change. CCS itself has no priority: an offered internal sync is
+   declinable while the agent has other transitions (the asynchrony that makes
+   push-to-cache unfaithful). But the SIMULATOR is free to choose how it walks
+   the LTS, and "fire internal syncs before offering external choices" is one
+   such walk. It leaves the spec's meaning (the full transition relation)
+   untouched — see ARCHITECTURE.md ("Borrowed vs owned data").
+
+   It fires the UNIQUE enabled internal tau repeatedly until the state is
+   tau-stable. Deliberately conservative:
+     - 0 taus ready        -> stop (tau-stable; offer the external ready set);
+     - exactly 1 tau ready -> fire it (forced-by-the-only-thing-to-do);
+     - >= 2 taus ready     -> STOP and hand back to the user. Auto-firing here
+                              would silently resolve a genuine nondeterministic
+                              tau-CHOICE; we never bury that.
+   A safety cap bounds the loop against a (here unexpected) tau-cycle.
+
+   Returns <|"state" -> tau-stable state, "events" -> {eventOf each tau fired},
+   "states" -> {pre-state of each tau}|> so the caller can extend trace + hist
+   (every auto-fired tau is RECORDED and Back-steppable — maximal progress
+   speeds driving, it does not hide the internal flow). *)
+autoTau::usage = "autoTau[tf, s] is the maximal-progress simulation strategy: fire the unique enabled internal tau repeatedly until tau-stable (stopping if >=2 taus are ready, leaving the genuine choice to the user). Returns <|state, events, states|>. A walk strategy over the LTS, not a change to the spec.";
+autoTau[tf_, s_] := Module[{cur = s, evs = {}, sts = {}, taus, guard = 0},
+  While[guard++ < 500 &&
+        Length[taus = Select[readyTransitions[tf, cur], isTauAct[First[#]] &]] === 1,
+    AppendTo[sts, cur];
+    AppendTo[evs, eventOf[First[First[taus]]]];
+    cur = Last[First[taus]]];
+  <|"state" -> cur, "events" -> evs, "states" -> sts|>];
+
+
 (* =====================================================================
    DYNAMIC WIDGETS  (notebook front end — drive these; not headless)
    ---------------------------------------------------------------------
@@ -238,6 +270,7 @@ Options[walkUI] = {"TransitionFunction" -> transVP};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"]},
   DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
+     maxprog = False,
      testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None]},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
@@ -250,6 +283,18 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
           dataView[tf, cur],
 
           Style["Transitions \[LongDash] click to step; type into input ports", Bold, 13],
+          (* maximal-progress toggle: a SIMULATION strategy (auto-fire internal
+             syncs between your actions), not a language change. Switching it ON
+             also settles the current state. The system plays the SYSTEM for you;
+             you still play the user (and the world). *)
+          Row[{Checkbox[Dynamic[maxprog, (maxprog = #;
+                 If[TrueQ[#],
+                   With[{a = autoTau[tf, cur]},
+                     hist = Join[hist, a["states"]];
+                     trace = Join[trace, a["events"]]; cur = a["state"]]]) &]],
+               Spacer[4],
+               Style["Auto-advance internal syncs (maximal progress)",
+                 GrayLevel[0.35], 11]}],
           If[trans === {},
             Style["(deadlocked \[LongDash] no transitions)", Italic, GrayLevel[0.5]],
             Column[
@@ -264,7 +309,13 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                                  supplyValue[tr, inVals[nm]], tr];
                         AppendTo[hist, cur];
                         AppendTo[trace, eventOf[First[taken]]];
-                        cur = Last[taken]; inVals = <||>; future = {}],
+                        cur = Last[taken]; inVals = <||>; future = {};
+                        (* maximal progress: let the system settle its internal
+                           syncs before offering the next external choice *)
+                        If[TrueQ[maxprog],
+                          With[{a = autoTau[tf, cur]},
+                            hist = Join[hist, a["states"]];
+                            trace = Join[trace, a["events"]]; cur = a["state"]]]],
                       Appearance -> "Frameless",
                       ActiveStyle -> {Background -> RGBColor[0.9, 0.95, 1.0]}],
                      (* hover: the derivative this transition leads to (symbolic,
@@ -324,7 +375,7 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
           traceView[trace]
 
         }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
-      TrackedSymbols :> {cur, inVals, testSel, future}]]];
+      TrackedSymbols :> {cur, inVals, testSel, future, maxprog}]]];
 
 
 (* --- the value-carrying test sequences (walkTests), loaded relative to


### PR DESCRIPTION
Batch **(a) + (d)** from the oracles/data-sharing discussion. Full suite **12/12** green (new `maxprog_test` included).

## (a) Decision: borrowed vs owned data — `ARCHITECTURE.md`
> **Own it → store it. Borrow it → fetch it fresh, at the point of use.**

- **Why not push-to-cache:** pure CCS has no priority, so an offered refresh is declinable — the stale-read trace `set_target(pt) · autofill[reads "fr"] · langToVS(pt)` is legal. A cache of borrowed data can't be kept coherent without leaving the calculus.
- **Mechanism — pull-on-use, forced by prefix (not priority):** a persistent internal `langRead!(source,target)` self-loop on Helm, read as a *prefix* of `VS.autofill` / PS scoring; restricted in `mioCore` (a τ, like `vAdd`/`pLoad`). No local copy ⇒ no staleness; Helm stays sole owner; oracles stay boundary functions called *with* the read value (`espeakG2P[word, voice]` already fits).
- **Escape hatch reserved:** priority/maximal-progress (Cleaveland & Hennessy; timed PA) or broadcast (Prasad CBS) only for the first borrowed-data **guard** (a control dep that must track a change with no action in flight). `set_speed` reads Helm's *own* state, so it doesn't count.
- The **data-cloud** reframed as the **incompleteness inventory of unmodelled owners** (DB, oracle knowledge); pull removes the language from it.

## (d) Maximal-progress toggle — `walk.wl`
`autoTau[tf, s]`: a **simulation strategy over the existing LTS**, not a language change. Fires the unique enabled internal τ until τ-stable; **stops if ≥2 τ are ready** (never silently resolves a real choice); safety-capped. `walkUI` gains an *Auto-advance internal syncs (maximal progress)* checkbox — every auto-fired τ is **recorded in the trace and Back-steppable**, and it advances on switch-on. Embodies the meta-agent split: you play the *user* (and the *world*); the simulator plays the *system*. Documented in `docs/walk.md`.

## Verification
`tests/maxprog_test.wls` (new) — `autoTau` on both `mioCore` (transVP) and `mioCoreD` (transNamed): one pending `vAdd` after `capture_vocab`, fires exactly one τ (polarity `tau`, channel `vAdd`), reaches τ-stable, no-op on a stable state, pre-state recorded. Full suite **12/12**.

Note: this records the decision and ships the simulator affordance; the **model change** (Helm `langRead` + VS/PS prefix-reads) is the next batch **(b)**, and the cloud panel **(c)** follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)