### PR TITLE
spec (b2): wire langRead for PS scoring — pull the target language at attempt_made

### DIFF
--- a/spec/HelmRecovered.wl
+++ b/spec/HelmRecovered.wl
@@ -22,7 +22,7 @@
      view!         always — the helmView projection everyone reads
      langRead!     always — INTERNAL read port (restricted in mioCore): emits
                    {source, target} for a borrower that pulls it at point of use
-                   (VS.autofill; PS scoring to follow). Not a UI control.
+                   (VS.autofill, PS.attempt_made scoring). Not a UI control.
      set_source    set the source (native) language name
      set_target    set the target language code (target_language mirrors it)
      set_tts       set the TTS engine

--- a/spec/PracticeSessionFunctions.wl
+++ b/spec/PracticeSessionFunctions.wl
@@ -33,8 +33,10 @@ audioOf[_] := Missing[];
 
 (* --- oracle: audio -> recognised phonemes -------------------------------
    The ASR / espeak-from-audio step. Genuinely IO (a model / external
-   process); left UNINTERPRETED. evaluate is parametric in it. *)
-(* recognisePhonemes[audio]  -- stub oracle, no downvalue *)
+   process); left UNINTERPRETED. evaluate is parametric in it.
+   recognisePhonemes[audio, lang] -- stub oracle, no downvalue. lang is the
+   target language CODE (which ASR model); BORROWED from Helm and pulled fresh
+   at the attempt_made port (ARCHITECTURE.md "Borrowed vs owned data"). *)
 
 
 (* --- levenshtein + compare_phonemes_edit_distance (comparison.py:9, 83).
@@ -61,14 +63,16 @@ comparePhonemes[user_String, correct_String] := Module[{dist, maxLen},
     "distance" -> dist|>];
 
 
-(* --- evaluate[target, rec] : the scoring of an attempt -----------------
+(* --- evaluate[target, rec, lang] : the scoring of an attempt -----------
    PURE core (comparePhonemes) composed with the ASR oracle. The recorded
-   audio is recognised to phonemes (IO oracle), then compared against the
-   target's correct phonemes (pure). The result Association is what the
-   agent wraps in scored[...]. *)
-evaluate[target_, rec_] :=
+   audio is recognised to phonemes (IO oracle, in the target language), then
+   compared against the target item's correct phonemes (pure). lang is the
+   BORROWED {source, target} pair pulled from Helm at attempt_made; the ASR
+   uses Last[lang] (the target code). The result Association is what the agent
+   wraps in scored[...]. *)
+evaluate[target_, rec_, lang_List] :=
   comparePhonemes[
-    ToString[recognisePhonemes[audioOf[rec]]],
+    ToString[recognisePhonemes[audioOf[rec], Last[lang]]],
     correctPhonemesOf[target]];
 
 

--- a/spec/PracticeSessionRecovered.wl
+++ b/spec/PracticeSessionRecovered.wl
@@ -60,9 +60,16 @@ defineAgent["PSActive", {phrases, pos, rec, res},
       precede[coLabel["recording_made", binding[audio]],
         call["PS", phrases, pos, recorded[audio], none]],
       choice[
+        (* BORROWED DATA: scoring's ASR (recognisePhonemes) needs the target
+           language, which Helm OWNS. So attempt_made PULLS the (source, target)
+           pair fresh as a PREFIX \[LongDash] langRead?(lp), restricted to Helm's
+           langRead! in mioCore (an internal tau). No cached language => no
+           staleness. See ARCHITECTURE.md "Borrowed vs owned data". The pair is
+           passed into evaluate, which uses the target code for the ASR. *)
         precede[coLabel["attempt_made"],
-          call["PS", phrases, pos, rec,
-            scored[evaluate[targetOf[phrases, pos], rec]]]],
+          precede[coLabel["langRead", binding[lp]],
+            call["PS", phrases, pos, rec,
+              scored[evaluate[targetOf[phrases, pos], rec, lp]]]]],
         precede[coLabel["clear_recording"],
           call["PS", phrases, pos, none, none]]]],
     if[pos < Length[phrases] - 1,

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -139,10 +139,10 @@ progress). Helm remains the **sole owner**; oracles stay boundary functions
 (decision-A) but are now called *with* the language the read delivered.
 `espeakG2P[word, voice]` already has this shape (`voice` = the target read).
 
-*Status:* implemented for **VS `autofill`** (`autofillIn[entries, id, lang]` →
-`enrichOracle[word, source, target]`), with Helm's `langRead!` restricted in
-`mioCore`. **PS scoring** (`recognisePhonemes` needs the target ASR language) is
-the next borrower to wire, by the identical prefix-read.
+*Status:* implemented for **both** borrowers, by the identical prefix-read, with
+Helm's `langRead!` restricted in `mioCore`:
+- **VS `autofill`** → `autofillIn[entries, id, lang]` → `enrichOracle[word, source, target]`;
+- **PS scoring** (`attempt_made`) → `evaluate[target, rec, lang]` → `recognisePhonemes[audio, targetCode]`.
 
 **The one escape hatch.** Pull-on-use covers a *data* dependency (the value is
 needed when an action runs). It does **not** cover a *control* dependency over

--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -60,8 +60,8 @@ The panel shows, top to bottom:
   or `Run test` clears the forward/redo line.)
 - **Auto-advance internal syncs (maximal progress)** — a checkbox. When on, the
   harness fires the system's internal synchronisations (`vAdd`, `pLoad`, and
-  `langRead` — the borrowed-language pull on `autofill`) for you between your
-  actions, until the state is τ-stable,
+  `langRead` — the borrowed-language pull on `autofill` and on `attempt_made`
+  scoring) for you between your actions, until the state is τ-stable,
   so you only ever click *external* ports. It's a **simulation strategy, not a
   language change** (`autoTau` in `walk.wl`): it just chooses how to walk the
   existing transition system. The meta-agent split — you play the *user* (and the

--- a/spec/tests/data_view_test.wls
+++ b/spec/tests/data_view_test.wls
@@ -61,7 +61,7 @@ assert["editingRow[id] kept inline (not a binding)?",
 Print[hr]; Print["2. linearize a LIVE projection from the dual-tau walk"]; Print[hr];
 
 plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
-        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"], tau["vAdd"]};
+        vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
 wlk = walkSteps[transNamed, mioCoreD, plan];
 assert["walk ran to completion (not stuck)?", ! wlk["stuck"]];
 

--- a/spec/tests/functions_test.wls
+++ b/spec/tests/functions_test.wls
@@ -128,8 +128,8 @@ Print["  comparePhonemes exact -> similarity 1.0? ",
 phr = practiseList[ei, none];
 tgt = targetOf[plf, 0];
 Print["  targetOf[_,0] is first phrase? ", ok[tgt["text"] === "chien"]];
-recognisePhonemes[aud_] := "dxg";          (* stub the IO oracle *)
-ev = evaluate[<|"ipa" -> "dog"|>, recorded["audio-blob"]];
+recognisePhonemes[aud_, _] := "dxg";       (* stub the IO oracle (audio, lang) *)
+ev = evaluate[<|"ipa" -> "dog"|>, recorded["audio-blob"], {"English", "fr"}];
 Print["  evaluate composes oracle+compare (dist 1)? ",
   ok[ev["distance"] === 1 && ev["exact_match"] === False]];
 

--- a/spec/tests/functions_unit_test.wls
+++ b/spec/tests/functions_unit_test.wls
@@ -20,7 +20,7 @@ $dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
 Get[$dir <> "MiolingoSpec.wl"];
 
 enrichOracle[_, _, _] := <|"translation" -> "ORC", "ipa" -> "ɔrk"|>;  (* word, source, target *)
-recognisePhonemes[_]  := "abc";
+recognisePhonemes[_, _]  := "abc";   (* audio, lang *)
 
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 allOk = True; n = 0;
@@ -206,7 +206,7 @@ assert["comparePhonemes 1 edit: dist 1, sim 1.0-1/3 (Real), not exact",
 cp0 = comparePhonemes["abc", ""];
 assert["comparePhonemes empty correct: sim 0.0, dist = len(user)",
   cp0["similarity"] === 0.0 && cp0["distance"] === 3];
-ev = evaluate[<|"ipa" -> "abd"|>, recorded["x"]];   (* recognise->"abc" vs "abd" *)
+ev = evaluate[<|"ipa" -> "abd"|>, recorded["x"], {"English", "fr"}];   (* recognise->"abc" vs "abd" *)
 assert["evaluate composes oracle+compare (dist 1)", ev["distance"] === 1];
 sv = sessionView[phr, 1, recorded["x"], scored[<|"distance" -> 1|>]];
 assert["sessionView total/pos/item/hasRecording/score",

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -36,7 +36,7 @@ Print[hr]; Print["2. transGroup / inputsFirst"]; Print[hr];
 (* a real tau transition: drive capture_vocab so vAdd is pending *)
 sV = Last[walkSteps[transVP, mioCore,
    {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
-    vis["recording_made", "audio"], vis["attempt_made"], vis["capture_vocab", "chat"]}]["states"]];
+    vis["recording_made", "audio"], vis["attempt_made"], tau["langRead"], vis["capture_vocab", "chat"]}]["states"]];
 tauTr = SelectFirst[readyTransitions[transVP, sV], isTauAct[First[#]] &];
 assert["a tau transition groups into internal (tau)",
   transGroup[pm, tauTr] === "internal (\[Tau])"];

--- a/spec/tests/internal_transitions_test.wls
+++ b/spec/tests/internal_transitions_test.wls
@@ -39,7 +39,7 @@ findStep[s_, tau[ch_]] := SelectFirst[transVP[s], MatchQ[First[#], tag[\[Tau], c
 
 plan = {
   vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
-  vis["recording_made"], vis["attempt_made"], vis["capture_vocab"], tau["vAdd"]
+  vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]
 };
 
 Print[hr];

--- a/spec/tests/maxprog_test.wls
+++ b/spec/tests/maxprog_test.wls
@@ -31,7 +31,7 @@ readyTaus[tf_, s_] := Select[readyTransitions[tf, s], isTauAct[First[#]] &];
 
 (* drive to just AFTER capture_vocab, BEFORE the vAdd tau *)
 plan = {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
-        vis["recording_made", "audio"], vis["attempt_made"], vis["capture_vocab", "chat"]};
+        vis["recording_made", "audio"], vis["attempt_made"], tau["langRead"], vis["capture_vocab", "chat"]};
 
 check[label_, tf_, s0_] := Module[{s, taus, a, stable},
   Print[hr]; Print[label]; Print[hr];

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -62,7 +62,7 @@ With[{succ = Last[First[de0]]},
 findStep[tf_, s_, vis[nm_]]  := SelectFirst[tf[s], !isTau[First[#]] && portName[First[#]] === nm &];
 findStep[tf_, s_, tau[ch_]] := SelectFirst[tf[s], MatchQ[First[#], tag[\[Tau], ch, ___]] &];
 plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
-        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"], tau["vAdd"]};
+        vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
 walk[tf_, s0_] := Module[{s = s0, labs = {}, t, stuck = False},
   Do[t = findStep[tf, s, p];
      If[MissingQ[t], stuck = True; Break[]];

--- a/spec/tests/trace_io_test.wls
+++ b/spec/tests/trace_io_test.wls
@@ -32,7 +32,7 @@ ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 
 (* the known dual-tau deterministic plan (see merge_defined_test.wls) *)
 plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
-        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"], tau["vAdd"]};
+        vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
 
 (* NB: do NOT name any variable `w` — the spec's agent equations use the
    bare symbol `w` as a value binder (binding[w]); assigning to w here would

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -90,6 +90,7 @@ walkTests = <|
     vis["clear_recording"],
     vis["recording_made", "audio-B"],
     vis["attempt_made"],
+    tau["langRead"],                                (* scoring PULLS the target language *)
     vis["capture_vocab", "souris"],
     tau["vAdd"]},                                   (* capture relays to VS *)
 
@@ -115,6 +116,7 @@ walkTests = <|
     vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
     vis["recording_made", "audio"],
     vis["attempt_made"],
+    tau["langRead"],                                (* scoring PULLS the target language *)
     vis["capture_vocab", "chat"],
     tau["vAdd"]},
 
@@ -142,6 +144,7 @@ walkTests = <|
     tau["pLoad"],
     vis["recording_made", "audio"],
     vis["attempt_made"],
+    tau["langRead"],                                (* scoring PULLS the target language *)
     vis["capture_vocab", "souris"],
     tau["vAdd"]}
 


### PR DESCRIPTION
The second (and final core) **borrowed-data dependency** — the identical prefix-read to b1's `VS.autofill`, now on PS scoring. Full suite **13/13** green. The language is now fully threaded through the model.

## The wiring
- **PS `attempt_made`** reads the language as a **prefix** before scoring:
  ```
  attempt_made · langRead?(lp) · call[PS, …, scored[evaluate[target, rec, lp]]]
  ```
  Scoring can't run without first reading Helm's **current** `(source, target)` — no cache ⇒ no staleness. `langRead` restricted in `mioCore` (internal τ).
- **`evaluate[target, rec, lang]`** → **`recognisePhonemes[audio, Last[lang]]`** (the target ASR language; was 1-arg). The oracle stays an uninterpreted boundary stub, now called *with* the language.

## Ripple (mechanical)
Every plan with `attempt_made` gains `tau["langRead"]` after it — walk-tests (`ps-score`, `sync-vadd`, `full-roundtrip`) and the dual-tau plans in `data_view` / `internal_transitions` / `trace_io` / `merge_defined` / `maxprog` / `grouping` tests. `functions_test` + `functions_unit_test`: `evaluate`/`recognisePhonemes` arity updated.

## Docs
`ARCHITECTURE.md` status (both borrowers wired), `HelmRecovered` port note, `walk.md` maxprog note.

## The picture now
**Helm owns the language; VS (enrich) and PS (score) pull it fresh at point of use. No borrowed-data caches anywhere** — exactly the (B) decision, in pure CCS. `langRead` never appears as an external port (verified: `merge_defined` ready set unchanged); it's a τ enabled only while a borrower waits.

**Try it:** `walkUI[mioCore]` → drive a practice round to `attempt_made`; the `langRead` τ appears in the *internal (τ)* frame (or auto-fires with maximal-progress on) before the score lands.

This closes the language-wiring arc. Remaining from the earlier plan: **(c)** the incompleteness-inventory panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)