### PR TITLE
spec (b2): full external-store migration — CargoHold owns vocab; VS & PS both read it

### DIFF
--- a/spec/CargoHoldRecovered.wl
+++ b/spec/CargoHoldRecovered.wl
@@ -26,8 +26,9 @@
    PORTS (mirror the vocab.py SQL surface; see cargohold-recovery.md):
      chRead!    always — emits the current collection (a self-loop, never
                 changing CargoHold). The READ a client pulls. ≈ list_vocab SELECT.
-     chUpsert   capture/import a word — INSERT … ON DUPLICATE KEY UPDATE
+     chUpsert   capture a word — INSERT … ON DUPLICATE KEY UPDATE
                 (dedup/bump): the recovered addEntry IS this upsert.
+     chImport   bulk capture — importInto (parse + fold upserts).
      chRemove   delete by id — DELETE.
      chAmend    update fields by id — UPDATE. Carries <|"id"->_, "fields"->_|>.
 
@@ -50,9 +51,17 @@ defineAgent["CargoHold", {entries},
     precede[label["chRead", param[entries]],
       call["CargoHold", entries]],
     (* @src vocab.py:106 (capture_vocab_entry) — INSERT … ON DUPLICATE KEY UPDATE.
-       addEntry is the recovered upsert (dedup + times_seen bump). *)
+       addEntry is the recovered upsert (dedup + times_seen bump). Two writers feed
+       it: chUpsert from the VS tab (type/paste), and vAdd from PS capture (capture
+       from practice writes the store DIRECTLY, not through the tab). *)
     precede[coLabel["chUpsert", binding[w]],
       call["CargoHold", addEntry[entries, w]]],
+    (* @src vocabulary_tab.py:7 — PS.capture_vocab relays here (a direct DB write) *)
+    precede[coLabel["vAdd", binding[w]],
+      call["CargoHold", addEntry[entries, w]]],
+    (* @src vocab.py:453 (import_from_file_contents) — bulk capture *)
+    precede[coLabel["chImport", binding[f]],
+      call["CargoHold", importInto[entries, f]]],
     (* @src vocab.py:301 (delete_vocab_entry) — DELETE … WHERE vocab_id=%s *)
     precede[coLabel["chRemove", binding[id]],
       call["CargoHold", deleteFrom[entries, id]]],

--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -59,11 +59,15 @@
    ready transitions per providing agent. One source of truth for "who the
    components are" — see walk.wl componentPortMap. *)
 mioComponents =
-  {"PS"   -> call["PS", {}, 0, none, none],
-   "VS"   -> call["VS", signedIn, {}, alpha, none, none],
-   "Helm" -> call["Helm", "English", "fr", google, 250]};
+  {"PS"        -> call["PS", {}, 0, none, none],
+   "VS"        -> call["VS", signedIn, alpha, none, none],   (* (i): NO entries — they live in CargoHold *)
+   "Helm"      -> call["Helm", "English", "fr", google, 250],
+   "CargoHold" -> call["CargoHold", {}]};                    (* the persisted collection, owned here *)
 
-mioRestricted = {label["vAdd"], label["pLoad"], label["langRead"]};
+mioRestricted = {label["vAdd"], label["pLoad"], label["langRead"],
+                 (* the external-store channels: VS reads/writes CargoHold internally *)
+                 label["chRead"], label["chUpsert"], label["chImport"],
+                 label["chRemove"], label["chAmend"]};
 
 mioCore = merge[mioComponents, mioRestricted];
 

--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -23,8 +23,14 @@
    capitalised PSView/VSView.
 
    Cross-component links (each a complementary output/input pair, restricted):
-     vAdd  : PS.capture_vocab(word)  --vAdd!(word)-->   VS adds the word
-     pLoad : VS.practise_vocab       --pLoad!(phrases)--> PS loads them
+     vAdd       : PS.capture_vocab(word)  --vAdd!(word)-->      CargoHold adds it
+     goPractice : VS.practise_vocab       --goPractice!(filter)--> PS (then PS PULLS)
+     chRead     : CargoHold.chRead!       --chRead!(es)-->       VS or PS reads it
+
+   Note the practise hand-off is now a SIGNAL, not a data push: goPractice carries
+   only the filter; PS then pulls the collection itself via chRead (a second τ). So
+   a practise relay shows as goPractice·chRead, not a single pLoad — no snapshot
+   crosses the boundary (single source of truth).
 
    Helm is composed in as a PURE PARALLEL agent (2026-06-01): NO control guard
    in PS/VS reads the language, so there is no new restricted channel — Helm
@@ -40,10 +46,10 @@
    google TTS, 250 wpm.
 
    VERIFIED on the engine (2026-06-01): transVP[mioCore] external ready set is
-   {add, helmView, import_bulk, load_material, pSView, set_filter, set_source,
-   set_sort, set_target, set_tts, vSView} — three view ports, no bare `view`
-   clash; vAdd/pLoad restricted (internal tau). (set_speed appears once tts is
-   set to espeak.)
+   {add, helmView, import_bulk, load_material, open_practice, pSView, set_filter,
+   set_source, set_sort, set_target, set_tts, vSView} — three view ports, no bare
+   `view` clash; vAdd/goPractice/chRead restricted (internal tau). open_practice is
+   the visible PS pull entry. (set_speed appears once tts is set to espeak.)
 
    BORROWED-DATA wiring (2026-06-01): langRead is also restricted, so Helm's
    internal read port pairs with VS.autofill's langRead?(lp) prefix as an
@@ -64,8 +70,8 @@ mioComponents =
    "Helm"      -> call["Helm", "English", "fr", google, 250],
    "CargoHold" -> call["CargoHold", {}]};                    (* the persisted collection, owned here *)
 
-mioRestricted = {label["vAdd"], label["pLoad"], label["langRead"],
-                 (* the external-store channels: VS reads/writes CargoHold internally *)
+mioRestricted = {label["vAdd"], label["goPractice"], label["langRead"],
+                 (* the external-store channels: VS and PS read/write CargoHold internally *)
                  label["chRead"], label["chUpsert"], label["chImport"],
                  label["chRemove"], label["chAmend"]};
 

--- a/spec/PracticeSessionFunctions.wl
+++ b/spec/PracticeSessionFunctions.wl
@@ -13,7 +13,7 @@
 
    STATE (from PracticeSessionRecovered.wl):
      phrases : queue, each a phrase Association <|"text","translation","ipa"|>
-               (this is exactly practiseList's output — VS feeds PS via pLoad)
+               (this is exactly practiseList's output — PS pulls it from CargoHold)
      pos     : 0-based index      rec : none | recorded[audio]
      res     : none | scored[r]   (r is the evaluate result)
    ===================================================================== *)

--- a/spec/PracticeSessionRecovered.wl
+++ b/spec/PracticeSessionRecovered.wl
@@ -23,7 +23,7 @@
      rec : none | recorded[audio]  res : none | scored[r]
 
    READY SETS (analysis; readyPorts, not declared):
-     PS[{},      _,_,_]            : view, load_material, pLoad
+     PS[{},      _,_,_]            : view, load_material, open_practice, goPractice
      PS[ne,p,none,    none]        : + clear_material, select_item,
                                        recording_made, next†, prev‡
      PS[ne,p,recorded,none]        : + attempt_made, clear_recording
@@ -34,18 +34,53 @@
    ===================================================================== *)
 
 
-(* --- top: always-on view/load/pLoad; domain ports only when non-empty
-   (shared-port split → one-armed if, no duplication) --- *)
+(* --- top: always-on view/load + the two CargoHold-pull entries; domain ports
+   only when non-empty (shared-port split → one-armed if, no duplication).
+
+   PS reads the store ITSELF now (no pushed snapshot). Two entries reach it:
+     • open_practice  — the VISIBLE quick-practice entry (a parameter-less input,
+       the user opening the practice-from-vocab picker), then chRead the store and
+       choose load_vocab / load_filtered (PSBrowse).
+     • goPractice     — the vocab-tab "Practise these" SIGNAL from VS, carrying the
+       FILTER only (not the entries); PS pulls the collection fresh and shapes it.
+   Both keep their VISIBLE input first (open_practice / goPractice), so the chRead
+   is the SECOND action — PS stays visibly-guarded (no initial τ), weak bisim a
+   congruence. chRead/goPractice are restricted → τ in mioCore. --- *)
 defineAgent["PS", {phrases, pos, rec, res},
   choice[
     precede[label["view", param[sessionView[phrases, pos, rec, res]]],
       call["PS", phrases, pos, rec, res]],
     precede[coLabel["load_material", binding[ps]],
       call["PS", ps, 0, none, none]],
-    precede[coLabel["pLoad", binding[ps]],
-      call["PS", ps, 0, none, none]],
+    (* PULL (quick_practice "Load vocabulary"/"Load filtered", quick_practice_tab.py):
+       visible open_practice → read CargoHold → PSBrowse picks what to load. *)
+    precede[coLabel["open_practice"],
+      precede[coLabel["chRead", binding[es]],
+        call["PSBrowse", es]]],
+    (* SIGNAL (vocab-tab "Practise these"): VS sends goPractice!(filter) — the
+       filter only. PS pulls the collection FRESH (chRead) and shapes it with that
+       filter. No cached snapshot crosses the boundary — single source of truth
+       (ARCHITECTURE.md "Borrowed vs owned data"). *)
+    precede[coLabel["goPractice", binding[filter]],
+      precede[coLabel["chRead", binding[es]],
+        call["PS", practiseList[es, filter], 0, none, none]]],
     if[Length[phrases] > 0,
       call["PSActive", phrases, pos, rec, res]]]]
+
+
+(* --- after open_practice + chRead: choose what to load from the store.
+   load_vocab = the whole collection; load_filtered(q) = the subset. Both shape
+   via practiseList (vocab.py:644) into the practice phrase queue. The es read here
+   is FRESH (pull-on-use); the loaded queue is a deliberate session snapshot the
+   user then practices through (next/prev/record/score). --- *)
+defineAgent["PSBrowse", {es},
+  choice[
+    (* @src quick_practice_tab.py:178 ("Load vocabulary (N)") *)
+    precede[coLabel["load_vocab"],
+      call["PS", practiseList[es, none], 0, none, none]],
+    (* @src quick_practice_tab.py:184 ("Load filtered (N)") *)
+    precede[coLabel["load_filtered", binding[q]],
+      call["PS", practiseList[es, filterBy[q]], 0, none, none]]]]
 
 
 (* --- domain ports for a non-empty queue --- *)

--- a/spec/VocabStoreFunctions.wl
+++ b/spec/VocabStoreFunctions.wl
@@ -184,6 +184,26 @@ autofillIn[entries_List, id_, lang_List] := Module[{pos, row, fill},
       n]], entries, pos]];
 
 
+(* --- autofillFields[entries, id, lang] : the WRITE side of autofill under the
+   external-store (i) form. autofillIn (above) does find-row + enrich + merge in
+   one go over a held collection; but with CargoHold owning the data, VS computes
+   ONLY the fill fields here (the same only-empty / never-overwrite logic) and
+   writes them via chAmend (which CargoHold applies with updateEntry). Returns the
+   Association of fields to set (possibly empty → a no-op amend). id_Integer gates
+   it held until the concrete id lands (cf. deleteFrom). *)
+autofillFields[entries_List, id_Integer, lang_List] := Module[{row, fill, out = <||>},
+  row = SelectFirst[entries, #["id"] === id &, <||>];
+  fill = enrichOracle[row["display_word"], First[lang], Last[lang]];
+  If[!AssociationQ[fill], Return[<||>]];
+  If[(Lookup[row, "translation", Null] === Null || row["translation"] === "") &&
+     emptyToNull[Lookup[fill, "translation", Null]] =!= Null,
+    out["translation"] = fill["translation"]];
+  If[(Lookup[row, "ipa", Null] === Null || row["ipa"] === "") &&
+     emptyToNull[Lookup[fill, "ipa", Null]] =!= Null,
+    out["ipa"] = fill["ipa"]];
+  out];
+
+
 (* --- import: _parse_import_line / parse_import_header / import_from_file_contents
    (vocab.py:453, 486, 545). f = <|"contents"->_String, "expectedTarget"->_|>.
    Pipe-delimited `word|translation|ipa|source|url`; IPA may be []-wrapped.

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -23,8 +23,8 @@
    WHAT VS READS FROM CARGOHOLD, AND WHY  (one chRead per cycle feeds all):
      read es (chRead!) ──┬─ ready-set guard   Length[es]==0  → which ports are afforded
                          ├─ view! projection  vocabView[…, es, …]   (≈ list_vocab)
-                         ├─ practise payload  practiseList[es, filter]  (→ PS via pLoad)
                          └─ export            exportCsv[es]
+     (practise_vocab no longer reads es: it signals PS the filter and PS pulls.)
      Reads are FRESH each cycle (a prefix chRead, restricted → internal τ in
      mioCore); there is NO cached copy, hence no staleness. In the app every
      Streamlit rerun re-runs list_vocab — a query — so view! is query-backed.
@@ -41,7 +41,7 @@
      update / update_notes / autofill → chAmend!(<|id, fields|>)   UPDATE
    set_sort / set_filter / begin_edit / cancel_edit change VS's OWN params only.
 
-   Cross-component: practise_vocab → PracticeSession.load_material (via pLoad);
+   Cross-component: practise_vocab → goPractice!(filter) → PS pulls from CargoHold;
    PracticeSession.capture_vocab → vAdd → CargoHold DIRECTLY (capture from practice
    writes to the store, NOT through this tab — the app's capture_vocab_entry is a
    direct DB write, vocabulary_tab.py:7 / vocab.py:106).
@@ -110,17 +110,23 @@ defineAgent["VSAuthed", {es, sort, filter, editing},
 
 
 (* --- non-empty: export + practise_vocab always; edit-mode refines per-entry.
-   practise_vocab sends the CURRENT view (practiseList[es,filter]) to PS via pLoad
-   — all vocab when filter===none, the filtered subset otherwise. *)
+   practise_vocab is the vocab-tab "Practise these" cross-tab nav. It no longer
+   PUSHES the data: it signals PS with goPractice!(filter) — the FILTER only — and
+   PS pulls the collection FRESH from CargoHold itself. So no snapshot crosses the
+   boundary (single source of truth); VS need not even read es to hand off. *)
 defineAgent["VSNonEmpty", {es, sort, filter, editing},
   choice[
     (* @src vocabulary_tab.py:69 (Export CSV) *)
     precede[label["export", param[exportCsv[es]]],
       call["VSRead", sort, filter, editing]],
-    (* @src quick_practice_tab.py:184 / vocabulary_tab.py:556 — to PracticeSession *)
+    (* @src vocabulary_tab.py:556 ("🎯 Practise these") — SIGNAL to PracticeSession;
+       carries the filter, not the entries (PS pulls them). This NAVIGATES AWAY from
+       the vocab tab, so VS returns to its un-opened entry (open_vocab), NOT VSRead —
+       it does not re-read. That also leaves PS's pull as the unique enabled τ, so
+       the hand-off settles deterministically (no competing VS re-read). *)
     precede[coLabel["practise_vocab"],
-      precede[label["pLoad", param[practiseList[es, filter]]],
-        call["VSRead", sort, filter, editing]]],
+      precede[label["goPractice", param[filter]],
+        call["VS", signedIn, sort, filter, editing]]],
     if[editing === none,
       call["VSEntryActions", es, sort, filter],
       call["VSEditActions", es, sort, filter, editing]]]]

--- a/spec/VocabStoreRecovered.wl
+++ b/spec/VocabStoreRecovered.wl
@@ -1,162 +1,162 @@
 (* ::Package:: *)
 
 (* =====================================================================
-   miolingo / L1 \[LongDash] VocabStore, RECOVERED (UI-first, stubbed)
+   miolingo / L1 — VocabStore, RECOVERED — (i) external-store form
    ---------------------------------------------------------------------
-   Per SPEC-RECOVERY.md. Recovered from the Streamlit source
-   (src/ui/vocabulary_tab.py + the vocab.py CRUD it calls), NOT invented.
-   See spec/docs/vocabstore-recovery.md for the \[Section]3 analysis.
+   Recovered from src/ui/vocabulary_tab.py + the vocab.py CRUD it calls.
+   See spec/docs/vocabstore-recovery.md for the §3 analysis and the
+   provenance table.
 
-   SPEC STYLE: guard-partitioned normal form.
-     - No `afforded` channel; readiness is derived from guards + structure.
-     - No degenerate conditionals: no if[c,P,nil] / if[c,nil,Q] in the
-       written form. Guards are hoisted outermost; every branch is a real
-       process expression.
+   (i) MIGRATION (2026-06-02): the persisted collection is OWNED by
+   CargoHold (the external store), NOT by VocabStore. VS holds only its UI
+   parameters and READS the collection fresh at the point of use, and WRITES
+   through CargoHold. Single source of truth (ARCHITECTURE.md "Borrowed vs
+   owned data"; the Stats-History † note). This is the "own it → store it;
+   borrow it → fetch fresh" rule applied to persistence.
 
-   Supersedes the invented strawman VocabStore.wl (kept for the
-   invented-vs-recovered contrast, H1/H3). The strawman's core claim \[LongDash]
-   per-entry ops gated on non-empty \[LongDash] is CONFIRMED; the recovery adds the
-   real guards it lacked: an AUTH gate over the whole component, a
-   search-non-empty guard on "Practise these", a missing-fields guard on
-   autofill (stubbed), and an inline EDIT-MODE that swaps a row's actions.
-
-   Cross-component: practise_vocab -> PracticeSession.load_material (via pLoad);
-   and PracticeSession.capture_vocab -> this agent's `add` (via vAdd). The two
-   are symmetric: practise_vocab sends the vocab view OUT to practice,
-   capture_vocab brings a practised word back IN. (bidirectional)
-
-   STUBBED: listVocab/addEntry/updateEntry/... are named, not defined.
-   Structural guards (auth, non-empty, filter present, edit-mode) are
-   concrete so the ready sets simulate.
-
-   LOAD ORDER: RCA_core.wl, then discipline.wl, then this file.
-
-   STATE: VS[auth, entries, sort, filter, editing]
+   STATE: VS[auth, sort, filter, editing]   — NO entries (they live in CargoHold)
      auth    : anon | signedIn
-     entries : the collection (list)
-     sort    : ordering value (alpha | recent | oldest)
-     filter  : none | filterBy[q]
-     editing : none | editingRow[id]   (which row is in inline edit-mode)
+     sort    : ordering value (alpha | recent | oldest)   — a VS-owned UI param
+     filter  : none | filterBy[q]                         — a VS-owned UI param
+     editing : none | editingRow[id]                      — a VS-owned UI param
 
-   RECOVERED READY SETS (analysis only; derived from the guards below,
-   not explicit channels in the process):
-     VS[anon,      _, _,_,_ ]          Anon     : (none)
-     VS[signedIn, {}, _,none,none]     Empty    : add, vAdd, import_bulk,
-                                                  set_sort, set_filter
-     VS[signedIn, ne, _,_,none]        NonEmpty : + export, practise_vocab,
-                                                  delete, update_notes,
-                                                  autofill, begin_edit
-                                                  (practise_vocab any filter;
-                                                  payload = practiseList[…,filter],
-                                                  all when filter===none)
-     VS[signedIn, ne, _,_,editingRow[id]] Editing  : export, practise_vocab,
-                                                  per-row update, cancel_edit
-                                                  (no delete/begin_edit)
+   WHAT VS READS FROM CARGOHOLD, AND WHY  (one chRead per cycle feeds all):
+     read es (chRead!) ──┬─ ready-set guard   Length[es]==0  → which ports are afforded
+                         ├─ view! projection  vocabView[…, es, …]   (≈ list_vocab)
+                         ├─ practise payload  practiseList[es, filter]  (→ PS via pLoad)
+                         └─ export            exportCsv[es]
+     Reads are FRESH each cycle (a prefix chRead, restricted → internal τ in
+     mioCore); there is NO cached copy, hence no staleness. In the app every
+     Streamlit rerun re-runs list_vocab — a query — so view! is query-backed.
 
-   NOTE: refactored to guard-partitioned normal form 2026-05-30.
-   RE-VERIFY on the engine before commit: simulated ready sets per mode
-   must be identical to the pre-refactor file (this is a normal-form
-   rewrite, meaning-preserving, NOT a semantic change).
+   ENTRY: VS is the Vocabulary TAB. open_vocab (a VISIBLE, parameter-less input —
+   the user selecting the tab) is the entry; it initiates the chRead. Keeping the
+   first action visible (not the chRead τ) keeps VS visibly-guarded so weak
+   bisimilarity stays a congruence under composition.
+
+   WHAT VS WRITES TO CARGOHOLD  (VS never mutates a local copy):
+     add         → chUpsert!(w)      type/paste a word (INSERT … ON DUPLICATE KEY)
+     import_bulk → chImport!(f)      bulk capture
+     delete      → chRemove!(id)     DELETE
+     update / update_notes / autofill → chAmend!(<|id, fields|>)   UPDATE
+   set_sort / set_filter / begin_edit / cancel_edit change VS's OWN params only.
+
+   Cross-component: practise_vocab → PracticeSession.load_material (via pLoad);
+   PracticeSession.capture_vocab → vAdd → CargoHold DIRECTLY (capture from practice
+   writes to the store, NOT through this tab — the app's capture_vocab_entry is a
+   direct DB write, vocabulary_tab.py:7 / vocab.py:106).
+
+   LOAD ORDER: RCA_core.wl, discipline.wl, then this (CargoHold too); MioCore
+   composes VS with CargoHold. Functions resolve at step time.
    ===================================================================== *)
 
 
-(* --- top level: view + auth gate --- *)
-defineAgent["VS", {auth, entries, sort, filter, editing},
+(* --- top: the Vocabulary TAB. Signed-in offers a VISIBLE entry, open_vocab
+   (the user selecting the tab); taking it initiates the store read. Keeping the
+   FIRST action visible (not the chRead τ) makes VS visibly-guarded, so weak
+   bisimilarity stays a congruence under composition — no initial τ to break it.
+   Capture from practice does NOT pass through the tab: it writes to CargoHold
+   directly (PS.capture_vocab → vAdd → CargoHold). VS is purely the gated
+   viewer/editor of the store. *)
+defineAgent["VS", {auth, sort, filter, editing},
   if[auth === signedIn,
+    precede[coLabel["open_vocab"], call["VSRead", sort, filter, editing]],
+    precede[label["view", param[vocabView[anon, {}, sort, filter, editing]]],
+      call["VS", anon, sort, filter, editing]]]]
+
+(* --- in the tab: PULL the collection (chRead — AFTER the visible open_vocab),
+   then offer the view + the authed surface. Loops back HERE (re-read each cycle),
+   NOT to VS: open_vocab is the one-time entry, not a per-action gate.
+   @src vocab.py:195 (list_vocab) — read the collection from CargoHold *)
+defineAgent["VSRead", {sort, filter, editing},
+  precede[coLabel["chRead", binding[es]],
     choice[
-      precede[label["view", param[vocabView[auth, entries, sort, filter, editing]]],
-        call["VS", auth, entries, sort, filter, editing]],
-      call["VSAuthed", entries, sort, filter, editing]],
-    precede[label["view", param[vocabView[auth, entries, sort, filter, editing]]],
-      call["VS", auth, entries, sort, filter, editing]]]]
+      precede[label["view", param[vocabView[signedIn, es, sort, filter, editing]]],
+        call["VSRead", sort, filter, editing]],
+      call["VSAuthed", es, sort, filter, editing]]]]
 
 
-(* --- signed in: always-available CRUD-in, then non-empty refinement --- *)
-defineAgent["VSAuthed", {entries, sort, filter, editing},
-  if[Length[entries] == 0,
+(* --- in the tab, signed in: add (type a word) / import write to CargoHold;
+   sort/filter are VS-owned params; non-empty adds the rest. NB capture FROM
+   PRACTICE does NOT appear here — it goes PS → CargoHold directly (vAdd). *)
+defineAgent["VSAuthed", {es, sort, filter, editing},
+  if[Length[es] == 0,
+    choice[
+      (* @src vocabulary_tab.py (paste/word add); vocab.py:106 — write to store *)
+      precede[coLabel["add", binding[w]],
+        precede[label["chUpsert", param[w]], call["VSRead", sort, filter, editing]]],
+      choice[
+        (* @src vocab.py:453 (import_from_file_contents) — bulk capture *)
+        precede[coLabel["import_bulk", binding[f]],
+          precede[label["chImport", param[f]], call["VSRead", sort, filter, editing]]],
+        choice[
+          precede[coLabel["set_sort", binding[s]],
+            call["VSRead", s, filter, editing]],
+          precede[coLabel["set_filter", binding[q]],
+            call["VSRead", sort, filterBy[q], editing]]]]],
     choice[
       precede[coLabel["add", binding[w]],
-        call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
+        precede[label["chUpsert", param[w]], call["VSRead", sort, filter, editing]]],
       choice[
-        precede[coLabel["vAdd", binding[w]],
-          call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
+        precede[coLabel["import_bulk", binding[f]],
+          precede[label["chImport", param[f]], call["VSRead", sort, filter, editing]]],
         choice[
-          precede[coLabel["import_bulk", binding[f]],
-            call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
+          precede[coLabel["set_sort", binding[s]],
+            call["VSRead", s, filter, editing]],
           choice[
-            precede[coLabel["set_sort", binding[s]],
-              call["VS", signedIn, entries, s, filter, editing]],
             precede[coLabel["set_filter", binding[q]],
-              call["VS", signedIn, entries, sort, filterBy[q], editing]]]]]],
-    choice[
-      precede[coLabel["add", binding[w]],
-        call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
-      choice[
-        precede[coLabel["vAdd", binding[w]],
-          call["VS", signedIn, addEntry[entries, w], sort, filter, editing]],
-        choice[
-          precede[coLabel["import_bulk", binding[f]],
-            call["VS", signedIn, importInto[entries, f], sort, filter, editing]],
-          choice[
-            precede[coLabel["set_sort", binding[s]],
-              call["VS", signedIn, entries, s, filter, editing]],
-            choice[
-              precede[coLabel["set_filter", binding[q]],
-                call["VS", signedIn, entries, sort, filterBy[q], editing]],
-              call["VSNonEmpty", entries, sort, filter, editing]]]]]]]]
+              call["VSRead", sort, filterBy[q], editing]],
+            call["VSNonEmpty", es, sort, filter, editing]]]]]]]
 
 
-(* --- non-empty: export + practise_vocab always; edit-mode refines per-entry --
-   practise_vocab is the SINGLE vocab->practice channel (the app exposes it as
-   "Load vocabulary" / "Load filtered" / "Practise these" — unified here). It is
-   available whenever the store is non-empty, regardless of filter, and emits the
-   CURRENT vocab VIEW to PracticeSession via pLoad (restricted -> tau in mioCore):
-   practiseList[entries, filter] is ALL vocab when filter===none ("Load
-   vocabulary") and the filtered subset when filterBy[q] ("Load filtered"). The
-   filter no longer GATES the route (it only parametrises the payload); the
-   previous filter split collapses, leaving just the edit-mode split for per-entry
-   actions. *)
-defineAgent["VSNonEmpty", {entries, sort, filter, editing},
+(* --- non-empty: export + practise_vocab always; edit-mode refines per-entry.
+   practise_vocab sends the CURRENT view (practiseList[es,filter]) to PS via pLoad
+   — all vocab when filter===none, the filtered subset otherwise. *)
+defineAgent["VSNonEmpty", {es, sort, filter, editing},
   choice[
-    precede[label["export", param[exportCsv[entries]]],
-      call["VS", signedIn, entries, sort, filter, editing]],
+    (* @src vocabulary_tab.py:69 (Export CSV) *)
+    precede[label["export", param[exportCsv[es]]],
+      call["VSRead", sort, filter, editing]],
+    (* @src quick_practice_tab.py:184 / vocabulary_tab.py:556 — to PracticeSession *)
     precede[coLabel["practise_vocab"],
-      precede[label["pLoad", param[practiseList[entries, filter]]],
-        call["VS", signedIn, entries, sort, filter, editing]]],
+      precede[label["pLoad", param[practiseList[es, filter]]],
+        call["VSRead", sort, filter, editing]]],
     if[editing === none,
-      call["VSEntryActions", entries, sort, filter],
-      call["VSEditActions", entries, sort, filter, editing]]]]
+      call["VSEntryActions", es, sort, filter],
+      call["VSEditActions", es, sort, filter, editing]]]]
 
 
-(* --- per-entry actions when NOT editing --- *)
-defineAgent["VSEntryActions", {entries, sort, filter},
+(* --- per-entry actions when NOT editing — each WRITES to CargoHold --- *)
+defineAgent["VSEntryActions", {es, sort, filter},
   choice[
+    (* @src vocab.py:301 (delete_vocab_entry) *)
     precede[coLabel["delete", binding[id]],
-      call["VS", signedIn, deleteFrom[entries, id], sort, filter, none]],
+      precede[label["chRemove", param[id]], call["VSRead", sort, filter, none]]],
     choice[
+      (* @src vocab.py:314 (update_vocab_notes) *)
       precede[coLabel["update_notes", binding[idn]],
-        call["VS", signedIn, updateNotesIn[entries, idn], sort, filter, none]],
+        precede[label["chAmend", param[<|"id" -> idn["id"], "fields" -> <|"notes" -> idn["notes"]|>|>]],
+          call["VSRead", sort, filter, none]]],
       choice[
-        (* autofill \[LongDash] the missing-fields guard needsAutofill[entries,id] is
-           a STUBBED value predicate, deferred; modelled as available per
-           entry when non-empty.
-           BORROWED DATA: enrichment needs the (source, target) language pair,
-           which Helm OWNS. So autofill PULLS it fresh as a PREFIX \[LongDash] langRead?(lp)
-           sits on the critical path of the action, restricted to Helm's langRead!
-           in mioCore (an internal tau). No cached language => no staleness; the
-           value read is always Helm's current pair. See ARCHITECTURE.md
-           "Borrowed vs owned data". lp = {source, target}. *)
+        (* @src vocab.py:411 (autofill_vocab_entry) — read the language (langRead,
+           borrowed from Helm), compute the fill, write it via chAmend *)
         precede[coLabel["autofill", binding[id]],
           precede[coLabel["langRead", binding[lp]],
-            call["VS", signedIn, autofillIn[entries, id, lp], sort, filter, none]]],
+            precede[label["chAmend", param[<|"id" -> id, "fields" -> autofillFields[es, id, lp]|>]],
+              call["VSRead", sort, filter, none]]]],
         precede[coLabel["begin_edit", binding[id]],
-          call["VS", signedIn, entries, sort, filter, editingRow[id]]]]]]]
+          call["VSRead", sort, filter, editingRow[id]]]]]]]
 
 
-(* --- per-entry actions WHILE editing a row --- *)
-defineAgent["VSEditActions", {entries, sort, filter, editing},
+(* --- per-entry actions WHILE editing a row — update WRITES via chAmend --- *)
+defineAgent["VSEditActions", {es, sort, filter, editing},
   choice[
+    (* @src vocab.py:343 (update_vocab_entry) ; editing = editingRow[id].
+       Extract the id by PATTERN (editing /. editingRow[i_] :> i), not First[editing]:
+       First[editing] would evaluate on the bare `editing` symbol at load (an atom →
+       error). ReplaceAll leaves a non-editingRow value untouched (held). *)
     precede[coLabel["update", binding[fields]],
-      call["VS", signedIn, updateEntry[entries, editing, fields], sort, filter, none]],
+      precede[label["chAmend", param[<|"id" -> (editing /. editingRow[i_] :> i), "fields" -> fields|>]],
+        call["VSRead", sort, filter, none]]],
     precede[coLabel["cancel_edit"],
-      call["VS", signedIn, entries, sort, filter, none]]]]
+      call["VSRead", sort, filter, none]]]]

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -130,11 +130,11 @@ VS:    autofill?(id) · langRead?(s,t) · ⟨enrichOracle[word, s, t]⟩ · VS�
 PS:    attempt_made  · langRead?(_,t) · ⟨recognisePhonemes[audio, t]⟩ · …
 ```
 
-`langRead` is **restricted** in `mioCore` (an internal τ, like `vAdd`/`pLoad`).
+`langRead` is **restricted** in `mioCore` (an internal τ, like `vAdd`/`chRead`).
 The consumer cannot complete the enrich/score without first taking it, and what
 it reads is necessarily Helm's *current* value — there is no local copy to be
 stale. This is **forced by sequencing, not by priority**: it is the same idiom
-`vAdd`/`pLoad` already use (a sync that is the only way for the agent to make
+`vAdd`/`chRead` already use (a sync that is the only way for the agent to make
 progress). Helm remains the **sole owner**; oracles stay boundary functions
 (decision-A) but are now called *with* the language the read delivered.
 `espeakG2P[word, voice]` already has this shape (`voice` = the target read).
@@ -151,7 +151,23 @@ VocabStore is the **Vocabulary *tab*** — a *gated viewer/editor*: a VISIBLE en
 view/edit actions; writes route to CargoHold (`chUpsert`/`chImport`/`chRemove`/
 `chAmend`, all restricted → τ). Capture from practice writes the store **directly**
 (`PS.capture_vocab → vAdd → CargoHold`), not through the tab — matching the app
-(`capture_vocab_entry` is a direct DB write). Two design points this settled:
+(`capture_vocab_entry` is a direct DB write).
+
+**PS reads the store too — practise is a pull, not a push (2026-06-03).** PracticeSession
+no longer receives a *pushed snapshot*. It reads CargoHold itself, by two visibly-guarded
+entries that mirror `open_vocab`:
+- **Pull** — `open_practice` (the visible quick-practice entry) → `chRead` → `PSBrowse`
+  offers `load_vocab` (all) / `load_filtered(q)`, shaping the collection into the practice
+  queue (`quick_practice_tab.py`'s "Load vocabulary"/"Load filtered").
+- **Signal** — the vocab-tab "Practise these" (`VS.practise_vocab`) now emits
+  `goPractice!(filter)` — the **filter only, not the entries** — and PS pulls the
+  collection *fresh* (`chRead`) and shapes it. No snapshot crosses the boundary. VS, having
+  navigated away, returns to its un-opened `open_vocab` entry (it does **not** re-read), which
+  also leaves PS's pull as the unique enabled τ so the hand-off settles deterministically.
+This replaced the old `pLoad` data-push: borrowed data (the collection) is pulled-on-use,
+consistent with the rule below. The loaded queue PS then holds is a deliberate *session*
+snapshot the user practices through — not a cache of borrowed data. Two design points this
+settled:
 - **Visible-guarding for congruence.** A *prefix-read* (VS's first action a `chRead`
   τ) put an **initial τ** in the composition, and `≈` fails to be a congruence over
   `+` exactly because of initial τ. Guarding the tab behind the **visible**

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -144,6 +144,25 @@ Helm's `langRead!` restricted in `mioCore`:
 - **VS `autofill`** → `autofillIn[entries, id, lang]` → `enrichOracle[word, source, target]`;
 - **PS scoring** (`attempt_made`) → `evaluate[target, rec, lang]` → `recognisePhonemes[audio, targetCode]`.
 
+**External store (CargoHold) — the persistence counterpart, now modelled.** The
+vocab collection is owned by the **CargoHold** agent (the DB), not held in VS.
+VocabStore is the **Vocabulary *tab*** — a *gated viewer/editor*: a VISIBLE entry
+`open_vocab` (the user selecting the tab), then a `chRead` of the store, then the
+view/edit actions; writes route to CargoHold (`chUpsert`/`chImport`/`chRemove`/
+`chAmend`, all restricted → τ). Capture from practice writes the store **directly**
+(`PS.capture_vocab → vAdd → CargoHold`), not through the tab — matching the app
+(`capture_vocab_entry` is a direct DB write). Two design points this settled:
+- **Visible-guarding for congruence.** A *prefix-read* (VS's first action a `chRead`
+  τ) put an **initial τ** in the composition, and `≈` fails to be a congruence over
+  `+` exactly because of initial τ. Guarding the tab behind the **visible**
+  `open_vocab` (no initial τ) keeps the system *initially stable* / visibly-guarded,
+  so weak bisimilarity stays a congruence. (The `ModeSelector` idea was eliminated:
+  each mode carries its own visible entry; no relay agent needed.)
+- **Store vs tab.** Separating *the store* (CargoHold, always accepting writes) from
+  *the tab* (VS, gated) is both faithful and what makes capture mode-independent.
+  This is the persistence half of the `†` Stats/History note: when stats/history
+  are recovered they read/write a store the same way.
+
 **The one escape hatch.** Pull-on-use covers a *data* dependency (the value is
 needed when an action runs). It does **not** cover a *control* dependency over
 borrowed data — a guard whose ready set must change the instant Helm changes,

--- a/spec/docs/PROVENANCE.md
+++ b/spec/docs/PROVENANCE.md
@@ -85,3 +85,15 @@ The first extraction recorded in this format (the vocab→practice channel, PR #
 | `pLoad` | sync (VS→PS τ) | `quick_practice_tab.py:170,190`; `vocabulary_tab.py:559-570` | sets `st.session_state.phrase_list`, `qp_phrase_position = 0` | **faithful** — the cross-component hand-off; PS loads at position 0. Restricted in `mioCore`. Verified: `internal_transitions_test`, `composition_test`. |
 | `practiseList[entries, filter]` | value-fn | `vocab.py:644 (vocab_as_practice_phrases)` | maps rows → `{text, translation, ipa}` | **faithful** — `filter = none` ⇒ all (`filterMatch[_, none] = True`); `filterBy[q]` ⇒ subset. |
 | `capture_vocab` | port (in, PS) | `vocabulary_tab.py:7` (capture hook), `vocab.py:106 (capture_vocab_entry)` | Story Reader / Quick Practice capture | **faithful** — the reverse direction; relays to VS via `vAdd`. Symmetric with `practise_vocab`. |
+
+> **Superseded by the CargoHold migration (PR-2b/2c, 2026-06-03).** This table is the
+> #161 snapshot, kept as the worked example. Since then the external store
+> (CargoHold) was modelled, and the vocab↔practice wiring changed accordingly:
+> - `pLoad` (the VS→PS *data push*) is **gone**, replaced by **`goPractice`** — a VS→PS
+>   *signal* carrying the filter only; **PS pulls** the collection itself (`chRead`) and
+>   applies `practiseList`. The "Load vocabulary"/"Load filtered" buttons are now PS-side
+>   pull entries (`open_practice` → `PSBrowse`), not VS ports.
+> - `capture_vocab` relays via `vAdd` **directly to CargoHold**, not to VS.
+> - The verifying plan `sync-pload` was renamed `sync-practise` (+ `ps-pull-*` added).
+>
+> See `cargohold-recovery.md`, `practice-session-recovery.md`, and ARCHITECTURE.md.

--- a/spec/docs/cargohold-recovery.md
+++ b/spec/docs/cargohold-recovery.md
@@ -17,6 +17,15 @@ tab type/paste) and **`vAdd` (PS capture from practice, written DIRECTLY — not
 the tab)**. The first VS action is the *visible* `open_vocab`, not the `chRead` τ,
 so the composition stays visibly-guarded (≈ a congruence — ARCHITECTURE.md).
 
+**Now TWO readers (2026-06-03).** `chRead` serves both VS *and* PS — PS reads the
+store directly to load practice material (pull-on-use), instead of receiving a pushed
+snapshot. PS's two visibly-guarded entries: `open_practice` (the quick-practice picker)
+→ `chRead` → `load_vocab`/`load_filtered`; and the vocab-tab signal
+`practise_vocab → goPractice!(filter)`, after which PS pulls (`chRead`) and shapes with
+that filter. The old `pLoad` data-push is gone (`goPractice` replaces it in the restricted
+set). `chRead!` is a self-loop output, so it answers any number of readers as separate τ
+syncs. See `practice-session-recovery.md` (PS pull/signal) and ARCHITECTURE.md.
+
 ---
 
 ## Provenance  (app src @ `504f8c8`, 2026-04-26)
@@ -24,7 +33,7 @@ so the composition stays visibly-guarded (≈ a congruence — ARCHITECTURE.md).
 | Spec element | Kind | Source `file:line (fn)` | App construct | Note |
 |---|---|---|---|---|
 | `CargoHold[entries]` | agent | `vocab.py` (all ops); `app_mysql.py:143 (get_connection)` | the `vocab_entries` table + its CRUD | **faithful** — the persisted collection, owned here. Single source of truth. |
-| `chRead` | port (out, self-loop) | `vocab.py:195 (list_vocab)` | `SELECT * FROM vocab_entries WHERE …` | **faithful** — emits the current collection; a self-loop (read never mutates). The READ a client pulls. (Filter/sort applied by the *reader*, VS, not in the store — kept minimal.) |
+| `chRead` | port (out, self-loop) | `vocab.py:195 (list_vocab)` | `SELECT * FROM vocab_entries WHERE …` | **faithful** — emits the current collection; a self-loop (read never mutates). The READ a client pulls. (Filter/sort applied by the *reader* — VS, or PS via practiseList — not in the store — kept minimal.) |
 | `chUpsert` | port (in) | `vocab.py:106 (capture_vocab_entry)` | `INSERT … ON DUPLICATE KEY UPDATE` | **faithful** — `addEntry` *is* this upsert (dedup on word + `times_seen` bump). Verified: `cargohold_test` §2. |
 | `chRemove` | port (in) | `vocab.py:301 (delete_vocab_entry)` | `DELETE … WHERE vocab_id=%s` | **faithful** — `deleteFrom`. Verified: `cargohold_test` §4. |
 | `chAmend` | port (in) | `vocab.py:343 (update_vocab_entry)` | `UPDATE … WHERE vocab_id=%s` | **simplified** — one port for field updates; carries `<|"id"->_, "fields"->_|>` → `updateEntry`. `update_vocab_notes` (`vocab.py:314`) and autofill enrichment fold in at the migration. Verified: `cargohold_test` §3. |

--- a/spec/docs/cargohold-recovery.md
+++ b/spec/docs/cargohold-recovery.md
@@ -9,10 +9,13 @@ and the persistence counterpart of the "own it → store it" rule.
 (`CargoHold`, not `Hold`: `Hold` is a Wolfram built-in. Nautical theme — `Helm`
 steers, the cargo hold stores.)
 
-**Status:** PR-1 defines it **standalone** (loaded via `loadRecoveredBase`, *not*
-yet composed into `mioCore` — no dual state until VS reads it). PR-2 composes it
-(restricted `chRead`/`chUpsert`/`chRemove`/`chAmend`) and migrates VS to read/write
-it (the (i) prefix-read model).
+**Status:** PR-1 defined it standalone. **PR-2 composes it into `mioCore`**
+(restricted `chRead`/`chUpsert`/`chImport`/`chRemove`/`chAmend` + `vAdd`) and
+migrates VS to the (i) form: VS holds no entries; it is the **`open_vocab`-gated
+tab** that reads/writes the store. **Two writers feed the store:** `chUpsert` (VS
+tab type/paste) and **`vAdd` (PS capture from practice, written DIRECTLY — not via
+the tab)**. The first VS action is the *visible* `open_vocab`, not the `chRead` τ,
+so the composition stays visibly-guarded (≈ a congruence — ARCHITECTURE.md).
 
 ---
 

--- a/spec/docs/function-recovery.md
+++ b/spec/docs/function-recovery.md
@@ -85,8 +85,9 @@ counters that REPLACE the schema's `first_seen_at`/`last_seen_at` wall-clock
 columns — see §"time".) `entries` is a `List[entry]`. `Null`
 encodes a Python NULL column. A practice `phrase` is `<|"text","translation",
 "ipa"|>` — exactly `vocab_as_practice_phrases`'s output, which is why
-`practiseList` (VS) directly produces a PS `phrases` queue: that is the `pLoad`
-relay made concrete.
+`practiseList` directly produces a PS `phrases` queue — now applied by **PS itself**
+after it pulls the collection from CargoHold (`goPractice`/`open_practice`), no longer
+the payload of a `pLoad` push.
 
 **`word` vs `text` — two interfaces, not an inconsistency.** A VocabStore entry
 is keyed by `"word"` (the lowercased dedup/lookup key; `"display_word"` keeps the

--- a/spec/docs/practice-session-recovery.md
+++ b/spec/docs/practice-session-recovery.md
@@ -132,3 +132,28 @@ Restriction/composition note: `capture_vocab` is the one link to another agent (
 `nextPos`/`prevPos`/`selectPos`, `capture(word, …)`, `persist(result)`.
 
 These are committed as *signatures only*. Their bodies survive framework-independently in `src/scoring/practice.py`, `src/scoring/phonemes.py`, `src/audio/`, and `src/vocab.py`, and are recovered mechanically later — not invented now (§4, §6).
+
+---
+
+## Amendment (2026-06-03) — PS reads CargoHold directly (pull + signal)
+
+PracticeSession now reads the external store (**CargoHold**) itself for vocab
+material, instead of receiving a pushed snapshot. Two visibly-guarded entries were
+added (mirroring VocabStore's `open_vocab`):
+
+- **Pull** — `open_practice` (a VISIBLE, parameter-less input: the quick-practice
+  picker) → `chRead?(es)` → **`PSBrowse[es]`**, which offers `load_vocab` (the whole
+  collection) and `load_filtered(q)` (the subset). Both shape `es` into the practice
+  queue via `practiseList` (`vocab.py:644`). `@src quick_practice_tab.py:178/184`.
+- **Signal** — the vocab-tab "🎯 Practise these" sends VS → `goPractice!(filter)`
+  (the filter only); PS receives `goPractice?(filter)`, pulls `chRead?(es)`, and loads
+  `practiseList[es, filter]`.
+
+Both keep their VISIBLE input first (`open_practice` / `goPractice`), so the `chRead`
+is the *second* action — PS stays **visibly-guarded** (no initial τ; `≈` a congruence).
+`chRead`/`goPractice` are restricted → τ in `mioCore`; `goPractice` **replaced** the old
+`pLoad` data-push. This makes the borrowed collection **pull-on-use** (ARCHITECTURE.md
+"Borrowed vs owned data"); the loaded queue PS then holds is a deliberate *session*
+snapshot, not a cache. The §3 ready-set adds `open_practice`/`goPractice` to the
+always-on top (`load_material` unchanged for non-vocab sources). See `MioCore.wl`
+(the `goPractice`/`chRead` links) and `cargohold-recovery.md` (two readers).

--- a/spec/docs/vocabstore-recovery.md
+++ b/spec/docs/vocabstore-recovery.md
@@ -134,3 +134,29 @@ Per Matthew's decision (2026-06-02), these are unified into **one channel**, `pr
 - Minimal Pairs is **not** modelled this round (a separate computed route, deferred).
 
 The τ hand-off itself was verified faithful before this change: PS receives the list and all PS features become available, identical to `load_material`. See `MioCore.wl` (the `pLoad` link) and `VocabStoreRecovered.wl` (`VSNonEmpty`).
+
+---
+
+## Amendment (2026-06-03) — the (i) external-store form: VS is the gated tab
+
+VocabStore no longer holds the collection. It is now the **Vocabulary tab**: a
+*gated viewer/editor* over **CargoHold** (the store agent, `cargohold-recovery.md`).
+
+- **State** drops `entries` → `VS[auth, sort, filter, editing]` (UI params only).
+- **Entry** is a VISIBLE, parameter-less `open_vocab` (the user selecting the tab);
+  it leads to `VSRead`, which `chRead`s the store, then offers view + actions and
+  loops back to `VSRead` (re-reads each cycle). Keeping the first action *visible*
+  (not the `chRead` τ) keeps the composition visibly-guarded so `≈` stays a
+  congruence (ARCHITECTURE.md → Borrowed-vs-owned; no `ModeSelector` needed).
+- **Reads** (one `chRead` per cycle) feed: the empty/non-empty ready-set guard,
+  the `view!` projection, the `practise_vocab` payload, and `export`.
+- **Writes** route to CargoHold: `add → chUpsert`, `import_bulk → chImport`,
+  `delete → chRemove`, `update`/`update_notes`/`autofill → chAmend`.
+- **Capture from practice does NOT pass through the tab** — `PS.capture_vocab →
+  vAdd → CargoHold` writes the store directly (the app's `capture_vocab_entry` is
+  a direct DB write, `vocabulary_tab.py:7`). So `vAdd` re-targeted PS→CargoHold,
+  and VS has no always-on capture summand to muddy its visible-guarding.
+
+The §4 ready-set table above describes the *in-process* (pre-(i)) shape; under
+(i) those domain ports are afforded **after `open_vocab` + `chRead`**, and the
+collection-dependent guards read the store rather than local `entries`.

--- a/spec/docs/vocabstore-recovery.md
+++ b/spec/docs/vocabstore-recovery.md
@@ -160,3 +160,13 @@ VocabStore no longer holds the collection. It is now the **Vocabulary tab**: a
 The §4 ready-set table above describes the *in-process* (pre-(i)) shape; under
 (i) those domain ports are afforded **after `open_vocab` + `chRead`**, and the
 collection-dependent guards read the store rather than local `entries`.
+
+**Practise hand-off is now a SIGNAL, not a push (supersedes the 2026-06-02 `pLoad`
+amendment).** `practise_vocab` no longer emits `pLoad!(practiseList[es, filter])` —
+the §2 row "→ `PracticeSession.load_material`" and the 2026-06-02 amendment are
+superseded. It now emits **`goPractice!(filter)`** — the *filter only* — and PS pulls
+the collection FRESH from CargoHold itself (`practice-session-recovery.md`). VS need
+not even read `es` to hand off, and since this navigates away from the tab, VS returns
+to its un-opened `open_vocab` entry (it does not re-read). Single source of truth: no
+snapshot crosses the boundary. The two quick-practice routes ("Load vocabulary"/"Load
+filtered") are now PS-side pull entries (`open_practice`), not VS ports.

--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -58,7 +58,7 @@ The panel shows, top to bottom:
   component** (Helm / PS / VS), **inputs before outputs** in each frame; internal
   syncs go in an *internal (τ)* frame. The port→component map is a pure syntactic
   scan of each agent's sort (`componentPortMap`), so it needs no execution and
-  can't be fooled by guards; dual restricted actions (`vAdd`/`pLoad`/`langRead`)
+  can't be fooled by guards; dual restricted actions (`vAdd`/`goPractice`/`langRead`)
   only ever appear as τ, so they never split across frames.
 - **Back / Forward / Reset**, a **`Test:` menu + `Run test`** (see below), and
   the **condensed trace** (with Copy). **Back** and **Forward** scrub a run: step
@@ -66,7 +66,7 @@ The panel shows, top to bottom:
   `Run test` to watch what each step of a sequence reveals. (A fresh manual step
   or `Run test` clears the forward/redo line.)
 - **Auto-advance internal syncs (maximal progress)** — a checkbox. When on, the
-  harness fires the system's internal synchronisations (`vAdd`, `pLoad`, and
+  harness fires the system's internal synchronisations (`vAdd`, `goPractice`, and
   `langRead` — the borrowed-language pull on `autofill` and on `attempt_made`
   scoring) for you between your actions, until the state is τ-stable,
   so you only ever click *external* ports. It's a **simulation strategy, not a
@@ -105,7 +105,7 @@ plan is a list of:
 
 - `vis["port"]` — a visible action with no value;
 - `vis["port", value]` — a value-carrying input, value supplied;
-- `tau["chan"]` — an internal sync (`pLoad`, `vAdd`).
+- `tau["chan"]` — an internal sync (`goPractice`, `vAdd`).
 
 Run one from the GUI: pick it in the **`Test:`** menu and click **`Run test`** —
 it replays the whole plan from the initial state, setting the data view and the
@@ -166,7 +166,7 @@ All have `::usage`, so `?walkUI`, `?supplyValue`, `?walkTests`, `?loadEngine`,
 - **`view` vs `View`.** `viewProjections` matches the view suffix
   case-insensitively, so both the bare agent's `view` and the relabelled
   `vSView`/`pSView` are picked up.
-- **Syncs are composed-only.** `pLoad`/`vAdd` are restricted internal channels;
+- **Syncs are composed-only.** `goPractice`/`vAdd` are restricted internal channels;
   the `sync-*`/`full-*` sequences run on `mioCore`/`mioCoreD`, not VS/PS alone.
 - **Deferred.** A cleaner value-supply route — giving `transVP` a parameter that
   derives an input transition *with* the substitution inline (supply-then-derive)

--- a/spec/tests/cargohold_test.wls
+++ b/spec/tests/cargohold_test.wls
@@ -33,8 +33,8 @@ ports[s_] := Sort[ToString /@ portName /@ First /@ readyTransitions[transNamed, 
 
 Print[hr]; Print["1. ports — read self-loop + three writes"]; Print[hr];
 s0 = call["CargoHold", {}];
-assert["empty store offers chRead, chUpsert, chRemove, chAmend",
-  ports[s0] === {"chAmend", "chRead", "chRemove", "chUpsert"}];
+assert["empty store offers chRead + the writes (incl vAdd capture from PS)",
+  ports[s0] === {"chAmend", "chImport", "chRead", "chRemove", "chUpsert", "vAdd"}];
 assert["chRead on empty emits {}", chReadOf[s0] === {}];
 
 Print[hr]; Print["2. chUpsert — capture + dedup (addEntry)"]; Print[hr];

--- a/spec/tests/composition_test.wls
+++ b/spec/tests/composition_test.wls
@@ -8,7 +8,7 @@
      2. steps each composition layer (sub-agent -> par -> restrict ->
         call[MioCore]) so a transNamed that returns UNEVALUATED is
         localised to the exact layer that fails,
-     3. checks the external ready set and the vAdd / pLoad tau syncs.
+     3. checks the external ready set and the vAdd / goPractice tau syncs.
 
    Run headless:   wolframscript -file spec/tests/composition_test.wls
    Or Get it into a session (NB: re-Getting RCA_core.wl resets agentDefs,
@@ -33,7 +33,7 @@ lab[a_]   := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
 Print[bar];
 Print["1. AGENT REGISTRATION (agentDefs)"];
 Print[bar];
-need = {"PS", "PSActive", "VS", "VSAuthed", "VSNonEmpty",
+need = {"PS", "PSActive", "PSBrowse", "VS", "VSAuthed", "VSNonEmpty",
         "VSEntryActions", "VSEditActions", "Helm", "CargoHold"};
 (* MioCore is now a composed MU-TERM value (relabeled view!), not a
    defineAgent; it is stepped with transVP[MioCore], not call["MioCore"]. *)
@@ -48,7 +48,7 @@ ps0 = call["PS", {}, 0, none, none];
 vs0 = call["VS", signedIn, alpha, none, none];          (* (i): no entries *)
 ch0 = call["CargoHold", {}];                            (* the store owns the entries *)
 helm0 = call["Helm", "English", "fr", google, 250];
-R = {label["vAdd"], label["pLoad"], label["langRead"],
+R = {label["vAdd"], label["goPractice"], label["langRead"],
      label["chRead"], label["chUpsert"], label["chImport"], label["chRemove"], label["chAmend"]};
 parTerm = par[par[par[ps0, vs0], helm0], ch0];
 resTerm = restrict[parTerm, R];
@@ -68,17 +68,19 @@ If[! evaluatedQ[tMio],
 Print[bar];
 Print["3. EXTERNAL READY SET (all restricted channels hidden)"];
 Print[bar];
-(* VS gates behind chRead under (i): settle that tau, then the external (non-tau)
-   ready set is the familiar one — and the restricted channels (vAdd/pLoad and the
-   ch* store channels) are NOT among the external named ports. *)
+(* VS gates behind chRead under (i): settle, then the external (non-tau) ready set
+   is the familiar one (now incl. open_practice, the PS pull entry) — and the
+   restricted channels (vAdd/goPractice and the ch* store channels) are NOT among
+   the external named ports. *)
 If[evaluatedQ[tMio],
   Module[{ns = Sort[portName /@ Select[First /@
        transVP[Last[walkSteps[transVP, mioCore, {}, "AutoTau" -> True]["states"]]], ! isTau[#] &]]},
     Print["   (settled) ", InputForm[ns]];
-    Print["   vAdd hidden?     ", ok[! MemberQ[ns, "vAdd"]]];
-    Print["   pLoad hidden?    ", ok[! MemberQ[ns, "pLoad"]]];
-    Print["   chRead hidden?   ", ok[! MemberQ[ns, "chRead"]]];
-    Print["   chUpsert hidden? ", ok[! MemberQ[ns, "chUpsert"]]]]];
+    Print["   open_practice shown? ", ok[MemberQ[ns, "open_practice"]]];
+    Print["   vAdd hidden?       ", ok[! MemberQ[ns, "vAdd"]]];
+    Print["   goPractice hidden? ", ok[! MemberQ[ns, "goPractice"]]];
+    Print["   chRead hidden?     ", ok[! MemberQ[ns, "chRead"]]];
+    Print["   chUpsert hidden?   ", ok[! MemberQ[ns, "chUpsert"]]]]];
 
 Print[bar];
 Print["4. CROSS-COMPONENT SYNCHRONISATION (via AutoTau on mioCoreD)"];
@@ -89,8 +91,11 @@ capLabels = labelsOf[{vis["load_material", {<|"text" -> "chat", "translation" ->
 Print["   capture_vocab relays via vAdd?   ", ok[MemberQ[capLabels, "vAdd"]]];
 Print["      ", InputForm[capLabels]];
 plLabels = labelsOf[{vis["open_vocab"], vis["add", <|"word" -> "chat"|>], vis["set_filter", "ch"], vis["practise_vocab"]}];
-Print["   practise_vocab relays via pLoad? ", ok[MemberQ[plLabels, "pLoad"]]];
+Print["   practise_vocab signals via goPractice? ", ok[MemberQ[plLabels, "goPractice"]]];
 Print["      ", InputForm[plLabels]];
+ppLabels = labelsOf[{vis["open_practice"], vis["load_vocab"]}];
+Print["   open_practice pulls via chRead?        ", ok[MemberQ[ppLabels, "chRead"]]];
+Print["      ", InputForm[ppLabels]];
 
 Print[bar];
 Print["done."];

--- a/spec/tests/composition_test.wls
+++ b/spec/tests/composition_test.wls
@@ -22,16 +22,19 @@ Print["Loading engine + spec (order matters: discipline before components,",
 loadEngine[];
 loadRecoveredBase[];
 mioGet["MioCore.wl"];
+mioGet["walk.wl"];   (* walkSteps "AutoTau" + value-carrying vis[nm,val] for §4 *)
 
 bar = StringRepeat["=", 64];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 evaluatedQ[x_] := ListQ[x];   (* transNamed returns a list of {action,succ} *)
+isTau[a_] := MatchQ[a, tag[\[Tau], ___]] || a === \[Tau];
+lab[a_]   := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
 
 Print[bar];
 Print["1. AGENT REGISTRATION (agentDefs)"];
 Print[bar];
 need = {"PS", "PSActive", "VS", "VSAuthed", "VSNonEmpty",
-        "VSEntryActions", "VSEditActions"};
+        "VSEntryActions", "VSEditActions", "Helm", "CargoHold"};
 (* MioCore is now a composed MU-TERM value (relabeled view!), not a
    defineAgent; it is stepped with transVP[MioCore], not call["MioCore"]. *)
 Do[Print["   ", StringPadRight[n, 16], KeyExistsQ[agentDefs, n] // ok], {n, need}];
@@ -42,13 +45,18 @@ Print[bar];
 Print["2. LAYER-BY-LAYER transNamed (find where it stops evaluating)"];
 Print[bar];
 ps0 = call["PS", {}, 0, none, none];
-vs0 = call["VS", signedIn, {}, alpha, none, none];
-parTerm = par[ps0, vs0];
-resTerm = restrict[parTerm, {label["vAdd"], label["pLoad"]}];
+vs0 = call["VS", signedIn, alpha, none, none];          (* (i): no entries *)
+ch0 = call["CargoHold", {}];                            (* the store owns the entries *)
+helm0 = call["Helm", "English", "fr", google, 250];
+R = {label["vAdd"], label["pLoad"], label["langRead"],
+     label["chRead"], label["chUpsert"], label["chImport"], label["chRemove"], label["chAmend"]};
+parTerm = par[par[par[ps0, vs0], helm0], ch0];
+resTerm = restrict[parTerm, R];
 
 tPS  = transNamed[ps0];   Print["   transNamed[PS]            evaluated? ", ok[evaluatedQ[tPS]]];
 tVS  = transNamed[vs0];   Print["   transNamed[VS]            evaluated? ", ok[evaluatedQ[tVS]]];
-tPar = transNamed[parTerm]; Print["   transNamed[par[PS,VS]]    evaluated? ", ok[evaluatedQ[tPar]]];
+tCH  = transNamed[ch0];   Print["   transNamed[CargoHold]     evaluated? ", ok[evaluatedQ[tCH]]];
+tPar = transNamed[parTerm]; Print["   transNamed[par[…]]        evaluated? ", ok[evaluatedQ[tPar]]];
 tRes = transNamed[resTerm]; Print["   transNamed[restrict[...]] evaluated? ", ok[evaluatedQ[tRes]]];
 tMio = transVP[mioCore];   (* composed mu-term: step with transVP *)
 Print["   transVP[mioCore] evaluated? ", ok[evaluatedQ[tMio]]];
@@ -58,36 +66,31 @@ If[! evaluatedQ[tMio],
 ];
 
 Print[bar];
-Print["3. EXTERNAL READY SET (vAdd / pLoad must be hidden by restriction)"];
+Print["3. EXTERNAL READY SET (all restricted channels hidden)"];
 Print[bar];
-nm[s_] := Sort[portName /@ (First /@ transNamed[s])];
+(* VS gates behind chRead under (i): settle that tau, then the external (non-tau)
+   ready set is the familiar one — and the restricted channels (vAdd/pLoad and the
+   ch* store channels) are NOT among the external named ports. *)
 If[evaluatedQ[tMio],
-  Module[{ns = Sort[portName /@ (First /@ transVP[mioCore])]},
-    Print["   ", InputForm[ns]];
-    Print["   vAdd hidden?  ", ok[! MemberQ[ns, "vAdd"]]];
-    Print["   pLoad hidden? ", ok[! MemberQ[ns, "pLoad"]]]]];
+  Module[{ns = Sort[portName /@ Select[First /@
+       transVP[Last[walkSteps[transVP, mioCore, {}, "AutoTau" -> True]["states"]]], ! isTau[#] &]]},
+    Print["   (settled) ", InputForm[ns]];
+    Print["   vAdd hidden?     ", ok[! MemberQ[ns, "vAdd"]]];
+    Print["   pLoad hidden?    ", ok[! MemberQ[ns, "pLoad"]]];
+    Print["   chRead hidden?   ", ok[! MemberQ[ns, "chRead"]]];
+    Print["   chUpsert hidden? ", ok[! MemberQ[ns, "chUpsert"]]]]];
 
 Print[bar];
-Print["4. CROSS-COMPONENT SYNCHRONISATION (step the composite to a tau)"];
+Print["4. CROSS-COMPONENT SYNCHRONISATION (via AutoTau on mioCoreD)"];
 Print[bar];
-R = {label["vAdd"], label["pLoad"]};
-isTau[a_] := MatchQ[a, tag[\[Tau], ___]] || a === \[Tau];
-stepTo[s_, name_] := Module[{t = SelectFirst[transNamed[s], portName[#[[1]]] === name &]},
-  If[MissingQ[t], $Failed, t[[2]]]];
-taus[s_] := Cases[First /@ transNamed[s], _?isTau];
-
-cv = restrict[par[call["PS", {p1}, 0, recorded[a], scored[r]], vs0], R];
-cv2 = stepTo[cv, "capture_vocab"];
-Print["   capture_vocab -> tau(vAdd)?  ",
-  ok[cv2 =!= $Failed && AnyTrue[taus[cv2], MatchQ[#, tag[\[Tau], "vAdd", ___]] &]]];
-If[cv2 =!= $Failed, Print["      ", InputForm[taus[cv2]]]];
-
-pf = restrict[par[call["PS", {}, 0, none, none],
-                  call["VS", signedIn, {e1}, alpha, filterBy["q"], none]], R];
-pf2 = stepTo[pf, "practise_vocab"];
-Print["   practise_vocab -> tau(pLoad)?  ",
-  ok[pf2 =!= $Failed && AnyTrue[taus[pf2], MatchQ[#, tag[\[Tau], "pLoad", ___]] &]]];
-If[pf2 =!= $Failed, Print["      ", InputForm[taus[pf2]]]];
+labelsOf[plan_] := lab /@ walkSteps[transNamed, mioCoreD, plan, "AutoTau" -> True]["actions"];
+capLabels = labelsOf[{vis["load_material", {<|"text" -> "chat", "translation" -> "cat"|>}],
+                      vis["recording_made", "a"], vis["attempt_made"], vis["capture_vocab", "chat"]}];
+Print["   capture_vocab relays via vAdd?   ", ok[MemberQ[capLabels, "vAdd"]]];
+Print["      ", InputForm[capLabels]];
+plLabels = labelsOf[{vis["open_vocab"], vis["add", <|"word" -> "chat"|>], vis["set_filter", "ch"], vis["practise_vocab"]}];
+Print["   practise_vocab relays via pLoad? ", ok[MemberQ[plLabels, "pLoad"]]];
+Print["      ", InputForm[plLabels]];
 
 Print[bar];
 Print["done."];

--- a/spec/tests/data_view_test.wls
+++ b/spec/tests/data_view_test.wls
@@ -60,9 +60,11 @@ assert["editingRow[id] kept inline (not a binding)?",
 --------------------------------------------------------------------- *)
 Print[hr]; Print["2. linearize a LIVE projection from the dual-tau walk"]; Print[hr];
 
-plan = {vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
-        vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
-wlk = walkSteps[transNamed, mioCoreD, plan];
+(* external-only plan; AutoTau fires the internal syncs (chRead/chUpsert/pLoad/
+   langRead/vAdd) between steps — so the action log includes them *)
+plan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
+        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
+wlk = walkSteps[transNamed, mioCoreD, plan, "AutoTau" -> True];
 assert["walk ran to completion (not stuck)?", ! wlk["stuck"]];
 
 (* Pull the VS `vocabView` projection out of the final composed state's view
@@ -96,7 +98,7 @@ condensedSize = LeafCount[log];
 Print["   raw  trace (all cumulative state terms) LeafCount : ", rawStatesSize];
 Print["   condensed event-log                     LeafCount : ", condensedSize];
 assert["condensed log strictly smaller than raw trace?", condensedSize < rawStatesSize];
-assert["one event per plan step?", Length[log] === Length[plan]];
+assert["at least one event per plan step (AutoTau adds internal taus)?", Length[log] >= Length[plan]];
 assert["both taus present (pLoad, vAdd)?",
        SubsetQ[#["port"] & /@ Select[log, #["polarity"] === "tau" &], {"pLoad", "vAdd"}]];
 assert["each event has exactly the 4 fields?",

--- a/spec/tests/data_view_test.wls
+++ b/spec/tests/data_view_test.wls
@@ -13,7 +13,7 @@
         cumulative state term (recoverable by replay).
 
    PLAN: the dual-tau deterministic walk from internal_transitions_test /
-   merge_defined_test (set_filter, add, practise_vocab, tau pLoad,
+   merge_defined_test (set_filter, add, practise_vocab, tau goPractice,
    recording_made, attempt_made, capture_vocab, tau vAdd) over mioCoreD
    (transNamed). It drives both cross-component internal taus.
 
@@ -60,7 +60,7 @@ assert["editingRow[id] kept inline (not a binding)?",
 --------------------------------------------------------------------- *)
 Print[hr]; Print["2. linearize a LIVE projection from the dual-tau walk"]; Print[hr];
 
-(* external-only plan; AutoTau fires the internal syncs (chRead/chUpsert/pLoad/
+(* external-only plan; AutoTau fires the internal syncs (chRead/chUpsert/goPractice/
    langRead/vAdd) between steps — so the action log includes them *)
 plan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
         vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
@@ -99,8 +99,8 @@ Print["   raw  trace (all cumulative state terms) LeafCount : ", rawStatesSize];
 Print["   condensed event-log                     LeafCount : ", condensedSize];
 assert["condensed log strictly smaller than raw trace?", condensedSize < rawStatesSize];
 assert["at least one event per plan step (AutoTau adds internal taus)?", Length[log] >= Length[plan]];
-assert["both taus present (pLoad, vAdd)?",
-       SubsetQ[#["port"] & /@ Select[log, #["polarity"] === "tau" &], {"pLoad", "vAdd"}]];
+assert["both taus present (goPractice, vAdd)?",
+       SubsetQ[#["port"] & /@ Select[log, #["polarity"] === "tau" &], {"goPractice", "vAdd"}]];
 assert["each event has exactly the 4 fields?",
        AllTrue[log, Sort[Keys[#]] === Sort[{"port","polarity","isVisible","value"}] &]];
 

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -40,16 +40,21 @@ sV = Last[walkSteps[transVP, mioCore,
 tauTr = SelectFirst[readyTransitions[transVP, sV], isTauAct[First[#]] &];
 assert["a tau transition groups into internal (tau)",
   transGroup[pm, tauTr] === "internal (\[Tau])"];
+(* add is not externally ready at mioCore init (VS gates behind chRead), so use a
+   synthetic transition — transGroup only looks at the action's port name *)
 assert["a named input groups into its agent (add -> VS)",
-  transGroup[pm, SelectFirst[readyTransitions[transVP, mioCore],
-     portName[First[#]] === "add" &]] === "VS"];
+  transGroup[pm, {coLabel["add", binding[w]], dummyState}] === "VS"];
 (* inputsFirst: coLabel before label *)
 mix = {{label["x", param[1]], s1}, {coLabel["y", binding[z]], s2}};
 assert["inputsFirst puts the coLabel (input) before the label (output)",
   MatchQ[First[First[inputsFirst[mix]]], coLabel[___]]];
 
-Print[hr]; Print["3. the initial mioCore ready set partitions cleanly (no 'other')"]; Print[hr];
-grp = GroupBy[readyTransitions[transVP, mioCore], transGroup[pm, #] &];
+Print[hr]; Print["3. the SETTLED mioCore ready set partitions cleanly (no 'other')"]; Print[hr];
+(* settle the chRead tau (VS gates behind it under the (i) store form) so VS's
+   external ports are present; CargoHold's ports are all restricted (internal),
+   so they never appear in the external grouping *)
+sInit = Last[walkSteps[transVP, mioCore, {}, "AutoTau" -> True]["states"]];
+grp = GroupBy[readyTransitions[transVP, sInit], transGroup[pm, #] &];
 assert["groups are exactly {VS, PS, Helm}", Sort[Keys[grp]] === {"Helm", "PS", "VS"}];
 assert["no port falls into 'other'", ! KeyExistsQ[grp, "other"]];
 

--- a/spec/tests/internal_transitions_test.wls
+++ b/spec/tests/internal_transitions_test.wls
@@ -3,16 +3,16 @@
    spec/tests/internal_transitions_test.wls
    ---------------------------------------------------------------------
    A DETERMINISTIC walk over the composed mu-term `mioCore` that drives
-   BOTH cross-component internal transitions (the vAdd and pLoad tau
+   BOTH cross-component internal transitions (the vAdd and goPractice tau
    syncs hidden by the restriction). The earlier random walk never
    reached them because they only fire from specific states.
 
    One path hits both, because the two relays chain:
 
-     VS: set_filter, add  ->  practise_vocab  --pLoad!-->  (tau)
-         => PS receives practiseList[...] and becomes ACTIVE
+     VS: set_filter, add  ->  practise_vocab  --goPractice!(filter)--> (tau)
+         => PS PULLS the collection (chRead tau) and becomes ACTIVE
      PS: recording_made, attempt_made  ->  capture_vocab  --vAdd!--> (tau)
-         => VS receives the captured word
+         => CargoHold receives the captured word (direct, not via VS)
 
    Each tau step is INVISIBLE (isVisible -> False); the external
    triggers around them are visible. The walk picks each transition by
@@ -33,9 +33,9 @@ hr = StringRepeat["=", 70];
 isTau[a_] := MatchQ[a, tag[\[Tau], ___]] || a === \[Tau];
 
 (* The plan lists only EXTERNAL triggers; "AutoTau" -> True fires the internal
-   syncs (chRead before each VS action, chUpsert on capture, pLoad/vAdd relays,
-   langRead for scoring) between them. The recorded action log therefore contains
-   the internal taus, so we confirm pLoad and vAdd actually fired. *)
+   syncs (chRead before each VS action, chUpsert on capture, goPractice + the PS
+   pull chRead, vAdd relay, langRead for scoring) between them. The recorded action
+   log therefore contains the internal taus, so we confirm goPractice and vAdd fired. *)
 lab[a_] := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
 plan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
         vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
@@ -47,12 +47,12 @@ Print[hr];
 w = walkSteps[transVP, mioCore, plan, "AutoTau" -> True];
 labels = lab /@ w["actions"];
 failed = w["stuck"];
-sawPLoad = MemberQ[labels, "pLoad"];
+sawGoPractice = MemberQ[labels, "goPractice"];
 sawVAdd  = MemberQ[labels, "vAdd"];
 Print["trace: ", InputForm[labels]];
 
 Print[hr];
-Print["pLoad tau taken (VS --practiseList--> PS) ? ", If[sawPLoad, "OK", "*** FAIL ***"]];
-Print["vAdd  tau taken (PS --word--> VS)         ? ", If[sawVAdd,  "OK", "*** FAIL ***"]];
+Print["goPractice tau taken (VS --filter--> PS, PS pulls) ? ", If[sawGoPractice, "OK", "*** FAIL ***"]];
+Print["vAdd  tau taken (PS --word--> CargoHold)            ? ", If[sawVAdd,  "OK", "*** FAIL ***"]];
 Print["walk completed without a stuck step       ? ", If[!failed, "OK", "*** FAIL ***"]];
 Print[hr];

--- a/spec/tests/internal_transitions_test.wls
+++ b/spec/tests/internal_transitions_test.wls
@@ -32,40 +32,24 @@ mioGet["MioCore.wl"];
 hr = StringRepeat["=", 70];
 isTau[a_] := MatchQ[a, tag[\[Tau], ___]] || a === \[Tau];
 
-(* a plan entry is  vis["port"]  (an external action, visible)
-                 or tau["chan"]  (an internal sync on that channel)      *)
-findStep[s_, vis[nm_]]  := SelectFirst[transVP[s], !isTau[First[#]] && portName[First[#]] === nm &];
-findStep[s_, tau[ch_]] := SelectFirst[transVP[s], MatchQ[First[#], tag[\[Tau], ch, ___]] &];
-
-plan = {
-  vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
-  vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]
-};
+(* The plan lists only EXTERNAL triggers; "AutoTau" -> True fires the internal
+   syncs (chRead before each VS action, chUpsert on capture, pLoad/vAdd relays,
+   langRead for scoring) between them. The recorded action log therefore contains
+   the internal taus, so we confirm pLoad and vAdd actually fired. *)
+lab[a_] := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
+plan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
+        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
 
 Print[hr];
-Print["DETERMINISTIC WALK over mioCore  (visible triggers + internal taus)"];
+Print["DETERMINISTIC WALK over mioCore  (external triggers; internal taus auto-fired)"];
 Print[hr];
 
-state = mioCore;
-sawPLoad = False; sawVAdd = False; failed = False;
-Do[
-  Module[{spec = plan[[k]], t},
-    t = findStep[state, spec];
-    If[MissingQ[t],
-      failed = True;
-      Print["step ", k, "  *** NO TRANSITION for ", InputForm[spec], " ***"];
-      Print["   ready now: ",
-            InputForm[Sort[portName /@ (First /@ transVP[state])]]];
-      Break[]];
-    Module[{act = First[t], vq},
-      vq = !isTau[act];
-      If[MatchQ[spec, tau["pLoad"]], sawPLoad = True];
-      If[MatchQ[spec, tau["vAdd"]],  sawVAdd  = True];
-      Print["step ", StringPadLeft[ToString[k], 2], "  ",
-            If[vq, "[vis] ", "[TAU] "], InputForm[act]];
-      state = Last[t]];
-  ],
-  {k, Length[plan]}];
+w = walkSteps[transVP, mioCore, plan, "AutoTau" -> True];
+labels = lab /@ w["actions"];
+failed = w["stuck"];
+sawPLoad = MemberQ[labels, "pLoad"];
+sawVAdd  = MemberQ[labels, "vAdd"];
+Print["trace: ", InputForm[labels]];
 
 Print[hr];
 Print["pLoad tau taken (VS --practiseList--> PS) ? ", If[sawPLoad, "OK", "*** FAIL ***"]];

--- a/spec/tests/maxprog_test.wls
+++ b/spec/tests/maxprog_test.wls
@@ -29,28 +29,31 @@ hr = StringRepeat["=", 70];
 
 readyTaus[tf_, s_] := Select[readyTransitions[tf, s], isTauAct[First[#]] &];
 
-(* drive to just AFTER capture_vocab, BEFORE the vAdd tau *)
+(* drive to just AFTER capture_vocab — PS is now mid-relay (vAdd!) and VS is at
+   its chRead prefix, so an internal tau is pending. Under the (i) store form the
+   capture relay is a SEQUENCE of taus: chRead (VS reads) → vAdd (PS→VS) → chUpsert
+   (VS→store) → chRead — autoTau fires them to stability, landing the word in the
+   store. (Setup plan keeps the explicit langRead; it is PS-side, no AutoTau.) *)
 plan = {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
         vis["recording_made", "audio"], vis["attempt_made"], tau["langRead"], vis["capture_vocab", "chat"]};
 
-check[label_, tf_, s0_] := Module[{s, taus, a, stable},
+check[label_, tf_, s0_] := Module[{s, a, stable},
   Print[hr]; Print[label]; Print[hr];
   s = Last[walkSteps[tf, s0, plan]["states"]];
-  taus = readyTaus[tf, s];
-  assert["exactly one tau (vAdd) pending after capture_vocab", Length[taus] === 1];
-  (* channel rep is incidental (symbol / string / label[]); match on its text *)
-  assert["that tau's channel is vAdd",
-    StringContainsQ[ToString[eventOf[First[First[taus]]]["port"]], "vAdd"]];
+  assert["an internal tau is pending after capture_vocab", Length[readyTaus[tf, s]] >= 1];
   a = autoTau[tf, s];
-  assert["autoTau fired exactly one event", Length[a["events"]] === 1];
-  assert["fired event polarity is tau", First[a["events"]]["polarity"] === "tau"];
-  assert["fired event port is vAdd",
-    StringContainsQ[ToString[First[a["events"]]["port"]], "vAdd"]];
-  assert["one pre-state recorded (Back-steppable)", Length[a["states"]] === 1];
+  assert["autoTau fired >=1 event, all taus",
+    Length[a["events"]] >= 1 && AllTrue[a["events"], #["polarity"] === "tau" &]];
+  assert["one recorded pre-state per fired tau (Back-steppable)",
+    Length[a["states"]] === Length[a["events"]]];
   stable = a["state"];
   assert["resulting state is tau-stable (no tau ready)", readyTaus[tf, stable] === {}];
   assert["autoTau is a no-op on a tau-stable state",
-    autoTau[tf, stable]["events"] === {} && autoTau[tf, stable]["states"] === {}];];
+    autoTau[tf, stable]["events"] === {} && autoTau[tf, stable]["states"] === {}];
+  (* the relay completed: the capture wrote to the store via the vAdd tau
+     (PS.capture_vocab -> vAdd -> CargoHold; viewing it would need open_vocab) *)
+  assert["the capture relay fired (vAdd tau among the auto-fired events)",
+    AnyTrue[a["events"], StringContainsQ[ToString[#["port"]], "vAdd"] &]];];
 
 check["1. mioCore  (transVP)",   transVP,   mioCore];
 check["2. mioCoreD (transNamed)", transNamed, mioCoreD];

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -34,19 +34,27 @@ isTau[a_]   := MatchQ[a, tag[\[Tau], ___]] || a === \[Tau];
 names[tr_]  := Sort[portName /@ (First /@ tr)];
 lab[a_]     := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
 
-mu0 = transVP[mioCore];
+mu0 = transVP[mioCore];      (* raw transitions — used by the compactness checks *)
 de0 = transNamed[mioCoreD];
-(* includes Helm's ports (2026-06-01): helmView + set_source/set_target/set_tts.
-   set_speed is NOT here — it is espeak-only and the initial tts is google. *)
-expected = {"add", "helmView", "import_bulk", "load_material", "pSView",
-            "set_filter", "set_sort", "set_source", "set_target", "set_tts",
-            "vSView"};   (* sorted: "set_sort" < "set_source" (r < u) *)
+(* Under the (i) external-store form VS GATES behind an internal chRead: at the
+   raw initial state VS offers nothing externally (only the chRead τ). SETTLE that
+   τ (maximal progress), then the external ready set is the familiar one — and
+   merge (transVP) and mergeDefined (transNamed) settle to the SAME set. *)
+settled[tf_, s0_]   := Last[walkSteps[tf, s0, {}, "AutoTau" -> True]["states"]];
+extNames[tf_, s_]   := Sort[portName /@ Select[First /@ tf[s], ! isTau[#] &]];
+muNames = extNames[transVP,   settled[transVP,   mioCore]];
+deNames = extNames[transNamed, settled[transNamed, mioCoreD]];
+(* VS now gates behind a VISIBLE open_vocab (the tab entry), so at the (stable)
+   initial state VS contributes only open_vocab — its CRUD/view appear once the
+   tab is opened. Helm's set_speed is espeak-only (tts=google). *)
+expected = {"helmView", "load_material", "open_vocab", "pSView",
+            "set_source", "set_target", "set_tts"};
 
-Print[hr]; Print["1. EXTERNAL READY-SET PARITY"]; Print[hr];
-Print["   merge       (transVP)   : ", InputForm[names[mu0]]];
-Print["   mergeDefined (transNamed): ", InputForm[names[de0]]];
-Print["   agree?             ", ok[names[mu0] === names[de0]]];
-Print["   equals documented? ", ok[names[de0] === expected]];
+Print[hr]; Print["1. EXTERNAL READY-SET PARITY (settled past the chRead τ)"]; Print[hr];
+Print["   merge       (transVP)   : ", InputForm[muNames]];
+Print["   mergeDefined (transNamed): ", InputForm[deNames]];
+Print["   agree?             ", ok[muNames === deNames]];
+Print["   equals documented? ", ok[deNames === expected]];
 
 Print[hr]; Print["2. COMPACTNESS / CALL-BASED SUCCESSORS"]; Print[hr];
 Print["   LeafCount mioCore  (mu-term)   : ", LeafCount[mioCore]];
@@ -58,17 +66,14 @@ With[{succ = Last[First[de0]]},
   Print["   one successor free of mu/rvar? ",
         ok[FreeQ[succ, mu] && FreeQ[succ, rvar]]]];
 
-(* shared deterministic walk, parametrised by the transition function *)
-findStep[tf_, s_, vis[nm_]]  := SelectFirst[tf[s], !isTau[First[#]] && portName[First[#]] === nm &];
-findStep[tf_, s_, tau[ch_]] := SelectFirst[tf[s], MatchQ[First[#], tag[\[Tau], ch, ___]] &];
-plan = {vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
-        vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
-walk[tf_, s0_] := Module[{s = s0, labs = {}, t, stuck = False},
-  Do[t = findStep[tf, s, p];
-     If[MissingQ[t], stuck = True; Break[]];
-     AppendTo[labs, lab[First[t]]];
-     s = Last[t], {p, plan}];
-  <|"labels" -> labs, "stuck" -> stuck|>];
+(* shared deterministic walk, parametrised by the transition function. Plan lists
+   only EXTERNAL actions; "AutoTau" fires the internal syncs (chRead/chUpsert/
+   pLoad/langRead/vAdd) between them, so the label trace includes those τs and we
+   can confirm pLoad/vAdd fired. *)
+plan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
+        vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
+walk[tf_, s0_] := Module[{w = walkSteps[tf, s0, plan, "AutoTau" -> True]},
+  <|"labels" -> (lab /@ w["actions"]), "stuck" -> w["stuck"]|>];
 
 Print[hr]; Print["3. DUAL-TAU WALK on mioCoreD (transNamed)"]; Print[hr];
 wd = walk[transNamed, mioCoreD];

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -12,7 +12,7 @@
      2. mioCoreD is much smaller than mioCore and stays call-based
         (free of mu / rvar), one step included
      3. the dual-tau deterministic walk runs on mioCoreD (transNamed):
-        both vAdd and pLoad internal syncs fire
+        both vAdd and goPractice internal syncs fire
      4. the visible+tau label trace agrees with merge's (transVP)
 
    Engine + paths come from spec/paths.wl; loadEngine[] asserts the engine
@@ -47,7 +47,7 @@ deNames = extNames[transNamed, settled[transNamed, mioCoreD]];
 (* VS now gates behind a VISIBLE open_vocab (the tab entry), so at the (stable)
    initial state VS contributes only open_vocab — its CRUD/view appear once the
    tab is opened. Helm's set_speed is espeak-only (tts=google). *)
-expected = {"helmView", "load_material", "open_vocab", "pSView",
+expected = {"helmView", "load_material", "open_practice", "open_vocab", "pSView",
             "set_source", "set_target", "set_tts"};
 
 Print[hr]; Print["1. EXTERNAL READY-SET PARITY (settled past the chRead τ)"]; Print[hr];
@@ -68,8 +68,8 @@ With[{succ = Last[First[de0]]},
 
 (* shared deterministic walk, parametrised by the transition function. Plan lists
    only EXTERNAL actions; "AutoTau" fires the internal syncs (chRead/chUpsert/
-   pLoad/langRead/vAdd) between them, so the label trace includes those τs and we
-   can confirm pLoad/vAdd fired. *)
+   goPractice/langRead/vAdd) between them, so the label trace includes those τs and
+   we can confirm goPractice/vAdd fired. *)
 plan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
         vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
 walk[tf_, s0_] := Module[{w = walkSteps[tf, s0, plan, "AutoTau" -> True]},
@@ -79,7 +79,7 @@ Print[hr]; Print["3. DUAL-TAU WALK on mioCoreD (transNamed)"]; Print[hr];
 wd = walk[transNamed, mioCoreD];
 Print["   trace: ", InputForm[wd["labels"]]];
 Print["   ran to completion? ", ok[! wd["stuck"]]];
-Print["   pLoad tau fired?   ", ok[MemberQ[wd["labels"], "pLoad"]]];
+Print["   goPractice tau fired? ", ok[MemberQ[wd["labels"], "goPractice"]]];
 Print["   vAdd  tau fired?   ", ok[MemberQ[wd["labels"], "vAdd"]]];
 
 Print[hr]; Print["4. TRACE PARITY  merge(transVP) vs mergeDefined(transNamed)"]; Print[hr];

--- a/spec/tests/trace_io_test.wls
+++ b/spec/tests/trace_io_test.wls
@@ -30,7 +30,7 @@ mioGet["MioCore.wl"];
 hr      = StringRepeat["=", 70];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 
-(* External-only plan; AutoTau fires the internal syncs (chRead/chUpsert/pLoad/
+(* External-only plan; AutoTau fires the internal syncs (chRead/chUpsert/goPractice/
    langRead/vAdd). The RECORDED trace (wlk["actions"]) therefore includes those
    taus — and that full trace is what the round-trips reproduce. *)
 extPlan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
@@ -60,7 +60,7 @@ txt = eventLogForm[eventLog[wlk]];
 Export[txtfile, txt, "Text"];
 fullPlan = importTrace[txtfile];
 Print["   recovered plan includes the taus? ",
-      ok[MemberQ[fullPlan, tau["pLoad"]] && MemberQ[fullPlan, tau["chRead"]]]];
+      ok[MemberQ[fullPlan, tau["goPractice"]] && MemberQ[fullPlan, tau["chRead"]]]];
 wlk3 = walkSteps[transNamed, mioCoreD, fullPlan];
 Print["   text->plan->replay actions match? ", ok[wlk3["actions"] === wlk["actions"]]];
 

--- a/spec/tests/trace_io_test.wls
+++ b/spec/tests/trace_io_test.wls
@@ -30,48 +30,47 @@ mioGet["MioCore.wl"];
 hr      = StringRepeat["=", 70];
 ok[b_] := If[TrueQ[b], "OK", "*** FAIL ***"];
 
-(* the known dual-tau deterministic plan (see merge_defined_test.wls) *)
-plan = {vis["set_filter"], vis["add"], vis["practise_vocab"], tau["pLoad"],
-        vis["recording_made"], vis["attempt_made"], tau["langRead"], vis["capture_vocab"], tau["vAdd"]};
+(* External-only plan; AutoTau fires the internal syncs (chRead/chUpsert/pLoad/
+   langRead/vAdd). The RECORDED trace (wlk["actions"]) therefore includes those
+   taus — and that full trace is what the round-trips reproduce. *)
+extPlan = {vis["open_vocab"], vis["set_filter"], vis["add"], vis["practise_vocab"],
+           vis["recording_made"], vis["attempt_made"], vis["capture_vocab"]};
 
 (* NB: do NOT name any variable `w` — the spec's agent equations use the
    bare symbol `w` as a value binder (binding[w]); assigning to w here would
    substitute it into every recorded action and corrupt the trace. Use wlk. *)
-wlk = walkSteps[transNamed, mioCoreD, plan];
+wlk = walkSteps[transNamed, mioCoreD, extPlan, "AutoTau" -> True];
 
 (* temp files *)
 tmpfile  = FileNameJoin[{$TemporaryDirectory, "trace_io_actions.m"}];
-tmpfile2 = FileNameJoin[{$TemporaryDirectory, "trace_io_plan.m"}];
 txtfile  = FileNameJoin[{$TemporaryDirectory, "trace_io_text.txt"}];
 
-Print[hr]; Print["A. FAITHFUL ROUND-TRIP via replayTrace"]; Print[hr];
+Print[hr]; Print["A. FAITHFUL ROUND-TRIP via replayTrace (the recorded actions)"]; Print[hr];
 Put[wlk["actions"], tmpfile];
 acts = Get[tmpfile];
 r = replayTrace[mioCoreD, acts, "TransitionFunction" -> transNamed];
-Print["   replay ok?            ", ok[r["ok"]]];
-Print["   steps === plan length? ", ok[r["steps"] === Length[plan]]];
-Print["   final state matches?   ", ok[r["final"] === Last[wlk["states"]]]];
+Print["   replay ok?               ", ok[r["ok"]]];
+Print["   steps === #actions?      ", ok[r["steps"] === Length[wlk["actions"]]]];
+Print["   final state matches?     ", ok[r["final"] === Last[wlk["states"]]]];
 
-Print[hr]; Print["B. PORTABLE-PLAN ROUND-TRIP"]; Print[hr];
-Put[plan, tmpfile2];
-wlk2 = walkSteps[transNamed, mioCoreD, Get[tmpfile2]];
-Print["   actions re-derived from labels? ", ok[wlk2["actions"] === wlk["actions"]]];
-
-Print[hr]; Print["C. TEXT GOLDEN + parser ROUND-TRIP"]; Print[hr];
+Print[hr]; Print["B. TEXT GOLDEN + parser ROUND-TRIP"]; Print[hr];
+(* the recovered plan is the FULL label sequence (external + the internal taus);
+   replaying it EXPLICITLY (no AutoTau) reproduces the recorded actions. *)
 txt = eventLogForm[eventLog[wlk]];
 Export[txtfile, txt, "Text"];
-plan2 = importTrace[txtfile];
-Print["   plan2 === plan?        ", ok[plan2 === plan]];
-wlk3 = walkSteps[transNamed, mioCoreD, plan2];
+fullPlan = importTrace[txtfile];
+Print["   recovered plan includes the taus? ",
+      ok[MemberQ[fullPlan, tau["pLoad"]] && MemberQ[fullPlan, tau["chRead"]]]];
+wlk3 = walkSteps[transNamed, mioCoreD, fullPlan];
 Print["   text->plan->replay actions match? ", ok[wlk3["actions"] === wlk["actions"]]];
 
-Print[hr]; Print["D. CROSS-ENGINE PARITY  transVP vs transNamed"]; Print[hr];
-logVP = eventLog[walkSteps[transVP, mioCore, plan]];
-logND = eventLog[walkSteps[transNamed, mioCoreD, plan]];
+Print[hr]; Print["C. CROSS-ENGINE PARITY  transVP vs transNamed"]; Print[hr];
+logVP = eventLog[walkSteps[transVP, mioCore, extPlan, "AutoTau" -> True]];
+logND = eventLog[walkSteps[transNamed, mioCoreD, extPlan, "AutoTau" -> True]];
 polSeq[log_] := {#["port"], #["polarity"]} & /@ log;
 Print["   event logs identical? ", ok[polSeq[logVP] === polSeq[logND]]];
 
 (* cleanup *)
-DeleteFile /@ Select[{tmpfile, tmpfile2, txtfile}, FileExistsQ];
+DeleteFile /@ Select[{tmpfile, txtfile}, FileExistsQ];
 
 Print[hr]; Print["done."];

--- a/spec/tests/walk_sequences_test.wls
+++ b/spec/tests/walk_sequences_test.wls
@@ -10,7 +10,7 @@
    — with its embedded values, so the GUI's "Run test" menu and walkSteps
    both replay them with no typing. Also checks the value-carrying ports
    actually computed (a captured word reaches the VS entries via the
-   vAdd sync; a practise relay reaches the PS queue via pLoad).
+   vAdd sync; a practise relay reaches the PS queue via goPractice + a PS pull).
 
    Run headless:  wolframscript -file spec/tests/walk_sequences_test.wls
    ===================================================================== *)
@@ -48,12 +48,12 @@ vsEntriesAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan, "Aut
   If[KeyExistsQ[vp, "vSView"], #["word"] & /@ vp["vSView"]["entries"], $Failed]];
 assert["sync-vadd: captured \"chat\" reaches VS entries",
   MemberQ[vsEntriesAfter[walkTests["sync-vadd"]], "chat"]];
-(* sync-pload: the practise relay loads PS (pSView total > 0) *)
+(* sync-practise: the practise relay loads PS (pSView total > 0) *)
 psTotalAfter[plan_] := Module[{s = Last[walkSteps[transVP, mioCore, plan, "AutoTau" -> True]["states"]], vp},
   vp = Map[Identity, viewProjections[transVP, s]];
   If[KeyExistsQ[vp, "pSView"], vp["pSView"]["total"], $Failed]];
-assert["sync-pload: practise relay loads the PS queue (total > 0)",
-  TrueQ[psTotalAfter[walkTests["sync-pload"]] > 0]];
+assert["sync-practise: practise relay loads the PS queue (total > 0)",
+  TrueQ[psTotalAfter[walkTests["sync-practise"]] > 0]];
 
 Print[hr];
 Print["ALL ASSERTIONS: ", ok[allOk]];

--- a/spec/tests/walk_test.wls
+++ b/spec/tests/walk_test.wls
@@ -29,23 +29,26 @@ assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", lbl, " ", ok[b]]);
 byName[tf_, s_, nm_] := SelectFirst[readyTransitions[tf, s], portName[First[#]] === nm &];
 hr = StringRepeat["=", 70];
 
-Print[hr]; Print["1. readyInputs : the value-carrying ports a user can drive"]; Print[hr];
-ri = readyInputs[transNamed, call["VS", signedIn, ent, alpha, none, none]];
+Print[hr]; Print["1. readyInputs : the value-carrying ports a user can drive (after open_vocab)"]; Print[hr];
+(* (i) external-store form: a bare VS first offers the VISIBLE open_vocab (the tab
+   entry); taking it reaches VSRead, which reads the store (chRead); then the CRUD
+   ports appear. vsRead[es] = VS having entered the tab and read the collection es. *)
+vsOpen   = Last[byName[transNamed, call["VS", signedIn, alpha, none, none], "open_vocab"]];
+vsRead[es_] := Last[supplyValue[byName[transNamed, vsOpen, "chRead"], es]];
+assert["a bare VS first offers open_vocab (the visible tab entry)",
+  MemberQ[ToString /@ portName /@ First /@ readyTransitions[transNamed, call["VS", signedIn, alpha, none, none]], "open_vocab"]];
+ri = readyInputs[transNamed, vsRead[{}]];
 assert["every readyInput is a value-carrying input (has a binder)",
   AllTrue[ri, valueInputQ[First[#]] &]];
-assert["the canonical VS input ports are present",
+assert["after reading, the canonical VS input ports are present",
   SubsetQ[ToString /@ portName /@ First /@ ri, {"add", "set_filter", "set_sort", "import_bulk"}]];
 
-(* regression: viewProjections must pick up the BARE agent's "view" port, not
-   only the composition-relabelled "{Agent}View" (vSView/pSView). A literal
-   "View" suffix test silently dropped "view", so the data view was empty when
-   driving a bare agent (e.g. walkUI[call["VS", ...]]) and add never showed. *)
-assert["viewProjections finds the bare \"view\" port (case-insensitive)",
-  KeyExistsQ[viewProjections[transNamed, call["VS", signedIn, {}, alpha, none, none]], "view"]];
-assert["after add on a bare VS agent, the view projection shows the entry",
-  Map[Identity, viewProjections[transNamed,
-      Last[supplyValue[byName[transNamed, call["VS", signedIn, {}, alpha, none, none], "add"],
-                       <|"word" -> "souris"|>]]]["view"]]["count"] === 1];
+(* viewProjections must pick up the BARE agent's "view" port (case-insensitive),
+   and VS projects what it READ from the store. *)
+assert["viewProjections finds the bare \"view\" port after reading",
+  KeyExistsQ[viewProjections[transNamed, vsRead[{}]], "view"]];
+assert["VS projects the entries it read (count reflects the store)",
+  Map[Identity, viewProjections[transNamed, vsRead[addEntry[{}, "souris"]]]["view"]]["count"] === 1];
 
 Print[hr]; Print["2. supplyValue : slot binder (load_material on PS) inserts cleanly"]; Print[hr];
 lm  = byName[transNamed, call["PS", {}, 0, none, none], "load_material"];
@@ -55,18 +58,24 @@ assert["value inserted into the PS state slot",
   Last[lmv] === call["PS", phr, 0, none, none]];
 assert["eventOf reads the concrete value", eventOf[First[lmv]]["value"] === {phr}];
 
-Print[hr]; Print["3. supplyValue : data preserved on a value-function port (add)"]; Print[hr];
-ad  = byName[transNamed, call["VS", signedIn, ent, alpha, none, none], "add"];
+Print[hr]; Print["3. supplyValue : add now WRITES to the store (chUpsert carries the word)"]; Print[hr];
+(* under (i) add no longer mutates VS state — it emits chUpsert!(w) to CargoHold.
+   supplyValue must thread the word into that emission (data preserved, routed out). *)
+ad  = byName[transNamed, vsRead[{}], "add"];
 wv  = <|"word" -> "Chat"|>;
 adv = supplyValue[ad, wv];
-assert["binder w replaced by the value inside addEntry (data preserved)",
-  Last[adv] === call["VS", signedIn, addEntry[ent, wv], alpha, none, none]];
-assert["addEntry kept (not collapsed); entries left symbolic", !FreeQ[Last[adv], addEntry[ent, wv]]];
+assert["add emits chUpsert carrying the word (data preserved, routed to the store)",
+  ! FreeQ[Last[adv], param[wv]] && ! FreeQ[Last[adv], label["chUpsert", ___]]];
+assert["the supplied word is NOT lost (binder w replaced by the value)",
+  FreeQ[Last[adv], binding[w]]];
 
 Print[hr]; Print["4. substVv is SCOPE-AWARE where ReplaceAll would leak"]; Print[hr];
 (* the mu-term add derivative re-unfolds clauses that REBIND w; the supplied
-   value must NOT land in those rebound occurrences. *)
-deriv = Last[byName[transVP, mioCore, "add"]];
+   value must NOT land in those rebound occurrences. (add is gated behind the
+   visible open_vocab then chRead under (i); take open_vocab + settle the chRead
+   to reach the state offering add.) *)
+mioSettled = Last[walkSteps[transVP, mioCore, {vis["open_vocab"]}, "AutoTau" -> True]["states"]];
+deriv = Last[byName[transVP, mioSettled, "add"]];
 assert["derivative does re-unfold clauses that rebind w (precondition)",
   Length[Cases[deriv, binding[w], Infinity]] > 0];
 assert["substVv does NOT leak into a rebound binding",

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -8,8 +8,8 @@
    actions:
      vis["port"]          take a visible action by port name (no value)
      vis["port", value]   take a value-carrying input port, supplying value
-   The internal syncs (vAdd / pLoad / langRead, and chRead once CargoHold is
-   composed) are fired AUTOMATICALLY between steps by walkSteps' maximal-progress
+   The internal syncs (vAdd / goPractice / langRead / chRead — the CargoHold reads
+   and writes) are fired AUTOMATICALLY between steps by walkSteps' maximal-progress
    mode ("AutoTau" -> True) — so plans stay readable and robust as new internal
    syncs are added (no plan edits). (A plan MAY still force a specific sync with
    tau["chan"] when a step is genuinely ambiguous; none need to here.)
@@ -28,7 +28,7 @@
    NAMING / CLASSIFICATION (kebab-case keys):
      vs-*    : VocabStore-only ports (capture, edit, sort/filter/export)
      ps-*    : PracticeSession-only ports (load, navigate, record/score)
-     sync-*  : a single cross-component synchronisation (pLoad / vAdd) —
+     sync-*  : a single cross-component synchronisation (goPractice / vAdd) —
                only meaningful in the COMPOSED system, not VS/PS alone
      helm-*  : Helm session/language settings. Thin in ISOLATION (a lone Helm
                just flips a field); meaningful only in the COMPOSED system,
@@ -98,24 +98,41 @@ walkTests = <|
     vis["attempt_made"],                            (* langRead auto-fires for scoring *)
     vis["capture_vocab", "souris"]},                (* vAdd auto-fires (relay to VS) *)
 
-  (* --- sync: VS practise_vocab (FILTERED) -> PS load (pLoad) ----------
-     a filter is set, so practise_vocab sends the filtered subset. *)
-  "sync-pload" -> {
+  (* --- sync: VS practise_vocab (FILTERED) -> PS pull (goPractice+chRead) ---
+     a filter is set, so PS pulls then shapes with the filtered subset. *)
+  "sync-practise" -> {
     vis["open_vocab"],
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["set_filter", "ch"],
-    vis["practise_vocab"],                          (* pLoad auto-fires *)
+    vis["practise_vocab"],                          (* goPractice→chRead auto-fires *)
     vis["select_item", 0]},
 
-  (* --- sync: VS practise_vocab (ALL, no filter) -> PS load (pLoad) ----
-     no filter, so the SAME channel sends the whole vocab ("Load vocabulary").
+  (* --- sync: VS practise_vocab (ALL, no filter) -> PS pull (goPractice+chRead) ---
+     no filter, so the SAME signal makes PS pull the whole vocab.
      practiseList[entries, none] = all entries. *)
   "practise-all" -> {
     vis["open_vocab"],
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["add", <|"word" -> "chien", "translation" -> "dog"|>],
-    vis["practise_vocab"],                          (* pLoad auto-fires *)
+    vis["practise_vocab"],                          (* goPractice→chRead auto-fires *)
     vis["select_item", 1]},
+
+  (* --- PS PULL route: open_practice reads CargoHold, then load the whole vocab.
+     open_practice is the VISIBLE entry; the chRead pull auto-fires after it. --- *)
+  "ps-pull-all" -> {
+    vis["open_vocab"],
+    vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
+    vis["open_practice"],                           (* chRead auto-fires (PS pulls) *)
+    vis["load_vocab"],
+    vis["select_item", 0]},
+
+  (* --- PS PULL route, filtered: load_filtered carries the filter string --- *)
+  "ps-pull-filtered" -> {
+    vis["open_vocab"],
+    vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
+    vis["add", <|"word" -> "souris", "translation" -> "mouse"|>],
+    vis["open_practice"],                           (* chRead auto-fires (PS pulls) *)
+    vis["load_filtered", "ch"]},
 
   (* --- sync: VS autofill PULLS the language from Helm (langRead) ------
      The first BORROWED-DATA read: autofill needs the (source, target) pair to
@@ -156,7 +173,7 @@ walkTests = <|
     vis["open_vocab"],
     vis["set_filter", "ch"],
     vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
-    vis["practise_vocab"],                          (* pLoad auto-fires *)
+    vis["practise_vocab"],                          (* goPractice→chRead auto-fires *)
     vis["recording_made", "audio"],
     vis["attempt_made"],                            (* langRead auto-fires for scoring *)
     vis["capture_vocab", "souris"]}                 (* vAdd auto-fires (relay to VS) *)

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -50,6 +50,7 @@ walkTests = <|
 
   (* --- VocabStore: capture, dedup, sort, filter, export --------------- *)
   "vs-capture" -> {
+    vis["open_vocab"],                           (* enter the Vocabulary tab *)
     vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
     vis["add", <|"word" -> "chien", "translation" -> "dog"|>],
     vis["add", <|"word" -> "chat"|>],            (* dedup: bumps times_seen *)
@@ -59,6 +60,7 @@ walkTests = <|
 
   (* --- VocabStore: bulk import then sort/export ----------------------- *)
   "vs-import" -> {
+    vis["open_vocab"],
     vis["import_bulk", <|"contents" -> "(en,fr)\nsouris|mouse\nchien|dog",
                          "expectedTarget" -> "fr"|>],
     vis["set_sort", oldest],
@@ -66,6 +68,7 @@ walkTests = <|
 
   (* --- VocabStore: the per-entry edit surface ------------------------- *)
   "vs-edit" -> {
+    vis["open_vocab"],
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["begin_edit", 1],
     vis["update", <|"translation" -> "feline"|>],   (* in edit-mode *)
@@ -98,6 +101,7 @@ walkTests = <|
   (* --- sync: VS practise_vocab (FILTERED) -> PS load (pLoad) ----------
      a filter is set, so practise_vocab sends the filtered subset. *)
   "sync-pload" -> {
+    vis["open_vocab"],
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["set_filter", "ch"],
     vis["practise_vocab"],                          (* pLoad auto-fires *)
@@ -107,6 +111,7 @@ walkTests = <|
      no filter, so the SAME channel sends the whole vocab ("Load vocabulary").
      practiseList[entries, none] = all entries. *)
   "practise-all" -> {
+    vis["open_vocab"],
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["add", <|"word" -> "chien", "translation" -> "dog"|>],
     vis["practise_vocab"],                          (* pLoad auto-fires *)
@@ -117,6 +122,7 @@ walkTests = <|
      enrich, so it reads Helm's langRead as a prefix (internal tau in mioCore).
      Only meaningful in the COMPOSED system (Helm must be present to answer). *)
   "sync-langread" -> {
+    vis["open_vocab"],
     vis["add", <|"word" -> "chat", "translation" -> "cat"|>],
     vis["autofill", 1]},                            (* langRead auto-fires *)
 
@@ -125,7 +131,8 @@ walkTests = <|
     vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
     vis["recording_made", "audio"],
     vis["attempt_made"],                            (* langRead auto-fires for scoring *)
-    vis["capture_vocab", "chat"]},                  (* vAdd auto-fires (relay to VS) *)
+    vis["capture_vocab", "chat"],                   (* vAdd auto-fires -> CargoHold (direct) *)
+    vis["open_vocab"]},                             (* now view the captured word in the tab *)
 
   (* --- Helm: settings tour + the espeak-only set_speed guard ---------- *)
   "helm-settings" -> {
@@ -139,12 +146,14 @@ walkTests = <|
   "helm-then-capture" -> {
     vis["set_target", "pt"],          (* choose the material language code *)
     vis["set_source", "English"],
+    vis["open_vocab"],
     vis["add", <|"word" -> "casa", "translation" -> "house"|>],
     vis["set_sort", recent],
     vis["export"]},
 
   (* --- full end-to-end: both syncs in one run ------------------------- *)
   "full-roundtrip" -> {
+    vis["open_vocab"],
     vis["set_filter", "ch"],
     vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
     vis["practise_vocab"],                          (* pLoad auto-fires *)

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -288,7 +288,7 @@ stateDisplay[s_] := If[agentDefs =!= <||>, foldAgentDisplay[normalizeSC[s]], Sho
    built term, with the bare "view" renamed to decap[name]<>"View" to match the
    composition's relabelled pSView/vSView/helmView (relabel is a lazy wrapper
    under transVP, so we rename the name set directly). Dual (restricted) actions
-   vAdd/pLoad/langRead live in two
+   vAdd/goPractice/langRead/chRead live in two
    sorts, but they are internal taus in the composed system and never queried as
    named ports here, so the overlap is harmless. *)
 sortOf::usage = "sortOf[term] gives the set of port names (strings) appearing syntactically in a process term \[LongDash] a pure scan, no execution.";
@@ -529,7 +529,7 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                Spacer[4],
                Button["Run test \[FilledRightTriangle]",
                  (* "AutoTau" -> True : the plans list only external actions, so
-                    fire the internal syncs (vAdd/pLoad/langRead/chRead) for us *)
+                    fire the internal syncs (vAdd/goPractice/langRead/chRead) for us *)
                  Module[{w = walkSteps[tf, agent, walkTests[testSel], "AutoTau" -> True]},
                    hist = Most[w["states"]]; trace = eventLog[w];
                    cur = Last[w["states"]]; future = {}; inVals = <||>],


### PR DESCRIPTION
The external-store **(i)** migration in its final, visibly-guarded shape. **CargoHold** owns the vocab collection (single source of truth); **both VS and PS read it** — no component caches a borrowed snapshot.

## VocabStore — the `open_vocab` tab
VS holds no entries. A **visible `open_vocab`** (selecting the tab) → `chRead` the store → view/edit, looping each cycle. Writes route to CargoHold (`chUpsert`/`chImport`/`chRemove`/`chAmend`). Capture from practice writes the store **directly** (`PS.capture_vocab → vAdd → CargoHold`), not through the tab.

## PracticeSession — practise is a PULL, not a push (2nd commit)
PS no longer receives a pushed snapshot. Two visibly-guarded entries mirror `open_vocab`:
- **Pull** — `open_practice` (visible) → `chRead` → `PSBrowse{load_vocab, load_filtered(q)}` (the quick_practice "Load vocabulary"/"Load filtered" routes).
- **Signal** — VS's "Practise these" emits `goPractice!(filter)` — the **filter only** — and PS pulls the collection *fresh* (`chRead`) and shapes it. VS navigates away (returns to un-opened `open_vocab`, doesn't re-read), leaving PS's pull as the unique τ → deterministic hand-off.

`pLoad` (the data push) is **gone**, replaced by `goPractice`. `CargoHold.chRead!` is a self-loop output, answering VS and PS as separate τ syncs.

## Why visible-guarded
Each tab/mode carries its own **visible** first action (`open_vocab` / `open_practice` / `goPractice`), so the `chRead` is always the *second* action — no initial τ in the composition, so weak bisimilarity stays a **congruence** over `+`. No `ModeSelector` needed.

## Bug fixed in passing
`deleteFrom` gated `id_Integer` (free-binder no-op delete, carried from PR-1).

## Tests — 14/14 green
External ready set now `{helmView, load_material, open_practice, open_vocab, pSView, set_source, set_target, set_tts}` (VS ports appear after `open_vocab`). Suite re-greened against the new shape; `composition` checks both the signal (`goPractice`) and pull (`open_practice→chRead`) routes; `walk-tests` adds `ps-pull-all`/`ps-pull-filtered` (pass on both engines).

## Docs in lockstep
ARCHITECTURE (PS-pull §, borrowed-vs-owned), cargohold-recovery (two readers), vocabstore- & practice-session-recovery (amendments), PROVENANCE (supersession note), walk.md, function-recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)