### PR TITLE
spec/walk: two harness UX touches — wrong-shape warning + git build stamp

### DIFF
--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -362,19 +362,46 @@ cloudPanel[tf_, s_, open_ : False] := With[
       Bold, 12, GrayLevel[0.45]],
     Column[cloudRow[#, ready] & /@ $walkCloud, Spacings -> 0.4]}, open]];
 
+(* --- build stamp: read the loaded checkout's git HEAD so the harness shows
+   exactly which spec build a cell is running — the merge commit's PR number,
+   short SHA, date, and a +local-edits flag if the tree is dirty. Read at walkUI
+   creation (cheap: a few git calls), so each fresh cell reflects what's on disk
+   NOW; a stale cell keeps its old stamp (a visible tell to re-make it).
+   $walkDir is captured at LOAD time ($InputFileName is only valid during Get). *)
+walkVersion::usage = "walkVersion[dir] gives a one-line build stamp for the git checkout at `dir` (PR #, short SHA, date, +local edits) — shown in walkUI so you can confirm which spec build the cell is running.";
+walkVersion[dir_] := Module[{run, sha, subj, date, dirty, pr},
+  run[a_] := Module[{r = Quiet @ RunProcess[Join[{"git", "-C", dir}, a]]},
+    If[AssociationQ[r] && r["ExitCode"] === 0, StringTrim[r["StandardOutput"]], $Failed]];
+  sha = run[{"rev-parse", "--short=9", "HEAD"}];
+  If[sha === $Failed, Return["(version unknown \[LongDash] not a git checkout)"]];
+  subj  = run[{"log", "-1", "--format=%s"}];
+  date  = run[{"log", "-1", "--format=%cs"}];
+  dirty = StringTrim[ToString[run[{"status", "--porcelain"}]]] =!= "";
+  pr = FirstCase[StringCases[ToString[subj], "#" ~~ d : DigitCharacter .. :> d], _, None];
+  StringJoin[
+    If[pr =!= None, "PR #" <> pr <> " \[CenterDot] ", ""],
+    ToString[sha], " \[CenterDot] ", ToString[date],
+    If[dirty, " \[CenterDot] +local edits", ""]]];
+$walkDir = DirectoryName[$InputFileName];
+
 Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> Automatic};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"],
    (* Automatic (the default): group if `agent` is a registered composed system,
       else flat. An explicit list / {} overrides. *)
    components = Replace[OptionValue["Components"], Automatic :> defaultComponents[agent]]},
-  With[{pmap = If[components === {}, <||>, componentPortMap[components]]},
+  With[{pmap = If[components === {}, <||>, componentPortMap[components]],
+        ver = walkVersion[$walkDir]},
   DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
      maxprog = False, stateOpen = False, cloudOpen = False,
      testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None]},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
         Framed[Column[{
+
+          (* build stamp (captured when THIS cell was created) — confirms which
+             spec build you're running; a stale cell shows an old PR#/SHA *)
+          Style["spec build: " <> ver, GrayLevel[0.55], 10],
 
           (* collapsible (default closed) so the process term doesn't eat space;
              open state persists across steps via stateOpen *)

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -228,9 +228,20 @@ viewPanel[nm_String, p_Association] := Module[
     Column[Join[{Style[nm, Bold, Darker[Blue]]}, {strip}, tables], Spacings -> 0.5],
     RoundingRadius -> 5, FrameStyle -> GrayLevel[0.8], FrameMargins -> 8,
     Background -> GrayLevel[0.99]]];
+(* A view projection that did NOT reduce to an Association (every view! function
+   — sessionView/vocabView/helmView — returns one when it computes). The usual
+   cause: a supplied value of the wrong SHAPE, so the projection function's
+   pattern (e.g. sessionView[phrases_List, ...]) doesn't match and it stays held.
+   Show the raw term (so you can see what didn't reduce) under a clear warning,
+   rather than a cryptic linearised stub. *)
 viewPanel[nm_String, other_] := Framed[
-  Column[{Style[nm, Bold, Darker[Blue]], linearizeGrid[other]}, Spacings -> 0.5],
-  RoundingRadius -> 5, FrameStyle -> GrayLevel[0.8], FrameMargins -> 8];
+  Column[{Style[nm, Bold, Darker[Blue]],
+          Style["\[WarningSign] projection did not reduce to data \[LongDash] the supplied \
+value is probably the wrong shape (e.g. a single entry, or `word`-keyed, where a \
+LIST of `text`-keyed phrases is expected). Use practise_vocab for vocab, or a list \
+like {<|\"text\"->...|>} for load_material.", Italic, Darker[Orange], 10],
+          linearizeGrid[other]}, Spacings -> 0.5],
+  RoundingRadius -> 5, FrameStyle -> Darker[Orange], FrameMargins -> 8];
 
 dataView[tf_, s_] := Module[{projs = viewProjections[tf, s]},
   If[projs === <||>,


### PR DESCRIPTION
Two small `walk.wl` quality-of-life fixes (both UI-only; the spec is unchanged). Suite **13/13** green.

## 1. Warn when a view projection doesn't reduce to data
A wrong-**shaped** supplied value leaves a `view!` function (`sessionView`/`vocabView`/`helmView`, gated on `_List` etc.) unmatched/held, and the data view printed a cryptic raw term (e.g. `sessionView[<single entry>, 0, none, none]`). `viewPanel`'s non-Association branch now shows a clear orange **⚠ "projection did not reduce to data — wrong shape? use practise_vocab, or a list of `text`-keyed phrases for load_material"** above the term. Only triggers when a projection fails to compute.

## 2. Git build stamp in the harness
`walkUI` shows which spec build the cell is running — read from the checkout's git HEAD at **cell-creation time**: `PR #NNN · <short-sha> · <date>` (+ `+local edits` if dirty). A fresh cell reflects what's on disk now; a **stale cell keeps its old stamp**, which directly answers "am I running the latest?" and flags a cell that needs re-making (e.g. the `practise_vocab`-in-"other" confusion was a stale snapshot). Degrades to "(version unknown)" off a git checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)