### PR TITLE
spec/walk: grouping is now the default in walkUI (auto via a registry)

### DIFF
--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -22,18 +22,19 @@ In a notebook, from **your own checkout** (not a worktree):
 Get[".../spec/MiolingoSpec.wl"];   (* engine + spec, in order *)
 Get[".../spec/walk.wl"];           (* the harness + walkTests *)
 
-walkMio[]                                             (* RECOMMENDED: grouped by component *)
-walkMioD[]                                             (* the transNamed/mioCoreD twin *)
-
-walkUI[mioCore]                                       (* mu-term, transVP default; ungrouped *)
-walkUI[mioCoreD, "TransitionFunction" -> transNamed]  (* compact call form *)
-walkUI[call["VS", signedIn, {}, alpha, none, none], "TransitionFunction" -> transNamed]  (* a bare agent *)
-walkUI[mioCore, "Components" -> mioComponents]         (* what walkMio[] expands to *)
+walkUI[mioCore]                                       (* GROUPED by component (auto) *)
+walkUI[mioCoreD, "TransitionFunction" -> transNamed]  (* grouped; compact call form *)
+walkMio[]   walkMioD[]                                 (* shorthands for the two above *)
+walkUI[call["VS", signedIn, {}, alpha, none, none], "TransitionFunction" -> transNamed]  (* bare agent: flat *)
 ```
 
-`walkMio[]` is the usual entry point: it groups the transitions by component
-(below). `walkUI[mioCore]` alone gives one flat list. The `"Components"` option
-takes the same decomposition `merge` uses (`mioComponents` in `MioCore.wl`).
+Grouping is **automatic**: `walkUI[term]` groups by component whenever `term` is
+a **registered composed system** (the registry maps a system term to its
+decomposition; `mioCore`/`mioCoreD` register themselves). A bare/unregistered
+agent falls back to one flat list. To group your own composed system, either
+register it (`registerWalkComponents[term, components]`) or pass
+`"Components" -> components` explicitly (the same `{name->call,...}` list `merge`
+uses; `"Components" -> {}` forces a flat list).
 
 `MiolingoSpec.wl` self-locates the rest (see `paths.wl`), so loading from any
 checkout works; just point the entry `Get` at the checkout you want to test.

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -53,6 +53,14 @@ grp = GroupBy[readyTransitions[transVP, mioCore], transGroup[pm, #] &];
 assert["groups are exactly {VS, PS, Helm}", Sort[Keys[grp]] === {"Helm", "PS", "VS"}];
 assert["no port falls into 'other'", ! KeyExistsQ[grp, "other"]];
 
+Print[hr]; Print["4. auto-grouping registry — walkUI groups known systems by default"]; Print[hr];
+assert["defaultComponents[mioCore] === mioComponents",
+  defaultComponents[mioCore] === mioComponents];
+assert["defaultComponents[mioCoreD] === mioComponents",
+  defaultComponents[mioCoreD] === mioComponents];
+assert["a bare agent resolves to {} (flat, ungrouped)",
+  defaultComponents[call["VS", signedIn, {}, alpha, none, none]] === {}];
+
 Print[hr];
 Print["ALL ASSERTIONS: ", ok[allOk]];
 Print[hr];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -287,6 +287,18 @@ componentPortMap[components : {(_String -> _) ..}] := Association @@
         (Replace[#, "view" -> decap[name] <> "View"] -> name) & /@
           sortOf[buildSystem[Last[nc]]]]] /@ components];
 
+(* Auto-grouping registry: a composed-system term -> its component decomposition,
+   so walkUI with "Components" -> Automatic (the default) groups a KNOWN system
+   without being told each time. Generic — any composed system can register; the
+   miolingo systems (mioCore/mioCoreD) register at the bottom of this file. An
+   unregistered / bare agent resolves to {} (a flat, ungrouped list). *)
+$walkComponents = {};
+registerWalkComponents::usage = "registerWalkComponents[term, components] records that the composed term `term` decomposes into `components` ({name->call,...}), so walkUI[term] groups its transitions automatically.";
+registerWalkComponents[term_, comps_] := AppendTo[$walkComponents, {term, comps}];
+defaultComponents[agent_] := Replace[
+  SelectFirst[$walkComponents, First[#] === agent &],
+  {{_, c_} :> c, _Missing -> {}}];
+
 (* transGroup: the frame a ready transition belongs in (its providing agent, or
    an internal-tau group for a sync). inputsFirst: order a group's rows inputs
    (coLabel) before outputs (label). *)
@@ -297,10 +309,12 @@ inputsFirst[ts_List] := Join[
   Select[ts, MatchQ[First[#], label[___]] &],
   Select[ts, ! MatchQ[First[#], coLabel[___] | label[___]] &]];
 
-Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> {}};
+Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> Automatic};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"],
-   components = OptionValue["Components"]},
+   (* Automatic (the default): group if `agent` is a registered composed system,
+      else flat. An explicit list / {} overrides. *)
+   components = Replace[OptionValue["Components"], Automatic :> defaultComponents[agent]]},
   With[{pmap = If[components === {}, <||>, componentPortMap[components]]},
   DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
      maxprog = False, stateOpen = False,
@@ -431,13 +445,17 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
       TrackedSymbols :> {cur, inVals, testSel, future, maxprog}]]]];
 
 
-(* --- convenience entry points: the miolingo harness with transitions GROUPED
-   by component (a Helm / PS / VS frame each, inputs before outputs). Plain
-   walkUI[mioCore] still gives the ungrouped flat list. mioComponents is the
-   single source of truth for the decomposition (MioCore.wl). --- *)
-walkMio::usage = "walkMio[] = walkUI[mioCore, \"Components\"->mioComponents]: the grouped harness (one frame per component). walkMioD[] is the transNamed/mioCoreD twin.";
-walkMio[]  := walkUI[mioCore,  "Components" -> mioComponents, "TransitionFunction" -> transVP];
-walkMioD[] := walkUI[mioCoreD, "Components" -> mioComponents, "TransitionFunction" -> transNamed];
+(* --- register the miolingo systems so walkUI[mioCore] / walkUI[mioCoreD] GROUP
+   by component automatically (no "Components" option needed). mioComponents is
+   the single source of truth for the decomposition (MioCore.wl). --- *)
+If[ValueQ[mioCore]  && ValueQ[mioComponents], registerWalkComponents[mioCore,  mioComponents]];
+If[ValueQ[mioCoreD] && ValueQ[mioComponents], registerWalkComponents[mioCoreD, mioComponents]];
+
+(* convenience entry points. walkUI[mioCore] now groups on its own (via the
+   registry); walkMioD[] additionally wires transNamed for the call-based twin. *)
+walkMio::usage = "walkMio[] = walkUI[mioCore] (grouped by component via the registry). walkMioD[] is the transNamed/mioCoreD twin.";
+walkMio[]  := walkUI[mioCore];
+walkMioD[] := walkUI[mioCoreD, "TransitionFunction" -> transNamed];
 
 (* --- the value-carrying test sequences (walkTests), loaded relative to
    this file so walkUI's "Run test" menu and walkSteps both have them. --- *)


### PR DESCRIPTION
Generalises the per-component grouping from `walkMio` to **`walkUI` itself** — `walkUI[mioCore]` now groups on its own, no `"Components"` needed. Full suite **13/13** green.

## How
- `"Components"` default is now **`Automatic`**, resolved via a small **registry** (`$walkComponents`: system-term → decomposition). `registerWalkComponents[term, comps]` records one; `mioCore`/`mioCoreD` register themselves at the bottom of `walk.wl`.
- A **bare/unregistered** agent resolves to `{}` → flat list (unchanged behaviour). An explicit `"Components" -> list` (or `{}`) still overrides.
- **Generic:** any composed system gets the framed view by registering or passing the list — nothing mio-specific in `walkUI`.
- `walkMio[]` / `walkMioD[]` kept as shorthands (`walkMio[]` is now just `walkUI[mioCore]`; `walkMioD[]` also wires `transNamed`).

## Tests / docs
`grouping_test` gains a registry section (`defaultComponents[mioCore]`/`[mioCoreD] === mioComponents`; bare agent → `{}`). `docs/walk.md` updated.

So now: **`walkUI[mioCore]` = grouped**, `walkUI[bareAgent]` = flat, and the feature is available to any composed system. Next: **(b2)** PS scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)