### PR TITLE
spec: Story Reader — one narrative position, 3 modes, practice-from-story

### DIFF
--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -65,10 +65,12 @@
    ready transitions per providing agent. One source of truth for "who the
    components are" — see walk.wl componentPortMap. *)
 mioComponents =
-  {"PS"        -> call["PS", {}, 0, none, none],
-   "Vocab"        -> call["Vocab", signedIn, alpha, none, none],   (* (i): NO entries — they live in VocabTable *)
-   "Helm"      -> call["Helm", "English", "fr", google, 250],
-   "VocabTable" -> call["VocabTable", {}]};                    (* the persisted collection, owned here *)
+  {"PS"          -> call["PS", {}, 0, none, none],
+   "Vocab"       -> call["Vocab", signedIn, alpha, none, none],   (* (i): NO entries — they live in VocabTable *)
+   "Helm"        -> call["Helm", "English", "fr", google, 250],
+   "VocabTable"  -> call["VocabTable", {}],                       (* the persisted collection, owned here *)
+   "StoryReader" -> call["StoryReader", 0, 0, browse, none, none]};  (* narrative tab; practice mode
+       mirrors PSActive, capturing via vocabUpsert + scoring via langRead — no NEW restricted channels *)
 
 mioRestricted = {label["goPractice"], label["langRead"],
                  (* the VocabTable channels: the Vocab tab and PS read/write the store

--- a/spec/MiolingoSpec.wl
+++ b/spec/MiolingoSpec.wl
@@ -52,4 +52,5 @@ mioGet["PracticeSessionFunctions.wl"];
    either order; mioCore needs it now.) Helm is composed as a PURE PARALLEL
    agent — no control guard reads the language, so no restricted sync. *)
 mioGet["HelmFunctions.wl"];
+mioGet["StoryFunctions.wl"];   (* sceneOf (story-content boundary) + storyView *)
 mioGet["MioCore.wl"];

--- a/spec/PracticeSessionRecovered.wl
+++ b/spec/PracticeSessionRecovered.wl
@@ -83,24 +83,31 @@ defineAgent["PSBrowse", {es},
       call["PS", practiseList[es, filterBy[q]], 0, none, none]]]]
 
 
-(* --- domain ports for a non-empty queue --- *)
+(* --- domain ports for a non-empty queue ---
+   This is the practice LOOP (select/next/prev/record/score/capture). StoryReader's
+   practice mode (StoryReaderRecovered.wl, StoryPractice) runs the SAME interaction;
+   the two share their value-functions (targetOf, evaluate, scored/recorded) but the
+   loop SUMMANDS are written per-context. Factoring the summands into ONE shared
+   builder was attempted and abandoned — see story-reader-recovery.md "Why the loop
+   isn't a single shared definition": the engine's guard mechanism (prepBody Hold-
+   wraps the conditions that are syntactically present in a hand-written body, so
+   `Length[phrases]` / `rec === none` are never evaluated until step-time with
+   concrete params) does not compose with a builder-produced body. A flagged
+   boundary case (docs/CLAUDE.md: framework difficulty is research data).
+   NB on capture_vocab — a modelling artifact, NOT a behaviour to implement: the
+   capture . vocabUpsert! . PS precede chain means PS is mid-handoff between the
+   capture and the emit and offers no `view` (the pSView panel momentarily blanks
+   until the τ fires). L3 must treat capture-and-relay as ATOMIC — no view flicker. *)
 defineAgent["PSActive", {phrases, pos, rec, res},
   choice[
     precede[coLabel["clear_material"],
       call["PS", {}, 0, none, none]],
     precede[coLabel["select_item", binding[i]],
       call["PS", phrases, i, none, none]],
-    (* two-armed: no recording -> record; recording present -> check / remove *)
     if[rec === none,
       precede[coLabel["recording_made", binding[audio]],
         call["PS", phrases, pos, recorded[audio], none]],
       choice[
-        (* BORROWED DATA: scoring's ASR (recognisePhonemes) needs the target
-           language, which Helm OWNS. So attempt_made PULLS the (source, target)
-           pair fresh as a PREFIX \[LongDash] langRead?(lp), restricted to Helm's
-           langRead! in mioCore (an internal tau). No cached language => no
-           staleness. See ARCHITECTURE.md "Borrowed vs owned data". The pair is
-           passed into evaluate, which uses the target code for the ASR. *)
         precede[coLabel["attempt_made"],
           precede[coLabel["langRead", binding[lp]],
             call["PS", phrases, pos, rec,
@@ -113,13 +120,6 @@ defineAgent["PSActive", {phrases, pos, rec, res},
     if[pos > 0,
       precede[coLabel["prev_item_requested"],
         call["PS", phrases, pos - 1, none, none]]],
-    (* capture_vocab relays to Vocab on vocabUpsert (restricted in MioCore).
-       NB — modelling artifact, NOT a behaviour to implement: this is a precede
-       chain capture_vocab . vocabUpsert! . PS, so between the capture and the vocabUpsert
-       emit, PS is mid-handoff and offers no `view` (the pSView panel momentarily
-       disappears in the simulator until the vocabUpsert tau fires). An L3 implementation
-       must treat capture-and-relay as ATOMIC — no view flicker. The split exists
-       only because CCS makes the synchronous handoff explicit as two events. *)
     if[res =!= none,
       precede[coLabel["capture_vocab", binding[word]],
         precede[label["vocabUpsert", param[word]],

--- a/spec/StoryFunctions.wl
+++ b/spec/StoryFunctions.wl
@@ -1,0 +1,43 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — Story Reader value-functions
+   ---------------------------------------------------------------------
+   Bodies for the stubs StoryReaderRecovered.wl names: the scene-content
+   boundary (sceneOf) and the published projection (storyView). ADDITIVE;
+   load AFTER StoryReaderRecovered.wl. See spec/docs/story-reader-recovery.md.
+
+   sceneOf[scene] — the STORY-CONTENT BOUNDARY. In the app the scenes live in
+   per-language JSON files (story_tab.py:_extract_scene_phrases reads them) — an
+   external, read-only data source. Properly this is a `StoryLibrary` STORE agent
+   read across a port (parallel to VocabTable; see the Naming/store tier in
+   ARCHITECTURE.md) — DEFERRED this round to keep the focus on the interaction +
+   the practice-loop reuse. Until then sceneOf is a small in-spec FIXTURE standing
+   in for that store, shaped EXACTLY as _extract_scene_phrases returns
+   ({text, translation, ipa}) so the practice loop runs over it unchanged.
+   When the store lands, StoryReader gains a visible `open_story` entry guarding a
+   `storyRead` τ (the open_vocab / open_practice pattern), and sceneOf is replaced
+   by that pull. Marked here so the cloud/incompleteness inventory stays honest. *)
+sceneOf[0] := {
+  <|"text" -> "Bonjour", "translation" -> "Hello", "ipa" -> "bɔ̃ʒuʁ"|>,
+  <|"text" -> "Comment ça va?", "translation" -> "How are you?", "ipa" -> "kɔmɑ̃ sa va"|>};
+sceneOf[1] := {
+  <|"text" -> "Au revoir", "translation" -> "Goodbye", "ipa" -> "o ʁəvwaʁ"|>};
+sceneOf[_Integer] := {};
+
+
+(* storyView[scene, pos, mode, rec, res] — the read-only projection the tab
+   publishes; the skin renders it per mode (full ⇒ whole story; browse ⇒ scene +
+   parallel translation at pos; practice ⇒ item + recording/score). A projection,
+   never raw state. `item`/`score` reuse the PS shape so a skin can share render
+   code, mirroring the loop reuse. sceneOf is held _List so Length/targetOf only
+   compute once the scene is concrete. *)
+storyView[scene_, pos_, mode_, rec_, res_] := With[{phrases = sceneOf[scene]},
+  <|"scene" -> scene,
+    "mode" -> mode,
+    "pos" -> pos,
+    "count" -> Length[phrases],
+    "phrases" -> phrases,
+    "item" -> If[Length[phrases] > 0, targetOf[phrases, pos], None],
+    "hasRecording" -> (rec =!= none),
+    "score" -> Replace[res, {scored[r_] :> r, none -> None}]|>];

--- a/spec/StoryReaderRecovered.wl
+++ b/spec/StoryReaderRecovered.wl
@@ -1,0 +1,113 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — Story Reader, RECOVERED (UI-first)
+   ---------------------------------------------------------------------
+   Recovered from src/ui/story_tab.py (NOT invented). The Story Reader tab
+   lets the user explore one story three ways and practise pronunciation from
+   it WITHOUT leaving the story — see spec/docs/story-reader-recovery.md.
+
+   THE DESIGN (plan A, 2026-06-04). The app runs TWO copies of the practice
+   loop (Quick Practice, and Story "Practice Mode" via render_practice_interface
+   with key_prefix="story" + separate state) — "grew like Topsy". Here both run the
+   SAME interaction (StoryPractice mirrors PSActive; value-functions targetOf/
+   evaluate are shared). It is written per-context rather than one shared definition
+   — an engine constraint, see story-reader-recovery.md "Why the loop isn't a single
+   shared definition". And the app's three story views keep INDEPENDENT positions
+   (story_practice_index vs the scene-browser's); here StoryReader owns ONE narrative
+   position (scene, pos) and the three modes are affordances over it, so switching
+   mode PRESERVES the position. That divergence is a deliberate fix (flagged in
+   PROVENANCE).
+
+   STATE: StoryReader[scene, pos, mode, rec, res]
+     scene : Integer   which scene (sceneOf[scene] gives its phrases)
+     pos   : Integer   phrase index within the scene — the narrative position
+     mode  : full | browse | practice   the reading mode
+     rec   : none | recorded[audio]     (practice only)
+     res   : none | scored[r]           (practice only)
+
+   MODES (@src story_tab.py:348 the st.radio mode selector):
+     full     "📄 Full Story"   — view! the whole story; no phrase nav
+     browse   "🎬 Scene by Scene"— scene with parallel translation; phrase nav
+     practice "🎙️ Practice Mode" — the full practice loop over the scene phrases
+
+   Always available: view! (storyView), set_mode (PRESERVES scene,pos; clears
+   rec,res), select_scene (new scene ⇒ pos:=0). The mode-specific ports are
+   spliced via a bare call[...] summand (its transitions join the choice), gated
+   by the mode guard — same idiom as PS splicing PSActive.
+
+   The narrative position lives HERE; practice mode borrows it (StoryPractice
+   returns to StoryReader with the moved pos). So flipping browse↔practice keeps
+   your place — read scene 5, practise scene 5.
+
+   LOAD ORDER: after discipline.wl and the other recovered agents. storyView/sceneOf
+   bodies arrive in StoryFunctions.wl (loaded after, like the other *Functions.wl).
+   ===================================================================== *)
+
+defineAgent["StoryReader", {scene, pos, mode, rec, res},
+  choice[
+    (* @src story_tab.py:295 (render_story_reader) — the tab's published view *)
+    precede[label["view", param[storyView[scene, pos, mode, rec, res]]],
+      call["StoryReader", scene, pos, mode, rec, res]],
+    (* @src story_tab.py:348 — the mode radio. PRESERVES (scene,pos); leaving a
+       practice session clears its rec/res. *)
+    precede[coLabel["set_mode", binding[m]],
+      call["StoryReader", scene, pos, m, none, none]],
+    (* @src story_tab.py:193 — scene selector. New scene ⇒ position resets. *)
+    precede[coLabel["select_scene", binding[s]],
+      call["StoryReader", s, 0, mode, none, none]],
+    (* browse: scroll the scene with parallel translation (phrase nav only) *)
+    if[mode === browse, call["StoryBrowse", scene, pos]],
+    (* practice: the full record/score/capture loop over the scene's phrases *)
+    if[mode === practice, call["StoryPractice", scene, pos, rec, res]]]]
+
+
+(* --- browse mode: phrase navigation over the scene (no record/score) ---
+   Ports are story_-prefixed so they are DISTINCT controls from Quick Practice's
+   (the app uses key_prefix="story" for exactly this); successors return to
+   StoryReader in browse mode, so the narrative position is owned by StoryReader
+   and survives a mode switch. *)
+defineAgent["StoryBrowse", {scene, pos},
+  choice[
+    precede[coLabel["story_select_item", binding[i]],
+      call["StoryReader", scene, i, browse, none, none]],
+    if[pos < Length[sceneOf[scene]] - 1,
+      precede[coLabel["story_next_item_requested"],
+        call["StoryReader", scene, pos + 1, browse, none, none]]],
+    if[pos > 0,
+      precede[coLabel["story_prev_item_requested"],
+        call["StoryReader", scene, pos - 1, browse, none, none]]]]]
+
+
+(* --- practice mode: the practice loop over the scene's phrases ---
+   The SAME interaction as PSActive (the plan's reuse target), written per-context
+   (see PSActive's note + story-reader-recovery.md on why it isn't one shared
+   definition). Value-functions ARE shared (targetOf, evaluate). Capture relays to
+   VocabTable on vocabUpsert (the same store channel PS capture uses); scoring
+   borrows the language from Helm on langRead (a τ). Both stay UNPREFIXED — they are
+   the store / Helm channels, shared by design; only the user-facing inputs carry
+   story_. Successors return to StoryReader (practice mode), preserving (scene,pos). *)
+defineAgent["StoryPractice", {scene, pos, rec, res},
+  choice[
+    precede[coLabel["story_select_item", binding[i]],
+      call["StoryReader", scene, i, practice, none, none]],
+    if[rec === none,
+      precede[coLabel["story_recording_made", binding[audio]],
+        call["StoryReader", scene, pos, practice, recorded[audio], none]],
+      choice[
+        precede[coLabel["story_attempt_made"],
+          precede[coLabel["langRead", binding[lp]],
+            call["StoryReader", scene, pos, practice, rec,
+              scored[evaluate[targetOf[sceneOf[scene], pos], rec, lp]]]]],
+        precede[coLabel["story_clear_recording"],
+          call["StoryReader", scene, pos, practice, none, none]]]],
+    if[pos < Length[sceneOf[scene]] - 1,
+      precede[coLabel["story_next_item_requested"],
+        call["StoryReader", scene, pos + 1, practice, none, none]]],
+    if[pos > 0,
+      precede[coLabel["story_prev_item_requested"],
+        call["StoryReader", scene, pos - 1, practice, none, none]]],
+    if[res =!= none,
+      precede[coLabel["story_capture_vocab", binding[word]],
+        precede[label["vocabUpsert", param[word]],
+          call["StoryReader", scene, pos, practice, rec, res]]]]]]

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ Two tiers: **interactive agents** (UI-facing) and **store agents** (the data tie
 | Vocabulary tab | `Vocab` | Interactive — the gated viewer/editor (holds no data) | High — **recovered** |
 | Session / language | `Helm` | Interactive — finite-choice settings; **owns the (source, target) language pair** | **recovered + composed** ‡ |
 | Vocab store | `VocabTable` | **Store** — the persisted vocab collection (DB `vocab_entries`) | **recovered + composed** |
-| Story Reader | `StoryReader` | Interactive — narrative nav + 3 modes; practice mode reuses the factored `PracticeLoop` | Next |
+| Story Reader | `StoryReader` | Interactive — narrative nav + 3 modes; one shared position; practice mode mirrors `PSActive` | **recovered + composed** |
 | Stats / History † | (read projections over a `Ledger` store) | view ports backed by store queries — **not** standalone interactive agents | Medium |
 | Mode Navigation | ~~`ModeSelector`~~ **eliminated** | each mode carries its own *visible* entry instead | — |
 

--- a/spec/docs/PROVENANCE.md
+++ b/spec/docs/PROVENANCE.md
@@ -69,6 +69,7 @@ indexed below). Columns:
 | Vocab tab | `VocabRecovered.wl` | `vocab-tab-recovery.md` | recovered (table: back-fill pending) |
 | Helm (session/language) | `HelmRecovered.wl` | `helm-recovery.md` | recovered (table: back-fill pending) |
 | VocabTable (vocab store) | `VocabTableRecovered.wl` | `vocab-table-recovery.md` | recovered + composed |
+| Story Reader | `StoryReaderRecovered.wl` | `story-reader-recovery.md` | recovered + composed (one position — a deliberate deviation; loop written per-context, an engine boundary case) |
 
 (Names per the 2026-06-03 rename — ARCHITECTURE.md "Naming": the tab is `Vocab`, the store `VocabTable`; channels are `vocab*`. The worked example below predates the rename and keeps its original names.)
 

--- a/spec/docs/story-reader-recovery.md
+++ b/spec/docs/story-reader-recovery.md
@@ -1,0 +1,107 @@
+# Story Reader — recovery & design (plan A)
+
+`StoryReader` is the narrative tab: read one story three ways and **practise
+pronunciation from it without leaving the story**. Recovered from
+`src/ui/story_tab.py` (app src @ `504f8c8`), composed into `mioCore` (2026-06-04).
+
+## What the app does (and the two artifacts we fix)
+
+`render_story_reader` is a `st.radio` mode selector over one story:
+- **📄 Full Story** — the whole markdown.
+- **🎬 Scene by Scene** — a scene with parallel translation.
+- **🎙️ Practice Mode** — `render_scene_practice_mode`, which renders **the same**
+  `render_practice_interface(…, key_prefix="story")` Quick Practice uses.
+
+Two things "grew like Topsy" here, and the spec deliberately corrects both:
+
+1. **A duplicated practice loop.** Story practice re-renders the practice interface
+   with a `story` key-prefix and **separate** state (`story_practice_index`,
+   `story_last_result`). Same logic, copied. There is **no "return to story" action**
+   — practice never leaves the tab; the radio *is* the navigation.
+2. **Independent positions per mode.** Practice Mode's scene+index is independent of
+   the reading modes' position, so flipping modes doesn't keep your place in the
+   narrative.
+
+## The design (plan A)
+
+`StoryReader[scene, pos, mode, rec, res]` owns **one narrative position**
+`(scene, pos)`; the three modes are **affordances over it**:
+
+| mode | ports | @src |
+|---|---|---|
+| `full` | `view!` (whole story); `set_mode`, `select_scene` only | `story_tab.py:360` |
+| `browse` | `+ story_select_item / story_next / story_prev` (scroll the scene) | `story_tab.py:386` |
+| `practice` | `+` the full record→score→capture loop (`StoryPractice`) | `story_tab.py:165` |
+
+- **`set_mode` PRESERVES `(scene, pos)`** (and clears `rec,res`). So you read scene 5
+  in browse, flip to practice, and you're practising scene 5 — the coherence the app
+  loses. **This is a deliberate deviation from the app** (flagged in PROVENANCE).
+- `select_scene` resets `pos` to 0 (new scene). `view!` publishes `storyView`.
+- The mode-specific ports are spliced via a bare `call[…]` summand gated by the mode
+  guard — the same idiom PS uses to splice `PSActive`.
+- Capture from a scene → **`vocabUpsert` → VocabTable** (the SAME store channel Quick
+  Practice capture uses). Scoring borrows the language from Helm on **`langRead`**.
+  Both are existing restricted channels — StoryReader adds **no new** sync channels.
+- User-facing loop ports are **`story_`-prefixed** (`story_recording_made`, …) so they
+  are distinct controls from Quick Practice's (the app's `key_prefix="story"`); the
+  `vocabUpsert`/`langRead` channels stay unprefixed (store/Helm channels, shared).
+
+## Why the loop isn't a single shared definition
+
+The plan asked to *factor* the practice loop into ONE definition reused by PS and
+StoryReader. It was attempted (a `practiceLoopSummands` builder splicing a `Sequence`
+of guarded summands into both bodies) and **abandoned** — a genuine
+framework-boundary case (`docs/CLAUDE.md`: framework difficulty is research data):
+
+- `defineAgent` is `HoldRest`; the engine's two readers treat guard conditions
+  **oppositely**. `transNamed[if[c_,p_]] := If[c,…]` needs a NAKED, already-evaluated
+  Boolean (it reads the raw body, ReleaseHold'd with **concrete** params).
+  `buildSystem`/`transVP` build a **parametric** mu-term with params **symbolic**, and
+  rely on `prepBody` to `Hold`-wrap the conditions that are **syntactically present in
+  the stored body**.
+- A runtime/builder-produced body defeats this: `prepBody` runs **before** the builder
+  expands, so it cannot wrap the conditions. Expanding the builder at define-time
+  instead makes conditions visible — but then they evaluate against the bare param
+  **symbols**, and several reduce **wrongly**: `Length[phrases] ⇒ 0` (a symbol is
+  atomic), `rec === none ⇒ False`. Shape-gated predicates (`hasNext[_List,_]`,
+  `recEmpty`) dodge those, but other intermediate states then leave the guard
+  *stuck* (`If[unevaluated,…]`) under composition.
+
+Net: the engine's guard mechanism assumes conditions are **hand-written in the stored
+body**. So the loop is written per context (`PSActive`, `StoryPractice`), and reuse is
+at the **value-function** level (`targetOf`, `evaluate`, `scored`/`recorded`) — which
+is where the real logic lives. A single-definition factoring would need an engine
+change (e.g. `transNamed[if]` doing `ReleaseHold`, or a define-time code-gen macro
+with `Hold`-surgery). Recorded as a finding, not worked around silently.
+
+## The story-content boundary (`sceneOf`) — a deferred store
+
+A scene's phrases come from per-language JSON files (`_extract_scene_phrases`), an
+external read-only source. Properly this is a **`StoryLibrary` store agent** read
+across a port — parallel to `VocabTable` (ARCHITECTURE.md store tier) — **deferred**
+this round to keep the focus on the interaction + position design. `sceneOf` is a
+small in-spec **fixture** standing in for it, shaped exactly as the app returns
+(`{text, translation, ipa}`) so the loop runs over it unchanged. When the store lands,
+StoryReader gains a visible **`open_story`** entry guarding a `storyRead` τ (the
+`open_vocab`/`open_practice` pattern) and `sceneOf` becomes that pull. In the
+cloud/incompleteness inventory until then.
+
+## Provenance  (app src @ `504f8c8`)
+
+| Spec element | Kind | Source `file:line (fn)` | App construct | Note |
+|---|---|---|---|---|
+| `StoryReader[scene,pos,mode,rec,res]` | agent | `story_tab.py:295 (render_story_reader)` | the Story Reader tab | **faithful** — one tab, one narrative position. |
+| `set_mode` | port (in) | `story_tab.py:348 (st.radio)` | the mode selector | **faithful** — but PRESERVES position (app doesn't). **deviation**. |
+| `select_scene` | port (in) | `story_tab.py:193 (scene selectbox)` | scene picker | **faithful** — new scene ⇒ pos 0. |
+| `view! (storyView)` | port (out) | `render_full_story / render_scene_by_scene` | per-mode render | **faithful** — one projection, skin renders per mode. |
+| `StoryBrowse` nav | ports (in) | `story_tab.py:386 (render_scene_by_scene)` | scene scroll | **faithful** — `story_`-prefixed. |
+| `StoryPractice` loop | ports (in) | `story_tab.py:165 (render_scene_practice_mode)` → `render_practice_interface` | the practice pane | **simplified** — mirrors `PSActive`; one position, not a separate index. **deviation**. |
+| `story_capture_vocab → vocabUpsert` | sync (→ VocabTable τ) | `story_tab.py:55 (capture_vocab_entry)` | scene capture | **faithful** — direct store write, same channel as PS capture. |
+| `story_attempt_made → langRead` | sync (Helm τ) | scoring path | borrowed language | **faithful** — same borrow as PS scoring. |
+| `sceneOf[scene]` | value-fn (boundary) | `story_tab.py:80 (_extract_scene_phrases)` | per-language scene JSON | **deferred** — fixture now; a `StoryLibrary` store later. |
+
+### Verified
+`composition_test` (StoryReader/StoryBrowse/StoryPractice registered; settled ready
+set), `merge_defined_test` (story ports in the parity set), `grouping_test` (StoryReader
+a clean group), `walk_sequences_test` (`story-browse`, `story-practice` complete on both
+engines — the latter drives the `langRead` + `vocabUpsert` τs and position preservation).

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -80,5 +80,6 @@ loadRecoveredBase[] := (
   mioGet["PracticeSessionRecovered.wl"];
   mioGet["VocabRecovered.wl"];
   mioGet["HelmRecovered.wl"];    (* third recovered agent; MioCore composes it *)
-  mioGet["VocabTableRecovered.wl"]);   (* the external store; defined here, composed
+  mioGet["VocabTableRecovered.wl"];    (* the external store; defined here, composed
                                          into MioCore at the (i) migration (PR-2) *)
+  mioGet["StoryReaderRecovered.wl"]);  (* narrative tab; practice mode mirrors PSActive *)

--- a/spec/tests/composition_test.wls
+++ b/spec/tests/composition_test.wls
@@ -21,6 +21,7 @@ Print["Loading engine + spec (order matters: discipline before components,",
       " components before MioCore) ..."];
 loadEngine[];
 loadRecoveredBase[];
+mioGet["StoryFunctions.wl"];   (* sceneOf — StoryReader's nav guard reads Length[sceneOf[scene]] *)
 mioGet["MioCore.wl"];
 mioGet["walk.wl"];   (* walkSteps "AutoTau" + value-carrying vis[nm,val] for §4 *)
 
@@ -34,7 +35,8 @@ Print[bar];
 Print["1. AGENT REGISTRATION (agentDefs)"];
 Print[bar];
 need = {"PS", "PSActive", "PSBrowse", "Vocab", "VocabAuthed", "VocabNonEmpty",
-        "VocabEntryActions", "VocabEditActions", "Helm", "VocabTable"};
+        "VocabEntryActions", "VocabEditActions", "Helm", "VocabTable",
+        "StoryReader", "StoryBrowse", "StoryPractice"};
 (* MioCore is now a composed MU-TERM value (relabeled view!), not a
    defineAgent; it is stepped with transVP[MioCore], not call["MioCore"]. *)
 Do[Print["   ", StringPadRight[n, 16], KeyExistsQ[agentDefs, n] // ok], {n, need}];

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -50,12 +50,14 @@ assert["inputsFirst puts the coLabel (input) before the label (output)",
   MatchQ[First[First[inputsFirst[mix]]], coLabel[___]]];
 
 Print[hr]; Print["3. the SETTLED mioCore ready set partitions cleanly (no 'other')"]; Print[hr];
-(* settle the vocabRead tau (Vocab gates behind it under the (i) store form) so Vocab's
-   external ports are present; VocabTable's ports are all restricted (internal),
-   so they never appear in the external grouping *)
+(* Vocab gates behind open_vocab so it contributes that; StoryReader is live (browse
+   mode) so it contributes its view/mode/nav ports; PS (empty) and Helm contribute
+   too. VocabTable's ports are all restricted (internal τ), so it never appears in the
+   external grouping. *)
 sInit = Last[walkSteps[transVP, mioCore, {}, "AutoTau" -> True]["states"]];
 grp = GroupBy[readyTransitions[transVP, sInit], transGroup[pm, #] &];
-assert["groups are exactly {Vocab, PS, Helm}", Sort[Keys[grp]] === {"Helm", "PS", "Vocab"}];
+assert["groups are exactly {Vocab, PS, Helm, StoryReader}",
+  Sort[Keys[grp]] === {"Helm", "PS", "StoryReader", "Vocab"}];
 assert["no port falls into 'other'", ! KeyExistsQ[grp, "other"]];
 
 Print[hr]; Print["4. auto-grouping registry — walkUI groups known systems by default"]; Print[hr];

--- a/spec/tests/merge_defined_test.wls
+++ b/spec/tests/merge_defined_test.wls
@@ -26,6 +26,7 @@ Get[FileNameJoin[{ParentDirectory[DirectoryName[$InputFileName]], "paths.wl"}]];
 
 loadEngine[];
 loadRecoveredBase[];
+mioGet["StoryFunctions.wl"];   (* sceneOf — StoryReader's nav guard reads Length[sceneOf[scene]] *)
 mioGet["MioCore.wl"];
 
 hr = StringRepeat["=", 70];
@@ -44,11 +45,14 @@ settled[tf_, s0_]   := Last[walkSteps[tf, s0, {}, "AutoTau" -> True]["states"]];
 extNames[tf_, s_]   := Sort[portName /@ Select[First /@ tf[s], ! isTau[#] &]];
 muNames = extNames[transVP,   settled[transVP,   mioCore]];
 deNames = extNames[transNamed, settled[transNamed, mioCoreD]];
-(* Vocab now gates behind a VISIBLE open_vocab (the tab entry), so at the (stable)
-   initial state Vocab contributes only open_vocab — its CRUD/view appear once the
-   tab is opened. Helm's set_speed is espeak-only (tts=google). *)
+(* Vocab gates behind a VISIBLE open_vocab (the tab entry), so initially it
+   contributes only open_vocab. StoryReader starts in browse mode at scene 0 / pos 0,
+   so it contributes storyReaderView + set_mode + select_scene + story_select_item +
+   story_next_item_requested (story_prev guarded out at pos 0). Helm's set_speed is
+   espeak-only (tts=google). VocabTable's ports are all restricted (internal τ). *)
 expected = {"helmView", "load_material", "open_practice", "open_vocab", "pSView",
-            "set_source", "set_target", "set_tts"};
+            "select_scene", "set_mode", "set_source", "set_target", "set_tts",
+            "story_next_item_requested", "storyReaderView", "story_select_item"};
 
 Print[hr]; Print["1. EXTERNAL READY-SET PARITY (settled past the vocabRead τ)"]; Print[hr];
 Print["   merge       (transVP)   : ", InputForm[muNames]];

--- a/spec/tests/story_reader_test.wls
+++ b/spec/tests/story_reader_test.wls
@@ -1,0 +1,90 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/story_reader_test.wls
+   ---------------------------------------------------------------------
+   Behavioural assertions for StoryReader, AND a regression guard that
+   PracticeSession (PSActive) is unchanged by this PR — explicit ready-set
+   checks at representative states, not just "walk didn't get stuck".
+
+   Run headless:  wolframscript -file spec/tests/story_reader_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];   (* full spec, so sceneOf / storyView have bodies *)
+Get[$dir <> "walk.wl"];
+
+ok[b_]   := If[TrueQ[b], "OK", "*** FAIL ***"];
+allOk    = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+ports[s_] := Sort[ToString /@ portName /@ First /@ transNamed[s]];
+hr = StringRepeat["=", 70];
+ph2 = {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>,
+       <|"text" -> "chien", "translation" -> "dog", "ipa" -> "ʃjɛ̃"|>};
+sc  = <|"sim" -> 0.9|>;   (* a stand-in score value *)
+
+Print[hr]; Print["1. PS REGRESSION — PSActive ready sets are exactly as before"]; Print[hr];
+assert["PS active (2-phrase, pos 0, no rec): exact port set",
+  ports[call["PS", ph2, 0, none, none]] ===
+    {"clear_material", "goPractice", "load_material", "next_item_requested",
+     "open_practice", "recording_made", "select_item", "view"}];
+assert["PS pos 1 (last): prev present, next gone",
+  With[{p = ports[call["PS", ph2, 1, none, none]]},
+    MemberQ[p, "prev_item_requested"] && ! MemberQ[p, "next_item_requested"]]];
+assert["PS with recording: attempt_made + clear_recording, recording_made gone",
+  With[{p = ports[call["PS", ph2, 0, recorded["a"], none]]},
+    MemberQ[p, "attempt_made"] && MemberQ[p, "clear_recording"] && ! MemberQ[p, "recording_made"]]];
+assert["PS scored: capture_vocab present",
+  MemberQ[ports[call["PS", ph2, 0, recorded["a"], scored[sc]]], "capture_vocab"]];
+assert["PS empty: no loop ports (just view/load/open_practice/goPractice)",
+  ports[call["PS", {}, 0, none, none]] ===
+    {"goPractice", "load_material", "open_practice", "view"}];
+
+Print[hr]; Print["2. StoryReader per-mode port sets (scene 0 has 2 phrases)"]; Print[hr];
+assert["full mode: only set_mode / select_scene / view (no phrase nav)",
+  ports[call["StoryReader", 0, 0, full, none, none]] === {"select_scene", "set_mode", "view"}];
+assert["browse: story nav present, NO record/capture",
+  With[{p = ports[call["StoryReader", 0, 0, browse, none, none]]},
+    SubsetQ[p, {"story_select_item", "story_next_item_requested"}] &&
+    ! MemberQ[p, "story_recording_made"] && ! MemberQ[p, "story_capture_vocab"]]];
+assert["practice (no rec): story_recording_made present, no attempt/capture",
+  With[{p = ports[call["StoryReader", 0, 0, practice, none, none]]},
+    MemberQ[p, "story_recording_made"] && ! MemberQ[p, "story_attempt_made"] &&
+    ! MemberQ[p, "story_capture_vocab"]]];
+assert["practice (recorded): story_attempt_made + story_clear_recording, no recording_made",
+  With[{p = ports[call["StoryReader", 0, 0, practice, recorded["a"], none]]},
+    MemberQ[p, "story_attempt_made"] && MemberQ[p, "story_clear_recording"] &&
+    ! MemberQ[p, "story_recording_made"]]];
+assert["practice (scored): story_capture_vocab present",
+  MemberQ[ports[call["StoryReader", 0, 0, practice, recorded["a"], scored[sc]]], "story_capture_vocab"]];
+
+Print[hr]; Print["3. THE design property — mode switch PRESERVES (scene,pos)"]; Print[hr];
+sb = Last[walkSteps[transNamed, call["StoryReader", 0, 0, browse, none, none],
+        {vis["story_next_item_requested"]}]["states"]];
+assert["browse next -> (scene 0, pos 1)", sb === call["StoryReader", 0, 1, browse, none, none]];
+assert["set_mode practice PRESERVES (0,1)",
+  Last[walkSteps[transNamed, sb, {vis["set_mode", practice]}]["states"]] ===
+    call["StoryReader", 0, 1, practice, none, none]];
+assert["set_mode full PRESERVES (0,1)",
+  Last[walkSteps[transNamed, sb, {vis["set_mode", full]}]["states"]] ===
+    call["StoryReader", 0, 1, full, none, none]];
+assert["select_scene RESETS pos to 0",
+  Last[walkSteps[transNamed, sb, {vis["select_scene", 1]}]["states"]] ===
+    call["StoryReader", 1, 0, browse, none, none]];
+
+Print[hr]; Print["4. COMPOSED — story-practice capture reaches VocabTable"]; Print[hr];
+(* practise scene 0 phrase 0 (Bonjour), capture it; then open the vocab tab and
+   confirm the store now holds it (proves story_capture_vocab -> vocabUpsert -> VocabTable). *)
+wcap = walkSteps[transVP, mioCore,
+  {vis["set_mode", practice], vis["story_recording_made", "a"], vis["story_attempt_made"],
+   vis["story_capture_vocab", "Bonjour"], vis["open_vocab"]}, "AutoTau" -> True];
+lab[a_] := If[MatchQ[a, tag[\[Tau], _, ___]], a[[2]], portName[a]];
+assert["the capture relayed via vocabUpsert (a τ)", MemberQ[lab /@ wcap["actions"], "vocabUpsert"]];
+vp = Map[Identity, viewProjections[transVP, Last[wcap["states"]]]];
+(* addEntry lowercases the lookup "word" key (dedup) and keeps the original case in
+   "display_word" — so the captured "Bonjour" shows as display_word "Bonjour". *)
+assert["VocabTable now holds the captured word (visible via the vocab tab)",
+  KeyExistsQ[vp, "vocabView"] &&
+    MemberQ[#["display_word"] & /@ vp["vocabView"]["entries"], "Bonjour"]];
+
+Print[hr]; Print["ALL ASSERTIONS: ", ok[allOk]]; Print[hr];
+If[! allOk, Exit[1]];

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -134,6 +134,26 @@ walkTests = <|
     vis["open_practice"],                           (* vocabRead auto-fires (PS pulls) *)
     vis["load_filtered", "ch"]},
 
+  (* --- Story Reader: browse a scene, navigate, switch mode (position kept) ---
+     mode starts at browse (scene 0). Navigate, jump, then flip to full — the
+     narrative position is owned by StoryReader, so the mode switch preserves it. *)
+  "story-browse" -> {
+    vis["story_next_item_requested"],               (* pos 0 -> 1 *)
+    vis["story_select_item", 0],                    (* jump back to 0 *)
+    vis["set_mode", full],                          (* whole-story view; pos kept *)
+    vis["set_mode", browse]},
+
+  (* --- Story Reader: practise a scene phrase end-to-end ---
+     enter practice mode, record, score (langRead τ from Helm), capture to the
+     store (vocabUpsert τ to VocabTable — the SAME channel Quick Practice uses),
+     then advance. The practice loop is StoryReader's own (mirrors PSActive). *)
+  "story-practice" -> {
+    vis["set_mode", practice],
+    vis["story_recording_made", "audio"],
+    vis["story_attempt_made"],                      (* langRead auto-fires (score) *)
+    vis["story_capture_vocab", "Bonjour"],          (* vocabUpsert -> VocabTable *)
+    vis["story_next_item_requested"]},
+
   (* --- sync: Vocab autofill PULLS the language from Helm (langRead) ------
      The first BORROWED-DATA read: autofill needs the (source, target) pair to
      enrich, so it reads Helm's langRead as a prefix (internal tau in mioCore).


### PR DESCRIPTION
Recovers the **Story Reader** tab (`src/ui/story_tab.py`) and composes it into `mioCore` as the 5th component — **plan A**.

## Design
`StoryReader[scene, pos, mode, rec, res]` owns **one narrative position** `(scene, pos)`; the three modes are **affordances over it**:
- **full** — `view!` the whole story
- **browse** — scroll the scene with parallel translation (`story_select_item`/`next`/`prev`)
- **practice** — the full record→score→capture loop (`StoryPractice`)

**`set_mode` preserves `(scene, pos)`** — read scene 5 in browse, flip to practice, you're practising scene 5. The app keeps *independent* positions per mode and *duplicates* the practice loop (`render_practice_interface(key_prefix="story")`); both are deliberately corrected.

## Composition — no new channels
Practice captures via **`vocabUpsert` → VocabTable** (the same store channel Quick Practice uses) and scores via **`langRead`** borrowed from Helm. User-facing loop ports are `story_`-prefixed (distinct controls, per the app's `key_prefix`); the store/Helm channels stay shared. `sceneOf` (in `StoryFunctions.wl`) is the story-content boundary — a fixture standing in for a future **`StoryLibrary`** store (deferred, like `Ledger`).

## Flagged boundary case (research data)
The plan asked to *factor* the practice loop into one shared definition. It was attempted and **abandoned** — the engine's guard mechanism assumes conditions are **hand-written in the stored body** (`prepBody` `Hold`-wraps them for the mu-term reader; `transNamed` reads them naked), which a runtime/builder body defeats (`Length[symbol]⇒0`, `rec===none⇒False`, or stuck guards under composition). So the loop is written per-context; **reuse is at the value-function level** (`targetOf`, `evaluate`). Full analysis in `story-reader-recovery.md` → "Why the loop isn't a single shared definition" (and `docs/CLAUDE.md`: framework difficulty is research data). A single-definition factoring would need an engine change.

## Tests — 14/14
`composition` (3 story agents + `StoryFunctions` load), `merge_defined` (story ports in the parity set), `grouping` (StoryReader a clean group), `walk_sequences` (**`story-browse`** + **`story-practice`** complete on both engines — the latter drives the `langRead` + `vocabUpsert` τs and position preservation).

Docs in lockstep: new `story-reader-recovery.md`, ARCHITECTURE inventory (StoryReader recovered+composed), PROVENANCE index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)