### PR TITLE
spec: CargoHold (external store) — standalone agent (PR-1)

### DIFF
--- a/spec/CargoHoldRecovered.wl
+++ b/spec/CargoHoldRecovered.wl
@@ -1,0 +1,62 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — CargoHold (the external store), RECOVERED
+   ---------------------------------------------------------------------
+   Recovered from src/vocab.py + src/app_mysql.py (the MySQL persistence
+   layer), NOT invented. Every vocab operation in the app opens a
+   connection (app_mysql.get_connection) and runs SQL against the
+   `vocab_entries` table — capture (INSERT … ON DUPLICATE KEY UPDATE),
+   list (SELECT), delete (DELETE), update (UPDATE). CargoHold is the agent
+   that OWNS that persisted collection.
+
+   (CargoHold, not Hold: `Hold` is a Wolfram built-in. Nautical theme —
+   Helm steers, the cargo hold stores.)
+
+   THE POINT (single source of truth; ARCHITECTURE.md "Borrowed vs owned
+   data" / the Stats-History † note): the persisted collection is OWNED here,
+   not in VocabStore. VS holds only its UI parameters (sort/filter/editing)
+   and READS the collection from CargoHold at the point of use — see PR-2,
+   the (i) migration. This file (PR-1) DEFINES CargoHold standalone; it is
+   loaded but NOT yet composed into mioCore (so no dual state until VS is
+   migrated to read it).
+
+   STATE: CargoHold[entries]   — entries : the persisted collection (list)
+
+   PORTS (mirror the vocab.py SQL surface; see cargohold-recovery.md):
+     chRead!    always — emits the current collection (a self-loop, never
+                changing CargoHold). The READ a client pulls. ≈ list_vocab SELECT.
+     chUpsert   capture/import a word — INSERT … ON DUPLICATE KEY UPDATE
+                (dedup/bump): the recovered addEntry IS this upsert.
+     chRemove   delete by id — DELETE.
+     chAmend    update fields by id — UPDATE. Carries <|"id"->_, "fields"->_|>.
+
+   When composed (PR-2), chRead/chUpsert/chRemove/chAmend are RESTRICTED in
+   mioCore (internal taus), and VS reads/writes through them.
+
+   LEAF agent (every branch loops back to CargoHold) — no sub-agent expansion.
+   Reuses the already-recovered collection transforms (addEntry/deleteFrom/
+   updateEntry, VocabStoreFunctions.wl) — they apply HERE now, where the data
+   lives. autofill's enrichment (oracle + borrowed language) is deferred to the
+   migration, so chAmend covers plain field updates for now.
+
+   LOAD ORDER: RCA_core.wl, discipline.wl, then this (alongside the other
+   recovered agents). Functions resolve at step time, as for the other agents.
+   ===================================================================== *)
+
+defineAgent["CargoHold", {entries},
+  choice[
+    (* @src vocab.py:195 (list_vocab) — SELECT * FROM vocab_entries WHERE … *)
+    precede[label["chRead", param[entries]],
+      call["CargoHold", entries]],
+    (* @src vocab.py:106 (capture_vocab_entry) — INSERT … ON DUPLICATE KEY UPDATE.
+       addEntry is the recovered upsert (dedup + times_seen bump). *)
+    precede[coLabel["chUpsert", binding[w]],
+      call["CargoHold", addEntry[entries, w]]],
+    (* @src vocab.py:301 (delete_vocab_entry) — DELETE … WHERE vocab_id=%s *)
+    precede[coLabel["chRemove", binding[id]],
+      call["CargoHold", deleteFrom[entries, id]]],
+    (* @src vocab.py:343 (update_vocab_entry) — UPDATE … WHERE vocab_id=%s.
+       u = <|"id" -> _, "fields" -> _Association|>. *)
+    precede[coLabel["chAmend", binding[u]],
+      call["CargoHold", updateEntry[entries, editingRow[u["id"]], u["fields"]]]]]]

--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -114,8 +114,15 @@ addEntry[entries_List, w : (_String | _Association)] := Module[
       entries, pos]]];
 
 
-(* --- deleteFrom[entries, id] : delete_vocab_entry (vocab.py:301) ------- *)
-deleteFrom[entries_List, id_] := DeleteCases[entries, e_ /; e["id"] === id];
+(* --- deleteFrom[entries, id] : delete_vocab_entry (vocab.py:301) -------
+   id_Integer (not id_): the vocab_id is an integer, and this is the SAME
+   held-until-concrete discipline as addEntry[w:(_String|_Association)] /
+   updateEntry[fields_Association]. Without it, deleteFrom fires while `id` is
+   still a FREE binder (concrete entries, symbolic id): DeleteCases then matches
+   nothing and collapses to the list UNCHANGED, before the supplied value lands —
+   a silent no-op delete (latent in VS.delete; surfaced by CargoHold.chRemove).
+   Gating on _Integer keeps it held until the real id arrives, then deletes. *)
+deleteFrom[entries_List, id_Integer] := DeleteCases[entries, e_ /; e["id"] === id];
 
 
 (* --- updateNotesIn[entries, idn] : update_vocab_notes (vocab.py:314).

--- a/spec/docs/cargohold-recovery.md
+++ b/spec/docs/cargohold-recovery.md
@@ -1,0 +1,48 @@
+# CargoHold — recovery & provenance
+
+`CargoHold` (`CH`) is the agent that **owns the persisted collection** — recovered
+from the app's MySQL layer (`src/vocab.py` over `src/app_mysql.py`), where every
+vocab operation opens a connection and runs SQL against the `vocab_entries` table.
+It is the model of the *external store* the `†` note (ARCHITECTURE.md) anticipated,
+and the persistence counterpart of the "own it → store it" rule.
+
+(`CargoHold`, not `Hold`: `Hold` is a Wolfram built-in. Nautical theme — `Helm`
+steers, the cargo hold stores.)
+
+**Status:** PR-1 defines it **standalone** (loaded via `loadRecoveredBase`, *not*
+yet composed into `mioCore` — no dual state until VS reads it). PR-2 composes it
+(restricted `chRead`/`chUpsert`/`chRemove`/`chAmend`) and migrates VS to read/write
+it (the (i) prefix-read model).
+
+---
+
+## Provenance  (app src @ `504f8c8`, 2026-04-26)
+
+| Spec element | Kind | Source `file:line (fn)` | App construct | Note |
+|---|---|---|---|---|
+| `CargoHold[entries]` | agent | `vocab.py` (all ops); `app_mysql.py:143 (get_connection)` | the `vocab_entries` table + its CRUD | **faithful** — the persisted collection, owned here. Single source of truth. |
+| `chRead` | port (out, self-loop) | `vocab.py:195 (list_vocab)` | `SELECT * FROM vocab_entries WHERE …` | **faithful** — emits the current collection; a self-loop (read never mutates). The READ a client pulls. (Filter/sort applied by the *reader*, VS, not in the store — kept minimal.) |
+| `chUpsert` | port (in) | `vocab.py:106 (capture_vocab_entry)` | `INSERT … ON DUPLICATE KEY UPDATE` | **faithful** — `addEntry` *is* this upsert (dedup on word + `times_seen` bump). Verified: `cargohold_test` §2. |
+| `chRemove` | port (in) | `vocab.py:301 (delete_vocab_entry)` | `DELETE … WHERE vocab_id=%s` | **faithful** — `deleteFrom`. Verified: `cargohold_test` §4. |
+| `chAmend` | port (in) | `vocab.py:343 (update_vocab_entry)` | `UPDATE … WHERE vocab_id=%s` | **simplified** — one port for field updates; carries `<|"id"->_, "fields"->_|>` → `updateEntry`. `update_vocab_notes` (`vocab.py:314`) and autofill enrichment fold in at the migration. Verified: `cargohold_test` §3. |
+
+### Functions used (already recovered; applied here now)
+`addEntry`, `deleteFrom`, `updateEntry` (`VocabStoreFunctions.wl`) — the collection
+transforms move to being applied *in CargoHold*, where the data lives.
+
+### Bug fixed in passing
+`deleteFrom[entries_List, id_]` → `deleteFrom[entries_List, id_Integer]`
+(`VocabStoreFunctions.wl`). Without the `_Integer` gate it fired while `id` was
+still a **free binder** (concrete entries, symbolic id): `DeleteCases` matched
+nothing and collapsed to the unchanged list *before* the supplied value landed —
+a **silent no-op delete**, latent in `VS.delete`, surfaced by `CargoHold.chRemove`
+(which asserts the post-delete effect). Same held-until-concrete discipline as
+`addEntry[w:(_String|_Association)]` / `updateEntry[fields_Association]`.
+
+---
+
+## Deferred (this round)
+- `chImport` (bulk `importInto`) — bulk upsert.
+- autofill's enrichment in the store (needs the oracle + borrowed language).
+- Stats / history tables (`get_user_stats`, session/attempt reads) — CargoHold (or
+  a sibling store agent) gains read ports for these when those views are recovered.

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -49,7 +49,7 @@ $minEngineSha = "5bcc031";
 
 mioGet::usage = "mioGet[\"file.wl\"] Gets a spec file by name, relative to $specDir (this spec directory, derived from paths.wl's own location).";
 loadEngine::usage = "loadEngine[] Gets the RCA engine ($rca = $RCA_CORE env var, else the canonical checkout) AND asserts (git merge-base --is-ancestor) that the checkout contains $minEngineSha, aborting loudly on divergence. The shared coordinate between the spec and engine repos.";
-loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the three recovered agents (PracticeSessionRecovered.wl, VocabStoreRecovered.wl, HelmRecovered.wl) in order — the common base every spec consumer loads first (MioCore composes all three).";
+loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the recovered agents (PracticeSessionRecovered.wl, VocabStoreRecovered.wl, HelmRecovered.wl, CargoHoldRecovered.wl) in order — the common base every spec consumer loads first. MioCore composes PS/VS/Helm; CargoHold is defined here and composed at the (i) migration.";
 
 mioGet[file_String] := Get[$specDir <> file];
 
@@ -79,4 +79,6 @@ loadRecoveredBase[] := (
   mioGet["discipline.wl"];
   mioGet["PracticeSessionRecovered.wl"];
   mioGet["VocabStoreRecovered.wl"];
-  mioGet["HelmRecovered.wl"]);   (* third recovered agent; MioCore composes it *)
+  mioGet["HelmRecovered.wl"];    (* third recovered agent; MioCore composes it *)
+  mioGet["CargoHoldRecovered.wl"]);   (* the external store; defined here, composed
+                                         into MioCore at the (i) migration (PR-2) *)

--- a/spec/tests/cargohold_test.wls
+++ b/spec/tests/cargohold_test.wls
@@ -1,0 +1,69 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/cargohold_test.wls
+   ---------------------------------------------------------------------
+   CargoHold (the external store) — STANDALONE (PR-1: defined, not yet
+   composed into mioCore). Drives the agent call-based (transNamed) and
+   checks the read self-loop and the three write ops against the recovered
+   collection transforms:
+     chRead    emits the current collection (and leaves CargoHold unchanged)
+     chUpsert  capture/dedup (addEntry — INSERT … ON DUPLICATE KEY UPDATE)
+     chRemove  delete by id (deleteFrom)
+     chAmend   update fields by id (updateEntry)
+
+   Run headless:  wolframscript -file spec/tests/cargohold_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];   (* loads CargoHoldRecovered via loadRecoveredBase *)
+Get[$dir <> "walk.wl"];           (* readyTransitions / supplyValue / walkSteps / vis *)
+
+ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+hr = StringRepeat["=", 70];
+
+(* CargoHold is call-based → step with transNamed *)
+held[entries_] := Last[walkSteps[transNamed, call["CargoHold", entries], {}]["states"]];  (* identity, sanity *)
+(* read the collection a CargoHold state would emit on chRead *)
+chReadOf[s_] := Module[{t = SelectFirst[readyTransitions[transNamed, s],
+     portName[First[#]] === "chRead" &]},
+  First[Cases[First[t], param[p_] :> p, Infinity], None]];
+ports[s_] := Sort[ToString /@ portName /@ First /@ readyTransitions[transNamed, s]];
+
+Print[hr]; Print["1. ports — read self-loop + three writes"]; Print[hr];
+s0 = call["CargoHold", {}];
+assert["empty store offers chRead, chUpsert, chRemove, chAmend",
+  ports[s0] === {"chAmend", "chRead", "chRemove", "chUpsert"}];
+assert["chRead on empty emits {}", chReadOf[s0] === {}];
+
+Print[hr]; Print["2. chUpsert — capture + dedup (addEntry)"]; Print[hr];
+s1 = Last[walkSteps[transNamed, s0, {vis["chUpsert", <|"word" -> "chat", "translation" -> "cat"|>]}]["states"]];
+r1 = chReadOf[s1];
+assert["after one upsert: 1 entry", Length[r1] === 1];
+assert["the entry's word is chat", r1[[1]]["word"] === "chat"];
+assert["times_seen starts at 1", r1[[1]]["times_seen"] === 1];
+(* upsert the SAME word again — dedup bumps, does not duplicate *)
+s2 = Last[walkSteps[transNamed, s1, {vis["chUpsert", <|"word" -> "chat"|>]}]["states"]];
+r2 = chReadOf[s2];
+assert["re-upsert same word: still 1 entry (dedup)", Length[r2] === 1];
+assert["times_seen bumped to 2", r2[[1]]["times_seen"] === 2];
+
+Print[hr]; Print["3. chAmend — update fields by id (updateEntry)"]; Print[hr];
+id1 = r2[[1]]["id"];
+s3 = Last[walkSteps[transNamed, s2,
+   {vis["chAmend", <|"id" -> id1, "fields" -> <|"translation" -> "feline"|>|>]}]["states"]];
+assert["amend updates the field", chReadOf[s3][[1]]["translation"] === "feline"];
+
+Print[hr]; Print["4. chRemove — delete by id (deleteFrom)"]; Print[hr];
+s4 = Last[walkSteps[transNamed, s3, {vis["chRemove", id1]}]["states"]];
+assert["after remove: empty store", chReadOf[s4] === {}];
+
+Print[hr]; Print["5. chRead is a self-loop — leaves the store unchanged"]; Print[hr];
+s5 = Last[walkSteps[transNamed, s1, {vis["chRead"]}]["states"]];
+assert["chRead does not change the collection", chReadOf[s5] === r1];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", ok[allOk]];
+Print[hr];
+If[!allOk, Exit[1]];


### PR DESCRIPTION
First of the stacked store-migration PRs. Defines **CargoHold (CH)** — the agent that **owns the persisted vocab collection** — recovered from the app's MySQL layer (`vocab.py` over `app_mysql.py`). Full suite **14/14** green.

## What's here
- **`CargoHoldRecovered.wl`** — `CargoHold[entries]` with ports mirroring the `vocab_entries` SQL surface: `chRead` (`SELECT`, a read self-loop), `chUpsert` (`INSERT…ON DUPLICATE KEY UPDATE` = `addEntry` dedup/bump), `chRemove` (`DELETE`), `chAmend` (`UPDATE` by id). Reuses the already-recovered transforms.
- **Loaded but not composed** — added to `loadRecoveredBase` (4th recovered agent), *not* yet in `mioCore`. Standalone ⇒ no dual state until VS reads it (PR-2).
- **`tests/cargohold_test.wls`** — drives it call-based; checks read / upsert / **dedup** / amend / remove and the read self-loop.
- **`docs/cargohold-recovery.md`** — provenance table (app src @ `504f8c8`).

## Bug fixed in passing
`deleteFrom[entries_List, id_]` → **`id_Integer`**. It fired on the *free* `id` binder (concrete entries, symbolic id) and collapsed to the unchanged list *before* the value arrived — a **silent no-op delete, latent in `VS.delete`** (plans only checked completion, not effect). `CargoHold.chRemove` asserts the effect, so it surfaced. Same held-until-concrete discipline as `addEntry`/`updateEntry`.

## Next (stacked)
**PR-2** branches off *this* branch: compose CargoHold into `mioCore` (restricted) + migrate VS to the (i) prefix-read model + the dropdown `ch-*` test plans. `walk.wl` untouched here (your local tweak is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)