### PR TITLE
walk: Run-trace field — type and run your own plan

### DIFF
--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -124,7 +124,7 @@ Kebab-case keys, prefixed by scope:
 |---|---|---|
 | `vs-*`   | Vocab-only ports | `vs-capture`, `vs-import`, `vs-edit` |
 | `ps-*`   | PracticeSession-only ports | `ps-navigate`, `ps-score` |
-| `sync-*` | one cross-component sync (composed-only) | `sync-pload`, `sync-vadd` |
+| `sync-*` | one cross-component sync (composed-only) | `sync-practise`, `sync-vadd` |
 | `full-*` | end-to-end, both syncs | `full-roundtrip` |
 
 Together they exercise **every** Vocab and PS port and both syncs.
@@ -136,6 +136,41 @@ values (quote strings, Enum symbols for sort, integers for ids, Associations for
 payloads). **The standing rule:** it must run to completion on *both* `mioCore`
 (`transVP`) and `mioCoreD` (`transNamed`). `tests/walk_sequences_test.wls`
 enforces this for every sequence; run it after editing the batch.
+
+### Typing your own trace (the `Trace:` field)
+
+To run a one-off trace **without** adding it to `walkTests`, type a plan straight
+into the **`Trace:`** field and click **`Run trace`**. It's the *same format* as a
+`walkTests` entry — a Wolfram list of plan entries:
+
+| entry | meaning | example |
+|---|---|---|
+| `vis["port"]` | a visible action, no value | `vis["story_attempt_made"]` |
+| `vis["port", value]` | a value-carrying input | `vis["set_mode", practice]`, `vis["select_item", 0]` |
+| `tau["chan"]` | force one internal sync (rarely needed) | `tau["vocabRead"]` |
+
+**You normally do NOT type the τ's.** Run trace uses maximal progress (`AutoTau`):
+the internal synchronisations (`vocabUpsert`, `goPractice`, `langRead`, `vocabRead`)
+fire automatically *between* your visible actions. List only what a *user* would do.
+(`tau["chan"]` is there only for the rare case where two internal syncs are both
+enabled and you want to force a specific one.)
+
+Values follow the data: strings in quotes (`"chat"`); the sort/mode **enum symbols**
+bare (`practice`, `browse`, `alpha`); integers for indices/ids (`0`); Associations
+for payloads (`<|"word" -> "chat"|>`); and a *list* of phrase Associations for
+`load_material`. Example — load a word, practise it, capture it:
+
+```wolfram
+{vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
+ vis["recording_made", "audio"],
+ vis["attempt_made"],
+ vis["capture_vocab", "chat"]}
+```
+
+The trace **runs from the initial state** (like `Run test`), so it's fresh and
+repeatable. The status text beside the button shows the parsed action count, or warns
+if what you typed isn't a list of `vis[…]`/`tau[…]`. The **Short trace** checkbox
+truncates bulky values in the event log.
 
 ---
 

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -38,7 +38,7 @@ viewProjections::usage = "viewProjections[tf, s] gives <|portName -> projectionV
 dataView::usage = "dataView[tf, s] renders the state's published projections through the data-compaction grid (linearizeGrid of the computed projection).";
 traceView::usage = "traceView[traceSymbol] renders the condensed event log of a walk trace (HoldFirst) with a Copy button.";
 stateDisplay::usage = "stateDisplay[s] gives a compact render of the CCS process state s (foldAgentDisplay \:043e normalizeSC) \[LongDash] where you are / where a transition leads.";
-walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests, step Back/Forward through a run, and record a trace. Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
+walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests (\"Run test\") OR an ad-hoc trace you type in the \"Trace:\" field (\"Run trace\"), step Back/Forward through a run, and record a trace. The Trace field takes a plan — a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"] — and runs it from the initial agent with AutoTau on (list only external actions; the internal τ's fire automatically). Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
 
 (* ---------------------------------------------------------------------
    readyTransitions[tf, s] : the enabled transitions at state s as a list
@@ -416,7 +416,8 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
   DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
      maxprog = False, stateOpen = False, cloudOpen = False,
      shortTrace = True, prevCloudActive = cloudActiveNames[tf, agent],
-     testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None]},
+     testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None],
+     userPlan = ""},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
         Framed[Column[{
@@ -561,12 +562,38 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                    cur = Last[w["states"]]; future = {}; inVals = <||>],
                  Enabled -> Dynamic[ValueQ[walkTests] && KeyExistsQ[walkTests, testSel]]]}],
 
+          (* Run an AD-HOC trace YOU type — a list of vis[…] / tau[…] entries. Runs
+             FROM THE INITIAL AGENT with "AutoTau" -> True, so you list only the
+             EXTERNAL (visible) actions and the internal syncs (the τ's) fire for you.
+             Same plan format as walkTests / "Run test". See walk.md "Typing your own
+             trace" for the syntax. The status text shows the parsed action count, or
+             a warning if it isn't a list of vis[…]/tau[…]. *)
+          Row[{Style["Trace: ", Bold, GrayLevel[0.4]], Spacer[4],
+               InputField[Dynamic[userPlan], String, FieldSize -> {44, 1},
+                 FieldHint -> "{vis[\"set_mode\", practice], vis[\"story_recording_made\", \"a\"], vis[\"story_attempt_made\"]}"],
+               Spacer[4],
+               Button["Run trace \[FilledRightTriangle]",
+                 Module[{plan = Quiet[ToExpression[userPlan]]},
+                   If[ListQ[plan],
+                     Module[{w = walkSteps[tf, agent, plan, "AutoTau" -> True]},
+                       hist = Most[w["states"]]; trace = eventLog[w];
+                       cur = Last[w["states"]]; future = {}; inVals = <||>]]],
+                 Enabled -> Dynamic[StringQ[userPlan] && StringTrim[userPlan] =!= ""]],
+               Spacer[6],
+               Dynamic[With[{p = Quiet[ToExpression[userPlan]]},
+                 Which[
+                   ! StringQ[userPlan] || StringTrim[userPlan] === "", "",
+                   ListQ[p], Style[ToString[Length[p]] <> " actions", Darker[Green], 10],
+                   True, Style["\[WarningSign] not a list of vis[…]/tau[…]", Darker[Red], 10]]]]}],
+          Style["  list EXTERNAL actions only — the τ's auto-fire. vis[\"port\"] · vis[\"port\", value] · (rarely) tau[\"chan\"]; runs from the initial state.",
+                GrayLevel[0.45], 10],
+
           Row[{Checkbox[Dynamic[shortTrace]], Spacer[4],
                Style["Short trace values (truncate bulky data)", GrayLevel[0.35], 11]}],
           traceView[trace, shortTrace]
 
         }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
-      TrackedSymbols :> {cur, inVals, testSel, future, maxprog, shortTrace}]]]];
+      TrackedSymbols :> {cur, inVals, testSel, future, maxprog, shortTrace, userPlan}]]]];
 
 
 (* --- register the miolingo systems so walkUI[mioCore] / walkUI[mioCoreD] GROUP


### PR DESCRIPTION
Adds the load/run-your-own-trace control you asked for, so you can test interactively without going through the headless test routines.

## What it adds
In `walkUI`, beside the existing **Run test** menu: a **`Trace:`** input field + **`Run trace ▶`** button. Type a plan and run it.

- Same format as `walkTests`: a list of `vis["port"]` / `vis["port", value]` / `tau["chan"]`.
- Runs **from the initial agent** with `AutoTau` on — so you type only the **external (visible)** actions and the internal τ's (`vocabUpsert`/`goPractice`/`langRead`/`vocabRead`) fire automatically. You don't have to know which τ's to include.
- A status text shows the parsed action count, or warns `⚠ not a list of vis[…]/tau[…]`. Malformed input never crashes (guarded by `ListQ`).

Example to paste:
```wolfram
{vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
 vis["recording_made", "audio"], vis["attempt_made"], vis["capture_vocab", "chat"]}
```

## Documentation
You specifically asked for syntax docs. `walk.md` gains a **"Typing your own trace"** section: the entry table, the **"you normally don't type the τ's"** rule (with *why*), the value conventions (quoted strings, bare enum symbols like `practice`, integer ids, Association payloads, a list for `load_material`), a worked example, and the runs-from-initial note. `walkUI::usage` updated too.

## Verified (headless)
`walk.wl` loads; the exact parse-and-run mechanic the button uses runs a 4-action story plan with `langRead`/`vocabUpsert` auto-fired; malformed input → non-list (warn, no crash). `walk_test` + `walk_sequences_test` green.

Independent of #172 (touches only `walk.wl` + `walk.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)