### PR TITLE
spec/walk: land auto-τ + Delimiter on claude/spec (re-target of #165)

### DIFF
--- a/spec/discipline.wl
+++ b/spec/discipline.wl
@@ -294,13 +294,28 @@ walkResolve[tf_, s_, vis[nm_]] :=
 walkResolve[tf_, s_, tau[ch_]] :=
   SelectFirst[tf[s], MatchQ[First[#], tag[\[Tau], ch, ___]] &];
 
-walkSteps[tf_, s0_, plan_List] := Module[
-  {s = s0, acts = {}, states = {s0}, t, stuck = False},
+Options[walkSteps] = {"AutoTau" -> False};
+walkSteps[tf_, s0_, plan_List, OptionsPattern[]] := Module[
+  {s = s0, acts = {}, states = {s0}, t, stuck = False,
+   auto = TrueQ[OptionValue["AutoTau"]], settle},
+  (* "AutoTau" -> True : maximal-progress between steps — fire the UNIQUE enabled
+     internal tau repeatedly (stop on 0, or on >=2, which is a real choice left to
+     an explicit tau[ch] entry). Lets a plan list only EXTERNAL actions, and stays
+     robust as new internal syncs (langRead, chRead, …) are added — no plan edits.
+     Same strategy as autoTau (walk.wl); kept here so walkSteps is self-contained.
+     Default off, so explicit-tau plans + the tau-checking tests are unchanged. *)
+  settle[] := If[auto,
+    Module[{taus, g = 0},
+      While[g++ < 500 && Length[taus = Select[tf[s], isTauAct[First[#]] &]] === 1,
+        AppendTo[acts, First[First[taus]]]; s = Last[First[taus]]; AppendTo[states, s]]]];
+  settle[];                                  (* settle taus reachable from s0 *)
   Do[t = walkResolve[tf, s, p];
      If[MissingQ[t], stuck = True; Break[]];
      AppendTo[acts, First[t]];
      s = Last[t];
-     AppendTo[states, s], {p, plan}];
+     AppendTo[states, s];
+     settle[],                               (* settle taus after each external step *)
+     {p, plan}];
   <|"actions" -> acts, "states" -> states, "stuck" -> stuck|>];
 
 (* eventLog[walk] : the COMPACT event log — one eventOf per action taken. *)

--- a/spec/tests/walk_sequences_test.wls
+++ b/spec/tests/walk_sequences_test.wls
@@ -31,8 +31,11 @@ assert["loadEngine::usage is set (?loadEngine works)", StringQ[loadEngine::usage
 assert["walkUI::usage is set", StringQ[walkUI::usage]];
 
 Print[hr]; Print["every sequence completes on BOTH mioCore and mioCoreD"]; Print[hr];
-runs[tf_, s0_, plan_] := Module[{w = walkSteps[tf, s0, plan]},
-  !w["stuck"] && Length[w["actions"]] === Length[plan]];
+(* plans list only external actions; "AutoTau" -> True fires the internal syncs
+   between steps, so we check completion (not stuck) — the action count now
+   includes the auto-fired taus, so it exceeds Length[plan]. *)
+runs[tf_, s0_, plan_] := Module[{w = walkSteps[tf, s0, plan, "AutoTau" -> True]},
+  !w["stuck"] && Length[w["actions"]] >= Length[plan]];
 Do[Module[{plan = walkTests[k]},
    assert[StringPadRight[k, 16] <> " on mioCore (transVP)",   runs[transVP, mioCore, plan]];
    assert[StringPadRight[k, 16] <> " on mioCoreD (transNamed)", runs[transNamed, mioCoreD, plan]]],
@@ -40,13 +43,13 @@ Do[Module[{plan = walkTests[k]},
 
 Print[hr]; Print["syncs actually move data across components"]; Print[hr];
 (* sync-vadd: a captured word ends up in the VS entries via vAdd *)
-vsEntriesAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan]["states"]], vp},
+vsEntriesAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan, "AutoTau" -> True]["states"]], vp},
   vp = Map[Identity, viewProjections[transVP, s]];
   If[KeyExistsQ[vp, "vSView"], #["word"] & /@ vp["vSView"]["entries"], $Failed]];
 assert["sync-vadd: captured \"chat\" reaches VS entries",
   MemberQ[vsEntriesAfter[walkTests["sync-vadd"]], "chat"]];
 (* sync-pload: the practise relay loads PS (pSView total > 0) *)
-psTotalAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan]["states"]], vp},
+psTotalAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan, "AutoTau" -> True]["states"]], vp},
   vp = Map[Identity, viewProjections[transVP, s]];
   If[KeyExistsQ[vp, "pSView"], vp["pSView"]["total"], $Failed]];
 assert["sync-pload: practise relay loads the PS queue (total > 0)",

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -4,16 +4,20 @@
    spec/walk-tests.wl — a batch of value-carrying test SEQUENCES (plans)
    that drive the spec through walk WITHOUT any typing into input fields.
    ---------------------------------------------------------------------
-   A test is a PLAN: a list of plan-entries
+   A test is a PLAN: a list of plan-entries. These plans list ONLY EXTERNAL
+   actions:
      vis["port"]          take a visible action by port name (no value)
      vis["port", value]   take a value-carrying input port, supplying value
-     tau["chan"]          take an internal sync on a named channel
-   (the vocabulary of walkResolve / walkSteps, discipline.wl + walk.wl).
+   The internal syncs (vAdd / pLoad / langRead, and chRead once CargoHold is
+   composed) are fired AUTOMATICALLY between steps by walkSteps' maximal-progress
+   mode ("AutoTau" -> True) — so plans stay readable and robust as new internal
+   syncs are added (no plan edits). (A plan MAY still force a specific sync with
+   tau["chan"] when a step is genuinely ambiguous; none need to here.)
 
-   Run a plan with the existing machinery:
-     walkSteps[transVP,   mioCore,  walkTests["full-roundtrip"]]   (* mu-term  *)
-     walkSteps[transNamed, mioCoreD, walkTests["full-roundtrip"]]  (* call form *)
-   or load one into the GUI from walkUI's "Run test" menu.
+   Run a plan with maximal progress (the GUI "Run test" and walk_sequences_test
+   do this):
+     walkSteps[transVP,   mioCore,  walkTests["full-roundtrip"], "AutoTau" -> True]
+     walkSteps[transNamed, mioCoreD, walkTests["full-roundtrip"], "AutoTau" -> True]
 
    EVERY sequence runs to completion on BOTH mioCore (transVP) and mioCoreD
    (transNamed) — that is the standing invariant (see
@@ -68,8 +72,7 @@ walkTests = <|
     vis["begin_edit", 1],
     vis["cancel_edit"],
     vis["update_notes", <|"id" -> 1, "notes" -> "seen in a book"|>],
-    vis["autofill", 1],
-    tau["langRead"],                                (* autofill PULLS the language *)
+    vis["autofill", 1],                             (* langRead auto-fires (pull language) *)
     vis["delete", 1]},
 
   (* --- PracticeSession: load + navigate ------------------------------- *)
@@ -89,18 +92,15 @@ walkTests = <|
     vis["recording_made", "audio-A"],
     vis["clear_recording"],
     vis["recording_made", "audio-B"],
-    vis["attempt_made"],
-    tau["langRead"],                                (* scoring PULLS the target language *)
-    vis["capture_vocab", "souris"],
-    tau["vAdd"]},                                   (* capture relays to VS *)
+    vis["attempt_made"],                            (* langRead auto-fires for scoring *)
+    vis["capture_vocab", "souris"]},                (* vAdd auto-fires (relay to VS) *)
 
   (* --- sync: VS practise_vocab (FILTERED) -> PS load (pLoad) ----------
      a filter is set, so practise_vocab sends the filtered subset. *)
   "sync-pload" -> {
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["set_filter", "ch"],
-    vis["practise_vocab"],
-    tau["pLoad"],
+    vis["practise_vocab"],                          (* pLoad auto-fires *)
     vis["select_item", 0]},
 
   (* --- sync: VS practise_vocab (ALL, no filter) -> PS load (pLoad) ----
@@ -109,8 +109,7 @@ walkTests = <|
   "practise-all" -> {
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["add", <|"word" -> "chien", "translation" -> "dog"|>],
-    vis["practise_vocab"],
-    tau["pLoad"],
+    vis["practise_vocab"],                          (* pLoad auto-fires *)
     vis["select_item", 1]},
 
   (* --- sync: VS autofill PULLS the language from Helm (langRead) ------
@@ -119,17 +118,14 @@ walkTests = <|
      Only meaningful in the COMPOSED system (Helm must be present to answer). *)
   "sync-langread" -> {
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
-    vis["autofill", 1],
-    tau["langRead"]},
+    vis["autofill", 1]},                            (* langRead auto-fires *)
 
   (* --- sync: PS capture_vocab -> VS add (vAdd) ----------------------- *)
   "sync-vadd" -> {
     vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
     vis["recording_made", "audio"],
-    vis["attempt_made"],
-    tau["langRead"],                                (* scoring PULLS the target language *)
-    vis["capture_vocab", "chat"],
-    tau["vAdd"]},
+    vis["attempt_made"],                            (* langRead auto-fires for scoring *)
+    vis["capture_vocab", "chat"]},                  (* vAdd auto-fires (relay to VS) *)
 
   (* --- Helm: settings tour + the espeak-only set_speed guard ---------- *)
   "helm-settings" -> {
@@ -151,12 +147,9 @@ walkTests = <|
   "full-roundtrip" -> {
     vis["set_filter", "ch"],
     vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
-    vis["practise_vocab"],
-    tau["pLoad"],
+    vis["practise_vocab"],                          (* pLoad auto-fires *)
     vis["recording_made", "audio"],
-    vis["attempt_made"],
-    tau["langRead"],                                (* scoring PULLS the target language *)
-    vis["capture_vocab", "souris"],
-    tau["vAdd"]}
+    vis["attempt_made"],                            (* langRead auto-fires for scoring *)
+    vis["capture_vocab", "souris"]}                 (* vAdd auto-fires (relay to VS) *)
 
 |>;

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -518,10 +518,19 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
              to its condensed event log and the state to the final state (hist
              keeps the intermediate states so Back walks through it). *)
           Row[{Style["Test: ", Bold, GrayLevel[0.4]], Spacer[4],
-               PopupMenu[Dynamic[testSel], Keys[If[ValueQ[walkTests], walkTests, <||>]]],
+               (* group the dropdown by prefix (vs- / ps- / sync- / helm- / …)
+                  with a horizontal Delimiter between groups, so it's clear which
+                  tests belong where *)
+               PopupMenu[Dynamic[testSel],
+                 Flatten[Riffle[
+                   SplitBy[Keys[If[ValueQ[walkTests], walkTests, <||>]],
+                           First[StringSplit[#, "-"], #] &],
+                   Delimiter]]],
                Spacer[4],
                Button["Run test \[FilledRightTriangle]",
-                 Module[{w = walkSteps[tf, agent, walkTests[testSel]]},
+                 (* "AutoTau" -> True : the plans list only external actions, so
+                    fire the internal syncs (vAdd/pLoad/langRead/chRead) for us *)
+                 Module[{w = walkSteps[tf, agent, walkTests[testSel], "AutoTau" -> True]},
                    hist = Most[w["states"]]; trace = eventLog[w];
                    cur = Last[w["states"]]; future = {}; inVals = <||>],
                  Enabled -> Dynamic[ValueQ[walkTests] && KeyExistsQ[walkTests, testSel]]]}],


### PR DESCRIPTION
#165 merged into the stacked branch (`claude/cargohold-standalone`) rather than `claude/spec`, so its content (auto-τ in `walkSteps` + the Delimiter-grouped Test dropdown, PR-2a) didn't reach `claude/spec`. This brings exactly that delta across — `discipline.wl`, `walk-tests.wl`, `walk_sequences_test.wls`, `walk.wl` (the last on top of your `9504e69` version tweak). Already reviewed as #165; suite was 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)