### PR TITLE
spec/walk: group transitions by component + collapsible state view

### DIFF
--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -54,12 +54,18 @@
    scoring is the next borrower to wire (b2).
    ===================================================================== *)
 
-mioCore =
-  merge[
-    {"PS" -> call["PS", {}, 0, none, none],
-     "VS" -> call["VS", signedIn, {}, alpha, none, none],
-     "Helm" -> call["Helm", "English", "fr", google, 250]},
-    {label["vAdd"], label["pLoad"], label["langRead"]}];
+(* The component decomposition, named once and reused: by merge/mergeDefined to
+   compose, and by the walk harness (walkUI's "Components" option) to GROUP the
+   ready transitions per providing agent. One source of truth for "who the
+   components are" — see walk.wl componentPortMap. *)
+mioComponents =
+  {"PS"   -> call["PS", {}, 0, none, none],
+   "VS"   -> call["VS", signedIn, {}, alpha, none, none],
+   "Helm" -> call["Helm", "English", "fr", google, 250]};
+
+mioRestricted = {label["vAdd"], label["pLoad"], label["langRead"]};
+
+mioCore = merge[mioComponents, mioRestricted];
 
 (* Compact call-based twin (mergeDefined): same composition, but stepped with
    transNamed and with call-based successors — no mu-term bulk. Use this for
@@ -67,9 +73,4 @@ mioCore =
    the transition-time transNamed[relabel] engine change (RCA_core branch
    relabel-transition-time); under the old static rule the view-rename no-ops
    on the bare calls and the views would clash. *)
-mioCoreD =
-  mergeDefined[
-    {"PS" -> call["PS", {}, 0, none, none],
-     "VS" -> call["VS", signedIn, {}, alpha, none, none],
-     "Helm" -> call["Helm", "English", "fr", google, 250]},
-    {label["vAdd"], label["pLoad"], label["langRead"]}];
+mioCoreD = mergeDefined[mioComponents, mioRestricted];

--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -22,20 +22,36 @@ In a notebook, from **your own checkout** (not a worktree):
 Get[".../spec/MiolingoSpec.wl"];   (* engine + spec, in order *)
 Get[".../spec/walk.wl"];           (* the harness + walkTests *)
 
-walkUI[mioCore]                                       (* mu-term, transVP default *)
+walkMio[]                                             (* RECOMMENDED: grouped by component *)
+walkMioD[]                                             (* the transNamed/mioCoreD twin *)
+
+walkUI[mioCore]                                       (* mu-term, transVP default; ungrouped *)
 walkUI[mioCoreD, "TransitionFunction" -> transNamed]  (* compact call form *)
 walkUI[call["VS", signedIn, {}, alpha, none, none], "TransitionFunction" -> transNamed]  (* a bare agent *)
+walkUI[mioCore, "Components" -> mioComponents]         (* what walkMio[] expands to *)
 ```
+
+`walkMio[]` is the usual entry point: it groups the transitions by component
+(below). `walkUI[mioCore]` alone gives one flat list. The `"Components"` option
+takes the same decomposition `merge` uses (`mioComponents` in `MioCore.wl`).
 
 `MiolingoSpec.wl` self-locates the rest (see `paths.wl`), so loading from any
 checkout works; just point the entry `Get` at the checkout you want to test.
 
 The panel shows, top to bottom:
 - **Current state** — the CCS process term (`foldAgentDisplay`), *where you are*.
+  **Collapsible** (an `OpenerView`, closed by default) so the term doesn't eat
+  space; the open/closed state persists across steps.
 - **Data view** — the published `view!` projections (`vSView`/`pSView`, or the
   bare `view`), rendered as the *computed* data through `linearizeGrid`.
 - **Transitions** — one clickable row each; hover shows *→ goes to:* the
-  derivative. Value-carrying input ports get an inline field.
+  derivative. Value-carrying input ports get an inline field. Under `walkMio[]`
+  (or any `"Components"`) they are **grouped into a frame per providing
+  component** (Helm / PS / VS), **inputs before outputs** in each frame; internal
+  syncs go in an *internal (τ)* frame. The port→component map is a pure syntactic
+  scan of each agent's sort (`componentPortMap`), so it needs no execution and
+  can't be fooled by guards; dual restricted actions (`vAdd`/`pLoad`/`langRead`)
+  only ever appear as τ, so they never split across frames.
 - **Back / Forward / Reset**, a **`Test:` menu + `Run test`** (see below), and
   the **condensed trace** (with Copy). **Back** and **Forward** scrub a run: step
   back through the states you've visited and forward again — handy after

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -1,0 +1,59 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/grouping_test.wls
+   ---------------------------------------------------------------------
+   The walk harness's transition-grouping substrate: componentPortMap (port
+   -> providing agent, by a pure syntactic sort scan), transGroup (which frame
+   a ready transition belongs in) and inputsFirst (inputs before outputs).
+   A walk-UI affordance, but the logic is pure and headless-testable.
+
+   Run headless:  wolframscript -file spec/tests/grouping_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];
+Get[$dir <> "walk.wl"];
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+hr = StringRepeat["=", 70];
+
+pm = componentPortMap[mioComponents];
+
+Print[hr]; Print["1. componentPortMap — each external port to its owning agent"]; Print[hr];
+assert["add -> VS",            pm["add"] === "VS"];
+assert["import_bulk -> VS",    pm["import_bulk"] === "VS"];
+assert["load_material -> PS",  pm["load_material"] === "PS"];
+assert["set_target -> Helm",   pm["set_target"] === "Helm"];
+assert["set_speed -> Helm",    pm["set_speed"] === "Helm"];
+(* the view ports are renamed per agent to match the composition *)
+assert["pSView -> PS",   pm["pSView"] === "PS"];
+assert["vSView -> VS",   pm["vSView"] === "VS"];
+assert["helmView -> Helm", pm["helmView"] === "Helm"];
+
+Print[hr]; Print["2. transGroup / inputsFirst"]; Print[hr];
+(* a real tau transition: drive capture_vocab so vAdd is pending *)
+sV = Last[walkSteps[transVP, mioCore,
+   {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
+    vis["recording_made", "audio"], vis["attempt_made"], vis["capture_vocab", "chat"]}]["states"]];
+tauTr = SelectFirst[readyTransitions[transVP, sV], isTauAct[First[#]] &];
+assert["a tau transition groups into internal (tau)",
+  transGroup[pm, tauTr] === "internal (\[Tau])"];
+assert["a named input groups into its agent (add -> VS)",
+  transGroup[pm, SelectFirst[readyTransitions[transVP, mioCore],
+     portName[First[#]] === "add" &]] === "VS"];
+(* inputsFirst: coLabel before label *)
+mix = {{label["x", param[1]], s1}, {coLabel["y", binding[z]], s2}};
+assert["inputsFirst puts the coLabel (input) before the label (output)",
+  MatchQ[First[First[inputsFirst[mix]]], coLabel[___]]];
+
+Print[hr]; Print["3. the initial mioCore ready set partitions cleanly (no 'other')"]; Print[hr];
+grp = GroupBy[readyTransitions[transVP, mioCore], transGroup[pm, #] &];
+assert["groups are exactly {VS, PS, Helm}", Sort[Keys[grp]] === {"Helm", "PS", "VS"}];
+assert["no port falls into 'other'", ! KeyExistsQ[grp, "other"]];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -266,18 +266,55 @@ traceView[trace_] := Column[{
    is the CCS term, complementing dataView's published data projections. *)
 stateDisplay[s_] := If[agentDefs =!= <||>, foldAgentDisplay[normalizeSC[s]], Short[s, 3]];
 
-Options[walkUI] = {"TransitionFunction" -> transVP};
+(* --- grouping the ready transitions by the agent that provides each port ---
+   sortOf[term] : the port NAMES (as strings) a process term offers, by a pure
+   SYNTACTIC scan (Cases over label/coLabel) — no execution, so guards and
+   infinite data state never bite. componentPortMap inverts the per-agent sorts
+   into <|"port" -> "Agent"|>. The merge decomposition is passed in (the same
+   {"PS"->call[...], ...} list merge uses); each agent's sort is scanned from its
+   built term, with the bare "view" renamed to decap[name]<>"View" to match the
+   composition's relabelled pSView/vSView/helmView (relabel is a lazy wrapper
+   under transVP, so we rename the name set directly). Dual (restricted) actions
+   vAdd/pLoad/langRead live in two
+   sorts, but they are internal taus in the composed system and never queried as
+   named ports here, so the overlap is harmless. *)
+sortOf::usage = "sortOf[term] gives the set of port names (strings) appearing syntactically in a process term — a pure scan, no execution.";
+componentPortMap::usage = "componentPortMap[{name->call,...}] gives <|portName -> agentName|> for grouping ready transitions by the component that provides each port (sort scanned from each agent's view-relabelled built term).";
+sortOf[term_] := Union[Cases[term, (label | coLabel)[nm_, ___] :> ToString[nm], Infinity]];
+componentPortMap[components : {(_String -> _) ..}] := Association @@
+  Flatten[Function[nc,
+      With[{name = First[nc]},
+        (Replace[#, "view" -> decap[name] <> "View"] -> name) & /@
+          sortOf[buildSystem[Last[nc]]]]] /@ components];
+
+(* transGroup: the frame a ready transition belongs in (its providing agent, or
+   an internal-tau group for a sync). inputsFirst: order a group's rows inputs
+   (coLabel) before outputs (label). *)
+transGroup[pmap_Association, tr_] := If[isTauAct[First[tr]], "internal (\[Tau])",
+  Lookup[pmap, ToString[portName[First[tr]]], "other"]];
+inputsFirst[ts_List] := Join[
+  Select[ts, MatchQ[First[#], coLabel[___]] &],
+  Select[ts, MatchQ[First[#], label[___]] &],
+  Select[ts, ! MatchQ[First[#], coLabel[___] | label[___]] &]];
+
+Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> {}};
 walkUI[agent_, opts : OptionsPattern[]] := With[
-  {tf = OptionValue["TransitionFunction"]},
+  {tf = OptionValue["TransitionFunction"],
+   components = OptionValue["Components"]},
+  With[{pmap = If[components === {}, <||>, componentPortMap[components]]},
   DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
-     maxprog = False,
+     maxprog = False, stateOpen = False,
      testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None]},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
         Framed[Column[{
 
-          Style["Current state \[LongDash] where you are (process term)", Bold, 13],
-          Pane[stateDisplay[cur], {Automatic, 140}, Scrollbars -> Automatic],
+          (* collapsible (default closed) so the process term doesn't eat space;
+             open state persists across steps via stateOpen *)
+          OpenerView[{
+            Style["Current state \[LongDash] where you are (process term)", Bold, 13],
+            Pane[stateDisplay[cur], {Automatic, 140}, Scrollbars -> Automatic]},
+            Dynamic[stateOpen]],
 
           Style["Data view \[LongDash] published projections", Bold, 13],
           dataView[tf, cur],
@@ -297,8 +334,7 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                  GrayLevel[0.35], 11]}],
           If[trans === {},
             Style["(deadlocked \[LongDash] no transitions)", Italic, GrayLevel[0.5]],
-            Column[
-              Map[Function[tr,
+            With[{row = Function[tr,
                 With[{act = First[tr], nm = ToString[portName[First[tr]]]},
                   Row[{
                     Tooltip[
@@ -335,8 +371,25 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                              Dynamic[Lookup[inVals, nm, First[inputBinderOf[act], ""]],
                                      (inVals[nm] = #) &],
                              Expression, FieldSize -> 20, ContinuousAction -> False]}],
-                      Nothing]}]]],
-                trans]]],
+                      Nothing]}]]]},
+            (* GROUP the ready transitions by the agent that provides each (a
+               frame per component, inputs before outputs). Flat list when no
+               "Components" option is given. Internal syncs (taus) fall into
+               their own "internal (tau)" frame. *)
+            If[pmap === <||>,
+              Column[row /@ trans],
+              With[{grp = GroupBy[trans, transGroup[pmap, #] &]},
+                Column[
+                  Function[k,
+                    Framed[
+                      Column[{Style[k, Bold, Darker[Blue], 11],
+                              Column[row /@ inputsFirst[grp[k]], Spacings -> 0.2]},
+                        Spacings -> 0.4],
+                      FrameStyle -> GrayLevel[0.82], RoundingRadius -> 4,
+                      FrameMargins -> 6]] /@
+                  Select[Join[Keys[components], {"other", "internal (\[Tau])"}],
+                    KeyExistsQ[grp, #] &],
+                  Spacings -> 0.5]]]]],
 
           (* Back / Forward scrub the run: Back pushes the current step onto a
              `future` stack; Forward replays it. A fresh step or Run test clears
@@ -375,8 +428,16 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
           traceView[trace]
 
         }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
-      TrackedSymbols :> {cur, inVals, testSel, future, maxprog}]]];
+      TrackedSymbols :> {cur, inVals, testSel, future, maxprog}]]]];
 
+
+(* --- convenience entry points: the miolingo harness with transitions GROUPED
+   by component (a Helm / PS / VS frame each, inputs before outputs). Plain
+   walkUI[mioCore] still gives the ungrouped flat list. mioComponents is the
+   single source of truth for the decomposition (MioCore.wl). --- *)
+walkMio::usage = "walkMio[] = walkUI[mioCore, \"Components\"->mioComponents]: the grouped harness (one frame per component). walkMioD[] is the transNamed/mioCoreD twin.";
+walkMio[]  := walkUI[mioCore,  "Components" -> mioComponents, "TransitionFunction" -> transVP];
+walkMioD[] := walkUI[mioCoreD, "Components" -> mioComponents, "TransitionFunction" -> transNamed];
 
 (* --- the value-carrying test sequences (walkTests), loaded relative to
    this file so walkUI's "Run test" menu and walkSteps both have them. --- *)


### PR DESCRIPTION
Two readability affordances for driving the harness without the whole spec in mind (the (a)/(b) you asked for before b2). Full suite **13/13** green.

## (a) Collapsible state view
The *Current state* process term is now an `OpenerView`, **closed by default** (it was eating vertical space); open/closed **persists across steps**.

## (b) Transitions grouped by component
Ready transitions render as **one framed group per providing component** (Helm / PS / VS), **inputs before outputs** in each; internal syncs get an *internal (τ)* frame.

- The port→component map (`componentPortMap`) is a **pure syntactic scan** of each agent's sort (`sortOf` = `Cases` over `label`/`coLabel` on the built term) — **no execution**, so guards can't fool it (e.g. `set_speed` still maps to Helm though it's espeak-gated).
- The bare `view` is renamed per agent to match the composition's `pSView`/`vSView`/`helmView`.
- Dual restricted actions (`vAdd`/`pLoad`/`langRead`) appear only as τ, so they never split across frames — exactly your "no two components share a non-dual action."

## API
`walkUI` gains `"Components" -> {name->call,…}` (default `{}` = flat list, unchanged). `mioComponents` is named once in `MioCore.wl` and reused by **both** `merge` and the walk grouping (one source of truth). New convenience entry points:

```wolfram
walkMio[]    (* = walkUI[mioCore,  "Components" -> mioComponents]  — recommended *)
walkMioD[]   (* = walkUI[mioCoreD, "Components" -> mioComponents, transNamed]   *)
```

## Tests / docs
`tests/grouping_test.wls` (new): `componentPortMap` attribution incl. the renamed view ports and the guard-gated `set_speed`; `transGroup` (τ vs agent); `inputsFirst` ordering; the initial ready set partitions into exactly `{VS, PS, Helm}` with no `"other"`. `docs/walk.md` updated.

**Try it:** `walkMio[]` — you'll see Helm / PS / VS frames, inputs then outputs, and the state term collapsed at the top. Next is **(b2)** PS scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)