### PR TITLE
spec/walk (c): the cloud — incompleteness inventory panel

### DIFF
--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -45,6 +45,13 @@ The panel shows, top to bottom:
   space; the open/closed state persists across steps.
 - **Data view** — the published `view!` projections (`vSView`/`pSView`, or the
   bare `view`), rendered as the *computed* data through `linearizeGrid`.
+- **Outside the model** — a collapsible *incompleteness inventory* (`$walkCloud`):
+  data the agents **read but don't own** because its owner isn't modelled yet
+  (`enrichOracle` / `recognisePhonemes` knowledge, vocab persistence, stats /
+  history). A standing reminder the agents aren't complete in themselves; it
+  **shrinks** as owners are modelled (the language left it once `langRead`
+  brought it in-model). Each item **lights up (●)** when a currently-ready action
+  would consult it — so the cloud changes as you walk.
 - **Transitions** — one clickable row each; hover shows *→ goes to:* the
   derivative. Value-carrying input ports get an inline field. Under `walkMio[]`
   (or any `"Components"`) they are **grouped into a frame per providing

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -61,6 +61,16 @@ assert["defaultComponents[mioCoreD] === mioComponents",
 assert["a bare agent resolves to {} (flat, ungrouped)",
   defaultComponents[call["VS", signedIn, {}, alpha, none, none]] === {}];
 
+Print[hr]; Print["5. the cloud — external-dependency inventory lights up on consulting ports"]; Print[hr];
+enrichItem = SelectFirst[$walkCloud, #["item"] === "enrichOracle" &];
+asrItem    = SelectFirst[$walkCloud, #["item"] === "recognisePhonemes" &];
+assert["enrichOracle active when autofill is ready",  cloudActiveQ[enrichItem, {"autofill", "delete"}]];
+assert["enrichOracle NOT active without autofill",  ! cloudActiveQ[enrichItem, {"add", "set_sort"}]];
+assert["recognisePhonemes active on attempt_made",   cloudActiveQ[asrItem, {"attempt_made"}]];
+assert["stats/history never auto-active (not modelled, no ports)",
+  ! cloudActiveQ[SelectFirst[$walkCloud, #["item"] === "stats / history" &], {"add", "attempt_made", "autofill"}]];
+assert["cloudPanel builds (Head OpenerView)", Head[cloudPanel[transVP, mioCore]] === OpenerView];
+
 Print[hr];
 Print["ALL ASSERTIONS: ", ok[allOk]];
 Print[hr];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -309,6 +309,48 @@ inputsFirst[ts_List] := Join[
   Select[ts, MatchQ[First[#], label[___]] &],
   Select[ts, ! MatchQ[First[#], coLabel[___] | label[___]] &]];
 
+(* --- the "cloud": an honest INVENTORY of what the simulated agents read but
+   do NOT own — data whose owner is not (yet) modelled. A standing reminder that
+   the agents are not complete in themselves (ARCHITECTURE.md "Borrowed vs owned
+   data" / the Stats-History note). It SHRINKS as each owner is modelled: the
+   language used to be here, but pull-on-use (langRead) brought it into the model,
+   so it is gone — what remains is the genuinely external world (oracle knowledge,
+   persistence). Hand-maintained in lockstep with the spec, like the ARCHITECTURE
+   notes. Each item lights up when a ready action would CONSULT it, so the cloud
+   visibly changes as you walk. *)
+$walkCloud = {
+  <|"item" -> "enrichOracle", "owner" -> "external translation / G2P service",
+    "why" -> "VS.autofill's translation + IPA are produced OUTSIDE the model; only the (source,target) pull (langRead) is in it.",
+    "ports" -> {"autofill"}|>,
+  <|"item" -> "recognisePhonemes", "owner" -> "external ASR / acoustic model",
+    "why" -> "PS scoring recognises audio -> phonemes outside the model; only the target-language pull (langRead) is in it.",
+    "ports" -> {"attempt_made"}|>,
+  <|"item" -> "vocab persistence", "owner" -> "external store (DB)",
+    "why" -> "entries are modelled in VS state in-process; really an external store. To become a DB agent (ARCHITECTURE \[Dagger]).",
+    "ports" -> {"add", "import_bulk", "delete", "update", "update_notes", "autofill"}|>,
+  <|"item" -> "stats / history", "owner" -> "external store (query-backed views)",
+    "why" -> "not yet recovered; will be queries/views on the external store, not in-process state.",
+    "ports" -> {}|>};
+cloudActiveQ[item_Association, readyNames_List] := IntersectingQ[item["ports"], readyNames];
+cloudActiveQ::usage = "cloudActiveQ[item, readyPortNames] is True iff a currently-ready port would consult this external item (so the cloud panel highlights it).";
+cloudRow[item_Association, ready_List] := With[{active = cloudActiveQ[item, ready]},
+  Framed[
+    Column[{
+      Row[{If[active, Style["\[FilledCircle] ", Darker[Orange]], Style["\[EmptyCircle] ", GrayLevel[0.75]]],
+           Style[item["item"], Bold, If[active, Darker[Orange], GrayLevel[0.4]]],
+           Style["  \[LongDash] owned by " <> item["owner"], Italic, GrayLevel[0.55], 10]}],
+      Style[item["why"], GrayLevel[0.5], 10]}, Spacings -> 0.2],
+    FrameStyle -> If[active, Darker[Orange], GrayLevel[0.88]], RoundingRadius -> 3,
+    FrameMargins -> 5, Background -> If[active, RGBColor[1, 0.97, 0.88], White]]];
+cloudPanel::usage = "cloudPanel[tf, s] renders the external-dependency inventory ($walkCloud) as a collapsible panel; items a ready port would consult are highlighted.";
+cloudPanel[tf_, s_] := With[
+  {ready = ToString /@ portName /@ First /@ readyTransitions[tf, s]},
+  OpenerView[{
+    Style[Row[{"Outside the model \[LongDash] read but not owned (",
+               Length[$walkCloud], " items; \[FilledCircle] = consulted by a ready action)"}],
+      Bold, 12, GrayLevel[0.45]],
+    Column[cloudRow[#, ready] & /@ $walkCloud, Spacings -> 0.4]}, False]];
+
 Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> Automatic};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"],
@@ -332,6 +374,10 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
 
           Style["Data view \[LongDash] published projections", Bold, 13],
           dataView[tf, cur],
+
+          (* the cloud: external data the agents read but don't own (collapsible);
+             items light up when a ready action would consult them *)
+          cloudPanel[tf, cur],
 
           Style["Transitions \[LongDash] click to step; type into input ports", Bold, 13],
           (* maximal-progress toggle: a SIMULATION strategy (auto-fire internal


### PR DESCRIPTION
The last item from the data-sharing plan: a collapsible **"Outside the model"** panel (`$walkCloud`) listing what the agents **read but don't own** — a standing, honest reminder they aren't complete in themselves. Full suite **13/13** green.

## What it shows
Now that language is in-model (`langRead`, b1/b2), **it has left the cloud**. What remains is the genuinely external world:
- `enrichOracle` / `recognisePhonemes` — boundary oracle *knowledge*;
- **vocab persistence** — modelled in VS state now; really a DB (a future agent, ARCHITECTURE †);
- **stats / history** — a future external store.

The cloud **shrinks** as each owner is modelled.

## It changes as you walk
Each item **lights up** (● + highlight) when a currently-ready action would consult it (`cloudActiveQ`: the item's ports ∩ the ready set) — e.g. `enrichOracle` on `autofill`, `recognisePhonemes` on `attempt_made`. So you *see* the external read coming, the remaining form of your "see the cloud change."

Hand-maintained in lockstep with the spec (like the ARCHITECTURE notes). `walkUI` renders it collapsed under the data view.

## Tests / docs
`grouping_test` gains a cloud section (active-on-consulting-port; stats/history never auto-active; panel builds). `docs/walk.md` updated.

This closes the measured-pace data-sharing plan (a–d + b1/b2 + c). Next: **extracting more of the spec.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)