### PR TITLE
spec (b): wire langRead — VS pulls the borrowed language at autofill

### DIFF
--- a/spec/HelmRecovered.wl
+++ b/spec/HelmRecovered.wl
@@ -20,6 +20,9 @@
 
    PORTS (sidebar controls):
      view!         always — the helmView projection everyone reads
+     langRead!     always — INTERNAL read port (restricted in mioCore): emits
+                   {source, target} for a borrower that pulls it at point of use
+                   (VS.autofill; PS scoring to follow). Not a UI control.
      set_source    set the source (native) language name
      set_target    set the target language code (target_language mirrors it)
      set_tts       set the TTS engine
@@ -42,6 +45,14 @@
 defineAgent["Helm", {source, target, tts, speed},
   choice[
     precede[label["view", param[helmView[source, target, tts, speed]]],
+      call["Helm", source, target, tts, speed]],
+    (* internal READ port (restricted in mioCore): borrowers PULL the
+       (source, target) pair fresh at the point of use. A self-loop — always
+       offered, never changing Helm — so a consumer waiting at langRead?(lp)
+       is forced (by its own sequencing) to take it and gets Helm's CURRENT
+       value; no cached copy, no staleness. See ARCHITECTURE.md "Borrowed vs
+       owned data". Distinct from the external `view` projection. *)
+    precede[label["langRead", param[{source, target}]],
       call["Helm", source, target, tts, speed]],
     precede[coLabel["set_source", binding[s]],
       call["Helm", s, target, tts, speed]],

--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -44,6 +44,14 @@
    set_sort, set_target, set_tts, vSView} — three view ports, no bare `view`
    clash; vAdd/pLoad restricted (internal tau). (set_speed appears once tts is
    set to espeak.)
+
+   BORROWED-DATA wiring (2026-06-01): langRead is also restricted, so Helm's
+   internal read port pairs with VS.autofill's langRead?(lp) prefix as an
+   internal tau — VS pulls the (source, target) pair fresh when enriching, never
+   caching it (ARCHITECTURE.md "Borrowed vs owned data"). langRead does NOT
+   appear in the external ready set (it is internal); it is enabled as a tau only
+   while a borrower waits at langRead? (currently: just after `autofill`). PS
+   scoring is the next borrower to wire (b2).
    ===================================================================== *)
 
 mioCore =
@@ -51,7 +59,7 @@ mioCore =
     {"PS" -> call["PS", {}, 0, none, none],
      "VS" -> call["VS", signedIn, {}, alpha, none, none],
      "Helm" -> call["Helm", "English", "fr", google, 250]},
-    {label["vAdd"], label["pLoad"]}];
+    {label["vAdd"], label["pLoad"], label["langRead"]}];
 
 (* Compact call-based twin (mergeDefined): same composition, but stepped with
    transNamed and with call-based successors — no mu-term bulk. Use this for
@@ -64,4 +72,4 @@ mioCoreD =
     {"PS" -> call["PS", {}, 0, none, none],
      "VS" -> call["VS", signedIn, {}, alpha, none, none],
      "Helm" -> call["Helm", "English", "fr", google, 250]},
-    {label["vAdd"], label["pLoad"]}];
+    {label["vAdd"], label["pLoad"], label["langRead"]}];

--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -152,16 +152,20 @@ updateEntry[entries_List, id : Except[_editingRow], fields_Association] :=
   updateEntry[entries, editingRow[id], fields];
 
 
-(* --- autofillIn[entries, id] : autofill_vocab_entry (vocab.py:411).
-   Fills ONLY empty translation/ipa, never overwrites. The enrichment is
-   the whole point of the function and is IO: it is the oracle
-   enrichOracle[word] -> <|"translation"->_, "ipa"->_|> (uninterpreted;
-   the spec is parametric in it). Existing-value fields are left intact. *)
-autofillIn[entries_List, id_] := Module[{pos, row, fill, m},
+(* --- autofillIn[entries, id, lang] : autofill_vocab_entry (vocab.py:411).
+   Fills ONLY empty translation/ipa, never overwrites. The enrichment is the
+   whole point of the function and is IO: the oracle
+   enrichOracle[word, source, target] -> <|"translation"->_, "ipa"->_|>
+   (uninterpreted; the spec is parametric in it). It translates source -> target
+   and produces the target-language IPA, so it needs the (source, target) pair.
+   BORROWED DATA (ARCHITECTURE.md): that pair is Helm's, pulled fresh at the
+   autofill port and passed in as `lang` = {source, target} — NOT cached.
+   Existing-value fields are left intact. *)
+autofillIn[entries_List, id_, lang_List] := Module[{pos, row, fill},
   pos = FirstPosition[entries, e_ /; e["id"] === id, None, {1}, Heads -> False];
   If[pos === None, Return[entries]];
   row = Extract[entries, pos];
-  fill = enrichOracle[row["display_word"]];
+  fill = enrichOracle[row["display_word"], First[lang], Last[lang]];
   If[!AssociationQ[fill], Return[entries]];
   MapAt[Function[e, Module[{n = e},
       If[(n["translation"] === Null || n["translation"] === "") &&

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -144,9 +144,16 @@ defineAgent["VSEntryActions", {entries, sort, filter},
       choice[
         (* autofill \[LongDash] the missing-fields guard needsAutofill[entries,id] is
            a STUBBED value predicate, deferred; modelled as available per
-           entry when non-empty *)
+           entry when non-empty.
+           BORROWED DATA: enrichment needs the (source, target) language pair,
+           which Helm OWNS. So autofill PULLS it fresh as a PREFIX \[LongDash] langRead?(lp)
+           sits on the critical path of the action, restricted to Helm's langRead!
+           in mioCore (an internal tau). No cached language => no staleness; the
+           value read is always Helm's current pair. See ARCHITECTURE.md
+           "Borrowed vs owned data". lp = {source, target}. *)
         precede[coLabel["autofill", binding[id]],
-          call["VS", signedIn, autofillIn[entries, id], sort, filter, none]],
+          precede[coLabel["langRead", binding[lp]],
+            call["VS", signedIn, autofillIn[entries, id, lp], sort, filter, none]]],
         precede[coLabel["begin_edit", binding[id]],
           call["VS", signedIn, entries, sort, filter, editingRow[id]]]]]]]
 

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -139,6 +139,11 @@ progress). Helm remains the **sole owner**; oracles stay boundary functions
 (decision-A) but are now called *with* the language the read delivered.
 `espeakG2P[word, voice]` already has this shape (`voice` = the target read).
 
+*Status:* implemented for **VS `autofill`** (`autofillIn[entries, id, lang]` →
+`enrichOracle[word, source, target]`), with Helm's `langRead!` restricted in
+`mioCore`. **PS scoring** (`recognisePhonemes` needs the target ASR language) is
+the next borrower to wire, by the identical prefix-read.
+
 **The one escape hatch.** Pull-on-use covers a *data* dependency (the value is
 needed when an action runs). It does **not** cover a *control* dependency over
 borrowed data — a guard whose ready set must change the instant Helm changes,

--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -42,8 +42,9 @@ The panel shows, top to bottom:
   `Run test` to watch what each step of a sequence reveals. (A fresh manual step
   or `Run test` clears the forward/redo line.)
 - **Auto-advance internal syncs (maximal progress)** — a checkbox. When on, the
-  harness fires the system's internal synchronisations (`vAdd`, `pLoad`, and the
-  coming `langRead`) for you between your actions, until the state is τ-stable,
+  harness fires the system's internal synchronisations (`vAdd`, `pLoad`, and
+  `langRead` — the borrowed-language pull on `autofill`) for you between your
+  actions, until the state is τ-stable,
   so you only ever click *external* ports. It's a **simulation strategy, not a
   language change** (`autoTau` in `walk.wl`): it just chooses how to walk the
   existing transition system. The meta-agent split — you play the *user* (and the

--- a/spec/tests/data_view_test.wls
+++ b/spec/tests/data_view_test.wls
@@ -38,7 +38,7 @@ Print[hr]; Print["1. linearize  (let-form / A-normal CSE pretty-print)"]; Print[
 
 big = exportCsv[autofillIn[updateEntry[updateNotesIn[deleteFrom[
         addEntry[addEntry[addEntry[importInto[{}, f], w], w], w],
-        id], idn], editingRow[id], fields], id]];
+        id], idn], editingRow[id], fields], id, lang]];
 
 lin = linearize[big];
 Print["   raw term:"];
@@ -106,7 +106,7 @@ assert["each event has exactly the 4 fields?",
 Print[hr]; Print["4. replay: snapshot is derived (Fold), not stored"]; Print[hr];
 ops = {importInto[#, f] &, addEntry[#, w] &, addEntry[#, w] &, addEntry[#, w] &,
        deleteFrom[#, id] &, updateNotesIn[#, idn] &,
-       updateEntry[#, editingRow[id], fields] &, autofillIn[#, id] &};
+       updateEntry[#, editingRow[id], fields] &, autofillIn[#, id, lang] &};
 snap = exportCsv[replay[{}, ops]];
 Print["   replay[{}, ops] then exportCsv:"];
 Print["     ", ToString[snap, InputForm]];

--- a/spec/tests/functions_test.wls
+++ b/spec/tests/functions_test.wls
@@ -56,15 +56,17 @@ Print["  updateEntry key-change rejected (no-op)? ", ok[e6 === e2]];
 e7 = updateEntry[e2, editingRow[id1], <|"word" -> "x"|>];
 Print["  updateEntry unknown field rejected? ", ok[e7 === e2]];
 
-(* autofillIn: oracle fills only empty fields *)
-enrichOracle["chien"] = <|"translation" -> "dog", "ipa" -> "ʃjɛ̃"|>;
+(* autofillIn: oracle fills only empty fields. enrichOracle now takes the
+   (source, target) pair (borrowed data); autofillIn is passed lang = {src,tgt}. *)
+enrichOracle["chien", _, _] = <|"translation" -> "dog", "ipa" -> "ʃjɛ̃"|>;
+lang = {"English", "fr"};
 ed = addEntry[{}, <|"word" -> "chien"|>];
-ef = autofillIn[ed, ed[[1]]["id"]];
+ef = autofillIn[ed, ed[[1]]["id"], lang];
 Print["  autofillIn fills empty translation+ipa via oracle? ",
   ok[ef[[1]]["translation"] === "dog" && ef[[1]]["ipa"] === "ʃjɛ̃"]];
 (* never overwrites an existing field *)
 eg = addEntry[{}, <|"word" -> "chien", "translation" -> "hound"|>];
-eh = autofillIn[eg, eg[[1]]["id"]];
+eh = autofillIn[eg, eg[[1]]["id"], lang];
 Print["  autofillIn does NOT overwrite existing translation? ",
   ok[eh[[1]]["translation"] === "hound" && eh[[1]]["ipa"] === "ʃjɛ̃"]];
 

--- a/spec/tests/functions_unit_test.wls
+++ b/spec/tests/functions_unit_test.wls
@@ -19,8 +19,8 @@
 $dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
 Get[$dir <> "MiolingoSpec.wl"];
 
-enrichOracle[_]      := <|"translation" -> "ORC", "ipa" -> "ɔrk"|>;
-recognisePhonemes[_] := "abc";
+enrichOracle[_, _, _] := <|"translation" -> "ORC", "ipa" -> "ɔrk"|>;  (* word, source, target *)
+recognisePhonemes[_]  := "abc";
 
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 allOk = True; n = 0;
@@ -108,12 +108,13 @@ assert["bare-id clause delegates to editingRow",
 (* ---------------- autofillIn ---------------------------------------- *)
 sec["autofillIn (oracle fills only empty fields)"];
 af0 = addEntry[{}, "chat"];   (* translation/ipa Null *)
-af1 = autofillIn[af0, 1];
+afL = {"English", "fr"};       (* the borrowed (source, target) pair *)
+af1 = autofillIn[af0, 1, afL];
 assert["fills empty translation + ipa via oracle",
   af1[[1]]["translation"] === "ORC" && af1[[1]]["ipa"] === "ɔrk"];
-af2 = autofillIn[updateEntry[af0, 1, <|"translation" -> "keep"|>], 1];
+af2 = autofillIn[updateEntry[af0, 1, <|"translation" -> "keep"|>], 1, afL];
 assert["does NOT overwrite existing translation", af2[[1]]["translation"] === "keep"];
-assert["missing id -> unchanged", autofillIn[af0, 99] === af0];
+assert["missing id -> unchanged", autofillIn[af0, 99, afL] === af0];
 
 (* ---------------- import parser ------------------------------------- *)
 sec["parseImportLine / parseImportHeader / isImportDataLine / importInto"];

--- a/spec/tests/helm_test.wls
+++ b/spec/tests/helm_test.wls
@@ -27,11 +27,19 @@ sG = call["Helm", "English", "fr", google, 250];   (* tts = google *)
 sE = call["Helm", "English", "fr", espeak, 250];    (* tts = espeak *)
 
 Print[hr]; Print["1. ports — set_speed is gated on tts === espeak"]; Print[hr];
-assert["google: view + set_source/target/tts, NO set_speed",
-  ports[sG] === {"set_source", "set_target", "set_tts", "view"}];
+(* langRead is the internal READ port (a borrower pulls {source,target} from it);
+   STANDALONE it is unrestricted so it shows here — in mioCore it is restricted
+   to an internal tau and does NOT appear externally. *)
+assert["google: view + langRead + set_source/target/tts, NO set_speed",
+  ports[sG] === {"langRead", "set_source", "set_target", "set_tts", "view"}];
 assert["espeak: + set_speed appears",
   MemberQ[ports[sE], "set_speed"]];
 assert["set_speed absent unless espeak", !MemberQ[ports[sG], "set_speed"]];
+
+(* langRead emits the (source, target) pair the borrowers pull *)
+assert["langRead carries {source, target}",
+  With[{t = SelectFirst[readyTransitions[transNamed, sG], portName[First[#]] === "langRead" &]},
+    First[Cases[First[t], param[p_] :> p, Infinity], None] === {"English", "fr"}]];
 
 Print[hr]; Print["2. helmView projection — the (source,target) pair others read"]; Print[hr];
 v = view[sG];

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -69,6 +69,7 @@ walkTests = <|
     vis["cancel_edit"],
     vis["update_notes", <|"id" -> 1, "notes" -> "seen in a book"|>],
     vis["autofill", 1],
+    tau["langRead"],                                (* autofill PULLS the language *)
     vis["delete", 1]},
 
   (* --- PracticeSession: load + navigate ------------------------------- *)
@@ -99,6 +100,15 @@ walkTests = <|
     vis["practise_filtered"],
     tau["pLoad"],
     vis["select_item", 0]},
+
+  (* --- sync: VS autofill PULLS the language from Helm (langRead) ------
+     The first BORROWED-DATA read: autofill needs the (source, target) pair to
+     enrich, so it reads Helm's langRead as a prefix (internal tau in mioCore).
+     Only meaningful in the COMPOSED system (Helm must be present to answer). *)
+  "sync-langread" -> {
+    vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
+    vis["autofill", 1],
+    tau["langRead"]},
 
   (* --- sync: PS capture_vocab -> VS add (vAdd) ----------------------- *)
   "sync-vadd" -> {


### PR DESCRIPTION
The first **borrowed-data dependency** in the model, implementing the (B) decision: *own it → store it; borrow it → fetch it fresh* via **pull-on-use forced by prefix** (not push-to-cache). Full suite **12/12** green.

## The wiring
- **Helm** gains an internal **`langRead!({source, target})`** port — a self-loop, always offered, never mutating Helm; distinct from the external `view`.
- **VS `autofill`** now reads it as a **prefix**:
  ```
  autofill?(id) · langRead?(lp) · call[VS, …, autofillIn[entries, id, lp], …]
  ```
  VS can't enrich without first reading Helm's **current** pair — no cache ⇒ no staleness. Forced by *sequencing* (the prefix), not priority.
- **`autofillIn[entries, id, lang]`** → **`enrichOracle[word, source, target]`** (oracle stays an uninterpreted boundary stub — decision-A — now called *with* the language).
- **MioCore**: `langRead` restricted in `mioCore` + `mioCoreD`, so `Helm.langRead!` pairs with `VS.langRead?` as an internal **τ**. It does **not** appear in the external ready set (verified: `merge_defined` unchanged) — it's enabled as a τ only while a borrower waits at `langRead?` (just after `autofill`).

## Tests / docs
- `walk-tests`: `vs-edit` gains `tau["langRead"]` after `autofill`; new **`sync-langread`** plan (`add · autofill · τ langRead`) — runs on both engines via `walk_sequences_test`.
- `helm_test`: standalone Helm now exposes `langRead` (unrestricted) carrying `{source, target}` — ports + a carries-the-pair assertion.
- `functions_test` / `functions_unit_test` / `data_view_test`: `autofillIn`/`enrichOracle` arity updated (data_view uses a free `lang` symbol at both symbolic sites so `snap === big` still holds).
- `ARCHITECTURE.md` + `walk.md`: status note.

## Try it
Drive `add` → `autofill` on `mioCore`. With **maximal-progress ON**, the `langRead` τ auto-fires and you land back at the enriched state; with it **OFF**, you'll see the `langRead` τ as a step to take. The trace shows the pull.

**Next:** **(b2)** PS scoring — `recognisePhonemes` needs the target ASR language — by the identical prefix-read. Then **(c)** the incompleteness-inventory panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)