### PR TITLE
spec: unify vocab→practice into one channel, practise_vocab (ungated)

### DIFF
--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -24,7 +24,7 @@
 
    Cross-component links (each a complementary output/input pair, restricted):
      vAdd  : PS.capture_vocab(word)  --vAdd!(word)-->   VS adds the word
-     pLoad : VS.practise_filtered    --pLoad!(phrases)--> PS loads them
+     pLoad : VS.practise_vocab       --pLoad!(phrases)--> PS loads them
 
    Helm is composed in as a PURE PARALLEL agent (2026-06-01): NO control guard
    in PS/VS reads the language, so there is no new restricted channel — Helm

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -20,8 +20,10 @@
    search-non-empty guard on "Practise these", a missing-fields guard on
    autofill (stubbed), and an inline EDIT-MODE that swaps a row's actions.
 
-   Cross-component: practise_filtered -> PracticeSession.load_material;
-   and PracticeSession.capture_vocab -> this agent's `add`. (bidirectional)
+   Cross-component: practise_vocab -> PracticeSession.load_material (via pLoad);
+   and PracticeSession.capture_vocab -> this agent's `add` (via vAdd). The two
+   are symmetric: practise_vocab sends the vocab view OUT to practice,
+   capture_vocab brings a practised word back IN. (bidirectional)
 
    STUBBED: listVocab/addEntry/updateEntry/... are named, not defined.
    Structural guards (auth, non-empty, filter present, edit-mode) are
@@ -41,13 +43,15 @@
      VS[anon,      _, _,_,_ ]          Anon     : (none)
      VS[signedIn, {}, _,none,none]     Empty    : add, vAdd, import_bulk,
                                                   set_sort, set_filter
-     VS[signedIn, ne, _,none,none]     NonEmpty : + export, delete,
-                                                  update_notes, autofill,
-                                                  begin_edit
-     VS[signedIn, ne, _,filterBy,none] +search  : + practise_filtered
-     VS[signedIn, ne, _,_,editingRow[id]] Editing  : per-row -> update,
-                                                  cancel_edit (no delete/
-                                                  begin_edit); export stays
+     VS[signedIn, ne, _,_,none]        NonEmpty : + export, practise_vocab,
+                                                  delete, update_notes,
+                                                  autofill, begin_edit
+                                                  (practise_vocab any filter;
+                                                  payload = practiseList[…,filter],
+                                                  all when filter===none)
+     VS[signedIn, ne, _,_,editingRow[id]] Editing  : export, practise_vocab,
+                                                  per-row update, cancel_edit
+                                                  (no delete/begin_edit)
 
    NOTE: refactored to guard-partitioned normal form 2026-05-30.
    RE-VERIFY on the engine before commit: simulated ready sets per mode
@@ -102,35 +106,26 @@ defineAgent["VSAuthed", {entries, sort, filter, editing},
               call["VSNonEmpty", entries, sort, filter, editing]]]]]]]]
 
 
-(* --- non-empty: export always; filter and edit-mode refine the branch --- *)
+(* --- non-empty: export + practise_vocab always; edit-mode refines per-entry --
+   practise_vocab is the SINGLE vocab->practice channel (the app exposes it as
+   "Load vocabulary" / "Load filtered" / "Practise these" — unified here). It is
+   available whenever the store is non-empty, regardless of filter, and emits the
+   CURRENT vocab VIEW to PracticeSession via pLoad (restricted -> tau in mioCore):
+   practiseList[entries, filter] is ALL vocab when filter===none ("Load
+   vocabulary") and the filtered subset when filterBy[q] ("Load filtered"). The
+   filter no longer GATES the route (it only parametrises the payload); the
+   previous filter split collapses, leaving just the edit-mode split for per-entry
+   actions. *)
 defineAgent["VSNonEmpty", {entries, sort, filter, editing},
-  if[filter =!= none,
+  choice[
+    precede[label["export", param[exportCsv[entries]]],
+      call["VS", signedIn, entries, sort, filter, editing]],
+    precede[coLabel["practise_vocab"],
+      precede[label["pLoad", param[practiseList[entries, filter]]],
+        call["VS", signedIn, entries, sort, filter, editing]]],
     if[editing === none,
-      choice[
-        precede[label["export", param[exportCsv[entries]]],
-          call["VS", signedIn, entries, sort, filter, editing]],
-        choice[
-          precede[coLabel["practise_filtered"],
-            precede[label["pLoad", param[practiseList[entries, filter]]],
-              call["VS", signedIn, entries, sort, filter, editing]]],
-          call["VSEntryActions", entries, sort, filter]]],
-      choice[
-        precede[label["export", param[exportCsv[entries]]],
-          call["VS", signedIn, entries, sort, filter, editing]],
-        choice[
-          precede[coLabel["practise_filtered"],
-            precede[label["pLoad", param[practiseList[entries, filter]]],
-              call["VS", signedIn, entries, sort, filter, editing]]],
-          call["VSEditActions", entries, sort, filter, editing]]]],
-    if[editing === none,
-      choice[
-        precede[label["export", param[exportCsv[entries]]],
-          call["VS", signedIn, entries, sort, filter, editing]],
-        call["VSEntryActions", entries, sort, filter]],
-      choice[
-        precede[label["export", param[exportCsv[entries]]],
-          call["VS", signedIn, entries, sort, filter, editing]],
-        call["VSEditActions", entries, sort, filter, editing]]]]]
+      call["VSEntryActions", entries, sort, filter],
+      call["VSEditActions", entries, sort, filter, editing]]]]
 
 
 (* --- per-entry actions when NOT editing --- *)

--- a/spec/docs/afforded-guard-normal-form-handoff.md
+++ b/spec/docs/afforded-guard-normal-form-handoff.md
@@ -88,7 +88,7 @@ Required rewrite goals:
 - preserve `view`
 - preserve auth gate
 - preserve empty/non-empty split
-- preserve filter-sensitive `practise_filtered`
+- preserve filter-sensitive `practise_filtered` (later renamed `practise_vocab` and made filter-INsensitive — the filter now parametrises the payload, not availability; see vocabstore-recovery.md Amendment 2026-06-02)
 - preserve edit-mode split
 - preserve cross-component `vAdd` and `pLoad`
 - normalize into guard-partitioned form

--- a/spec/docs/vocabstore-recovery.md
+++ b/spec/docs/vocabstore-recovery.md
@@ -51,7 +51,7 @@ Per `SPEC-RECOVERY.md` §3. Component: **Vocabulary** tab (per-user, per-languag
 | "✖ Cancel" | `cancel_edit(id)` | leave edit-mode |
 | Sort selectbox | `set_sort(s)` | reparametrise the view |
 | Search box | `set_filter(q)` | reparametrise the view |
-| "🎯 Practise these" | `practise_filtered` | **cross-component** → `PracticeSession.load_material` |
+| "🎯 Practise these" / QP "📂 Load vocabulary" / "🎯 Load filtered" | `practise_vocab` | **cross-component** → `PracticeSession.load_material`. ONE channel; payload `practiseList(entries, filter)` is all vocab when `filter=none`, the subset otherwise (see Amendment below) |
 | (text fields, the upload widget) | — not ports — | |
 
 *"🔊 Play"* is an output effect (TTS), not a store mutation.
@@ -77,15 +77,13 @@ Per `SPEC-RECOVERY.md` §3. Component: **Vocabulary** tab (per-user, per-languag
 | Mode | Domain ports | Recovered from |
 |---|---|---|
 | **Anon** (not authenticated) | — (none) | `_require_auth()` early-returns the whole tab |
-| **Empty** (signed in, no entries in this pairing) | `add`, `import_bulk`, `set_sort`, `set_filter` | no rows ⇒ no per-entry actions, no export, no "Practise these" |
-| **NonEmpty** | `+ export`, and per entry: `delete`, `update_notes`, `autofill`†, `begin_edit` | `for row in rows:` renders the action rows |
-| **NonEmpty + search** | `+ practise_filtered` | `if rows and search.strip():` |
-| **Editing(id)** (a row in edit-mode) | for that row: `update(id)`, `cancel_edit(id)` *instead of* the normal actions | `if editing: _render_entry_edit_form` |
+| **Empty** (signed in, no entries in this pairing) | `add`, `import_bulk`, `set_sort`, `set_filter` | no rows ⇒ no per-entry actions, no export, no practise |
+| **NonEmpty** | `+ export`, `practise_vocab`, and per entry: `delete`, `update_notes`, `autofill`†, `begin_edit` | `for row in rows:` renders the action rows |
+| **Editing(id)** (a row in edit-mode) | for that row: `update(id)`, `cancel_edit(id)` *instead of* the normal actions (`export`, `practise_vocab` stay) | `if editing: _render_entry_edit_form` |
 
 Guards (state-dependent enablement):
 - **auth** gates every domain port (Anon offers none).
-- per-entry ops + export gate on **non-empty**.
-- `practise_filtered` gates on **non-empty ∧ filter non-empty**.
+- per-entry ops + export + `practise_vocab` gate on **non-empty** (the filter no longer gates practise — see Amendment).
 - † `autofill` gates on the entry **missing translation or IPA** (`need_autofill`) — a per-entry stubbed-value guard.
 - `begin_edit` vs `update`/`cancel_edit` switch on **edit-mode** for that entry.
 
@@ -106,7 +104,7 @@ Guards (state-dependent enablement):
         ◄──export(csv)──────                                │
         ◄──whyEmpty(...)────└──────────────────────────────┘
                                  │                    ▲
-              practise_filtered ─┘                    └── add ◄── capture_vocab
+              practise_vocab ────┘                    └── add ◄── capture_vocab
                   │                                          (from PracticeSession)
                   ▼
             PracticeSession.load_material      ⇒ VocabStore ⇄ PracticeSession (bidirectional)
@@ -123,3 +121,16 @@ Guards (state-dependent enablement):
 `needsAutofill(entries, id)`, `vocabView(...)`.
 
 Names recovered from `vocabulary_tab.py`'s calls into `vocab.py`; bodies survive framework-independently in `src/vocab.py` and are recovered mechanically later — not invented now.
+
+---
+
+## Amendment (2026-06-02) — the vocab→practice channel is `practise_vocab`, ungated
+
+The original recovery extracted only the vocab tab's "🎯 Practise these" button, as `practise_filtered`, **gated on a filter** (`if rows and search.strip()`). That under-extracted the design: **`src/ui/quick_practice_tab.py`** exposes the same hand-off from the *Quick Practice* side with **two more routes** — **"📂 Load vocabulary (N)"** (the *whole, unfiltered* vocab, available whenever vocab is non-empty) and **"🎯 Load filtered (N)"** (the filtered subset) — plus a Minimal-Pairs route (a computed subset).
+
+Per Matthew's decision (2026-06-02), these are unified into **one channel**, `practise_vocab`:
+- available whenever the store is **non-empty** (the filter no longer *gates* it);
+- it emits the **current view** to PracticeSession via `pLoad` (restricted → τ): `practiseList(entries, filter)` — **all** vocab when `filter = none`, the filtered subset when `filterBy[q]`. So the filter *parametrises the payload*, it does not enable/disable the route.
+- Minimal Pairs is **not** modelled this round (a separate computed route, deferred).
+
+The τ hand-off itself was verified faithful before this change: PS receives the list and all PS features become available, identical to `load_material`. See `MioCore.wl` (the `pLoad` link) and `VocabStoreRecovered.wl` (`VSNonEmpty`).

--- a/spec/tests/composition_test.wls
+++ b/spec/tests/composition_test.wls
@@ -84,8 +84,8 @@ If[cv2 =!= $Failed, Print["      ", InputForm[taus[cv2]]]];
 
 pf = restrict[par[call["PS", {}, 0, none, none],
                   call["VS", signedIn, {e1}, alpha, filterBy["q"], none]], R];
-pf2 = stepTo[pf, "practise_filtered"];
-Print["   practise_filtered -> tau(pLoad)?  ",
+pf2 = stepTo[pf, "practise_vocab"];
+Print["   practise_vocab -> tau(pLoad)?  ",
   ok[pf2 =!= $Failed && AnyTrue[taus[pf2], MatchQ[#, tag[\[Tau], "pLoad", ___]] &]]];
 If[pf2 =!= $Failed, Print["      ", InputForm[taus[pf2]]]];
 

--- a/spec/tests/data_view_test.wls
+++ b/spec/tests/data_view_test.wls
@@ -13,7 +13,7 @@
         cumulative state term (recoverable by replay).
 
    PLAN: the dual-tau deterministic walk from internal_transitions_test /
-   merge_defined_test (set_filter, add, practise_filtered, tau pLoad,
+   merge_defined_test (set_filter, add, practise_vocab, tau pLoad,
    recording_made, attempt_made, capture_vocab, tau vAdd) over mioCoreD
    (transNamed). It drives both cross-component internal taus.
 
@@ -60,7 +60,7 @@ assert["editingRow[id] kept inline (not a binding)?",
 --------------------------------------------------------------------- *)
 Print[hr]; Print["2. linearize a LIVE projection from the dual-tau walk"]; Print[hr];
 
-plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
+plan = {vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
         vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
 wlk = walkSteps[transNamed, mioCoreD, plan];
 assert["walk ran to completion (not stuck)?", ! wlk["stuck"]];

--- a/spec/tests/internal_transitions_test.wls
+++ b/spec/tests/internal_transitions_test.wls
@@ -9,7 +9,7 @@
 
    One path hits both, because the two relays chain:
 
-     VS: set_filter, add  ->  practise_filtered  --pLoad!-->  (tau)
+     VS: set_filter, add  ->  practise_vocab  --pLoad!-->  (tau)
          => PS receives practiseList[...] and becomes ACTIVE
      PS: recording_made, attempt_made  ->  capture_vocab  --vAdd!--> (tau)
          => VS receives the captured word
@@ -38,7 +38,7 @@ findStep[s_, vis[nm_]]  := SelectFirst[transVP[s], !isTau[First[#]] && portName[
 findStep[s_, tau[ch_]] := SelectFirst[transVP[s], MatchQ[First[#], tag[\[Tau], ch, ___]] &];
 
 plan = {
-  vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
+  vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
   vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]
 };
 

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -61,7 +61,7 @@ With[{succ = Last[First[de0]]},
 (* shared deterministic walk, parametrised by the transition function *)
 findStep[tf_, s_, vis[nm_]]  := SelectFirst[tf[s], !isTau[First[#]] && portName[First[#]] === nm &];
 findStep[tf_, s_, tau[ch_]] := SelectFirst[tf[s], MatchQ[First[#], tag[\[Tau], ch, ___]] &];
-plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
+plan = {vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
         vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
 walk[tf_, s0_] := Module[{s = s0, labs = {}, t, stuck = False},
   Do[t = findStep[tf, s, p];

--- a/spec/tests/trace_io_test.wls
+++ b/spec/tests/trace_io_test.wls
@@ -31,7 +31,7 @@ hr      = StringRepeat["=", 70];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 
 (* the known dual-tau deterministic plan (see merge_defined_test.wls) *)
-plan = {vis["set_filter"], vis["add"], vis["practise_filtered"], tau["pLoad"],
+plan = {vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
         vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
 
 (* NB: do NOT name any variable `w` — the spec's agent equations use the

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -94,13 +94,24 @@ walkTests = <|
     vis["capture_vocab", "souris"],
     tau["vAdd"]},                                   (* capture relays to VS *)
 
-  (* --- sync: VS practise_filtered -> PS load (pLoad) ------------------ *)
+  (* --- sync: VS practise_vocab (FILTERED) -> PS load (pLoad) ----------
+     a filter is set, so practise_vocab sends the filtered subset. *)
   "sync-pload" -> {
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["set_filter", "ch"],
-    vis["practise_filtered"],
+    vis["practise_vocab"],
     tau["pLoad"],
     vis["select_item", 0]},
+
+  (* --- sync: VS practise_vocab (ALL, no filter) -> PS load (pLoad) ----
+     no filter, so the SAME channel sends the whole vocab ("Load vocabulary").
+     practiseList[entries, none] = all entries. *)
+  "practise-all" -> {
+    vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
+    vis["add", <|"word" -> "chien", "translation" -> "dog"|>],
+    vis["practise_vocab"],
+    tau["pLoad"],
+    vis["select_item", 1]},
 
   (* --- sync: VS autofill PULLS the language from Helm (langRead) ------
      The first BORROWED-DATA read: autofill needs the (source, target) pair to
@@ -140,7 +151,7 @@ walkTests = <|
   "full-roundtrip" -> {
     vis["set_filter", "ch"],
     vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
-    vis["practise_filtered"],
+    vis["practise_vocab"],
     tau["pLoad"],
     vis["recording_made", "audio"],
     vis["attempt_made"],


### PR DESCRIPTION
Recovery fix for the gap you spotted: the spec only modelled the vocab tab's "🎯 Practise these" as `practise_filtered`, **gated on a filter**. But `quick_practice_tab.py` exposes the same hand-off with more routes — **"📂 Load vocabulary"** (the *whole, unfiltered* vocab) and **"🎯 Load filtered"** — so requiring a filter under-extracted the design. (The `pLoad` τ itself was already faithful — PS receives the list and all PS features come alive, identical to `load_material`; only the route's availability/name was wrong.)

## Change — one channel (your call: no minimal pairs)
- `practise_filtered` → **`practise_vocab`**, hoisted in `VSNonEmpty` to be available **whenever non-empty** (the filter no longer *gates* it).
- It emits the **current view** via `pLoad` (restricted → τ): `practiseList[entries, filter]` is **all** vocab when `filter = none` ("Load vocabulary"), the subset when `filterBy[q]` ("Load filtered" / "Practise these"). The filter now only **parametrises the payload**.
- The old filter split in `VSNonEmpty` collapses; the edit-mode split remains. Nicely symmetric with `capture_vocab` (the PS→VS reverse).

## Verified
- `practise_vocab` ready after any add, **regardless of filter**;
- unfiltered route sends **all** entries (`pSView` total = 2 after 2 adds);
- old `practise_filtered` gone; full suite **13/13** green (incl. the new `practise-all` walk-test exercising the unfiltered route on both engines).

## Docs
`vocabstore-recovery.md` **Amendment (2026-06-02)** documents the under-extraction and the unification; handoff doc annotated.

**Try it:** `walkUI[mioCore]` → add a couple of words (no filter) → `practise_vocab` is in the VS frame → fire it + the `pLoad` τ → PS loads the whole vocab. The `practise-all` and `sync-pload` test plans show both behaviours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)