### PR TITLE
walk: Copy trace ↔ Run trace round-trip, with auto/manual-τ symmetry

### DIFF
--- a/spec/docs/walk.md
+++ b/spec/docs/walk.md
@@ -147,18 +147,27 @@ into the **`Trace:`** field and click **`Run trace`**. It's the *same format* as
 |---|---|---|
 | `vis["port"]` | a visible action, no value | `vis["story_attempt_made"]` |
 | `vis["port", value]` | a value-carrying input | `vis["set_mode", practice]`, `vis["select_item", 0]` |
-| `tau["chan"]` | force one internal sync (rarely needed) | `tau["vocabRead"]` |
+| `tau["chan"]` | an internal sync | `tau["langRead"]`, `tau["vocabUpsert"]` |
 
-**You normally do NOT type the τ's.** Run trace uses maximal progress (`AutoTau`):
-the internal synchronisations (`vocabUpsert`, `goPractice`, `langRead`, `vocabRead`)
-fire automatically *between* your visible actions. List only what a *user* would do.
-(`tau["chan"]` is there only for the rare case where two internal syncs are both
-enabled and you want to force a specific one.)
+**Run trace honours the Auto-advance checkbox — the same auto-/manual-τ choice you
+have when stepping by hand.** This is the key symmetry: the τ's behave in a trace
+exactly as they do when you click through the transitions.
+
+- **Box ticked (auto-τ, maximal progress)** — list only what a *user* does. The
+  internal syncs (`vocabUpsert`, `goPractice`, `langRead`, `vocabRead`) fire for you
+  *between* your visible actions. **Any `tau[…]` you pasted is dropped** (it would
+  otherwise double-fire) — the status shows *"N τ ignored (auto mode)"*.
+- **Box clear (manual-τ)** — the `tau[…]` entries **are driven literally**, in
+  order, so a recorded trace replays step-for-step. An external-only plan in this
+  mode behaves like manual stepping without clicking the τ rows: the syncs simply
+  don't fire (tick the box to auto-fire them).
+
+(`Run test` is always auto — its `walkTests` are curated external-only plans.)
 
 Values follow the data: strings in quotes (`"chat"`); the sort/mode **enum symbols**
 bare (`practice`, `browse`, `alpha`); integers for indices/ids (`0`); Associations
 for payloads (`<|"word" -> "chat"|>`); and a *list* of phrase Associations for
-`load_material`. Example — load a word, practise it, capture it:
+`load_material`. Example — load a word, practise it, capture it (auto-τ mode):
 
 ```wolfram
 {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
@@ -167,10 +176,18 @@ for payloads (`<|"word" -> "chat"|>`); and a *list* of phrase Associations for
  vis["capture_vocab", "chat"]}
 ```
 
+**Round-trip with Copy trace.** The **Copy trace** button copies the *current* run
+as an executable plan (`traceToPlan`) — the **full** trace including the τ's, with
+values inline. Paste it straight back into the `Trace:` field and it reproduces the
+run: in **manual-τ** mode literally (τ's and all); in **auto-τ** mode with the τ's
+auto-ignored. (Pasting a raw event-log Association list works too — Run trace
+auto-converts it.)
+
 The trace **runs from the initial state** (like `Run test`), so it's fresh and
-repeatable. The status text beside the button shows the parsed action count, or warns
-if what you typed isn't a list of `vis[…]`/`tau[…]`. The **Short trace** checkbox
-truncates bulky values in the event log.
+repeatable. The status text beside the button shows the parsed action count and the
+τ-handling for the current mode, or warns if what you typed isn't a list of
+`vis[…]`/`tau[…]`. The **Short trace** checkbox truncates bulky values in the event
+log.
 
 ---
 

--- a/spec/tests/walk_test.wls
+++ b/spec/tests/walk_test.wls
@@ -97,6 +97,42 @@ assert["final state carries the supplied value",
 assert["recorded event carries the concrete value",
   eventOf[First[w1["actions"]]]["value"] === {phr}];
 
+Print[hr]; Print["7. Copy/Run-trace round-trip : traceToPlan + normalisePlan, both \[Tau]-modes"]; Print[hr];
+(* A run WITH internal taus (story practice + capture): set_mode, record, attempt
+   (-> langRead tau), capture (-> vocabUpsert tau). traceToPlan must recover an
+   executable plan that reproduces it in EITHER tau-mode \[LongDash] the symmetry the Run-
+   trace field gives the user via the Auto-advance checkbox. *)
+obs[s_] := Sort[Normal[Map[Identity, viewProjections[transVP, s]]]];
+tracePlan = {vis["set_mode", practice], vis["story_recording_made", "aud"],
+             vis["story_attempt_made"], vis["story_capture_vocab", "Bonjour"]};
+runA  = walkSteps[transVP, mioCore, tracePlan, "AutoTau" -> True];   (* the recorded run *)
+plan2 = traceToPlan[eventLog[runA]];
+assert["traceToPlan keeps the WHOLE log (vis + tau), nothing dropped",
+  Length[plan2] === Length[eventLog[runA]]];
+assert["traceToPlan keeps the internal taus as tau[chan]", Count[plan2, tau[_]] > 0];
+assert["traceToPlan carries values inline (set_mode practice)",
+  MemberQ[plan2, vis["set_mode", practice]]];
+(* MANUAL-tau replay: drive the tau[…] literally (AutoTau off) -> identical run *)
+runMan = walkSteps[transVP, mioCore, plan2, "AutoTau" -> False];
+assert["MANUAL-\[Tau] replay: event log === original", eventLog[runMan] === eventLog[runA]];
+assert["MANUAL-\[Tau] replay: views === original",
+  obs[Last[runMan["states"]]] === obs[Last[runA["states"]]]];
+(* AUTO-tau replay: strip the taus (as Run trace does in auto mode); AutoTau refires *)
+runAut = walkSteps[transVP, mioCore, DeleteCases[plan2, tau[_]], "AutoTau" -> True];
+assert["AUTO-\[Tau] replay (taus stripped): event log === original",
+  eventLog[runAut] === eventLog[runA]];
+assert["AUTO-\[Tau] replay: views === original",
+  obs[Last[runAut["states"]]] === obs[Last[runA["states"]]]];
+(* normalisePlan : accept a typed plan, convert a pasted event log, reject junk *)
+assert["normalisePlan: a vis/tau plan passes through unchanged",
+  normalisePlan[tracePlan] === tracePlan];
+assert["normalisePlan: a pasted event log -> traceToPlan",
+  normalisePlan[eventLog[runA]] === plan2];
+assert["normalisePlan: a non-plan list -> $Failed (status can warn)",
+  normalisePlan[{1, 2, 3}] === $Failed];
+assert["normalisePlan: a non-list -> $Failed", normalisePlan["nope"] === $Failed];
+assert["normalisePlan: {} -> {}", normalisePlan[{}] === {}];
+
 Print[hr];
 Print["ALL ASSERTIONS: ", ok[allOk]];
 Print[hr];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -36,9 +36,11 @@ readyInputs::usage = "readyInputs[tf, s] gives the ready transitions that are va
 supplyValue::usage = "supplyValue[trans, val] inserts a user value into an input transition's binder via the engine's substVv (scope-aware), returning {action, derivative-with-value}. No validation: the value is the user's responsibility.";
 viewProjections::usage = "viewProjections[tf, s] gives <|portName -> projectionValue|> for the published read-only view ports at s (the bare \"view\" or a relabelled \"{Agent}View\").";
 dataView::usage = "dataView[tf, s] renders the state's published projections through the data-compaction grid (linearizeGrid of the computed projection).";
-traceView::usage = "traceView[traceSymbol] renders the condensed event log of a walk trace (HoldFirst) with a Copy button.";
+traceView::usage = "traceView[traceSymbol] renders the condensed event log of a walk trace (HoldFirst) with a Copy button. Copy emits the trace as an EXECUTABLE plan (traceToPlan), so it pastes straight back into the Run-trace field.";
+traceToPlan::usage = "traceToPlan[trace] turns a recorded event log (list of eventOf Associations) BACK into an executable plan \[LongDash] a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"] entries, values inline. The FULL trace is kept, INCLUDING the internal \[Tau]'s (as tau[chan]): in manual-\[Tau] mode they replay literally; in auto-\[Tau] mode Run trace drops them and re-fires them itself. Inverse of eventLog for replay.";
+normalisePlan::usage = "normalisePlan[expr] canonicalises a typed/pasted trace to a plan list, or returns $Failed. Accepts a list of vis/tau entries as-is, OR a pasted raw event log (list of eventOf Associations) which it converts via traceToPlan.";
 stateDisplay::usage = "stateDisplay[s] gives a compact render of the CCS process state s (foldAgentDisplay \:043e normalizeSC) \[LongDash] where you are / where a transition leads.";
-walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests (\"Run test\") OR an ad-hoc trace you type in the \"Trace:\" field (\"Run trace\"), step Back/Forward through a run, and record a trace. The Trace field takes a plan — a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"] — and runs it from the initial agent with AutoTau on (list only external actions; the internal τ's fire automatically). Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
+walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests (\"Run test\") OR an ad-hoc trace you type in the \"Trace:\" field (\"Run trace\"), step Back/Forward through a run, and record a trace. The Trace field takes a plan — a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"], or a pasted Copy-trace — and runs it from the initial agent, HONOURING the maximal-progress checkbox just like manual stepping: box ON = auto-τ (external actions only, pasted τ's dropped); box OFF = manual-τ (the τ's in the trace are driven literally). Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
 
 (* ---------------------------------------------------------------------
    readyTransitions[tf, s] : the enabled transitions at state s as a list
@@ -262,10 +264,42 @@ eventRow[e_Association, short_] := Row[{
   Style[Switch[e["polarity"], "out", "!", "in", "?", _, ""], GrayLevel[0.5]],
   If[e["value"] === None, "", Row[{"\[ThinSpace]", renderTraceVal[e["value"], short]}]]}];
 
+(* traceToPlan[trace] : recover an EXECUTABLE plan from a recorded event log (the
+   list of eventOf Associations that `trace` holds), so a copied trace pastes back
+   into the Run-trace field and reproduces the run. Values are carried inline (the
+   singleton binder is unwrapped) so value-driven runs reproduce faithfully. The
+   FULL log is kept, INCLUDING the internal \[Tau]'s as tau[chan] \[LongDash] mirroring the
+   manual/auto-\[Tau] symmetry: in MANUAL-\[Tau] mode the tau[…] entries replay literally;
+   in AUTO-\[Tau] mode Run trace drops them (maximal progress re-fires them). This is
+   the structured, value-preserving analogue of parseEventLog (which works from the
+   string form and ignores values). *)
+traceToPlan[trace_List] := Map[
+  Which[
+    ! TrueQ[#["isVisible"]],                          tau[#["port"]],   (* a \[Tau]: keep channel *)
+    #["value"] === None || #["value"] === {},         vis[#["port"]],
+    MatchQ[#["value"], {_}],                          vis[#["port"], First[#["value"]]],
+    True,                                             vis[#["port"]]] &,  (* multi-binder: symbolic *)
+  trace];
+
+(* plan validity / normalisation for the Run-trace field. A plan ENTRY is one of
+   vis["p"] | vis["p", v] | tau["c"]; an event-log ENTRY is an eventOf Association.
+   normalisePlan accepts a typed plan as-is, OR a pasted raw event log (converted
+   via traceToPlan), so an old-style Copy still runs; anything else is $Failed (so
+   the status text can warn instead of silently passing a non-plan list). *)
+planEntryQ[e_]  := MatchQ[e, vis[_String] | vis[_String, _] | tau[_String]];
+eventAssocQ[e_] := MatchQ[e, _Association] && KeyExistsQ[e, "isVisible"];
+normalisePlan[expr_] := Which[
+  ! ListQ[expr],                $Failed,
+  expr === {},                  {},
+  AllTrue[expr, planEntryQ],    expr,
+  AllTrue[expr, eventAssocQ],   traceToPlan[expr],
+  True,                         $Failed];
+
 (* traceView[trace, short] : the trace rendered as naked-expression rows (not a
    string), so it copies/reads cleanly. `short` (a Bool, tracked by walkUI) wraps
-   bulky values in Short. eventLogForm (string form) is kept for trace round-trip
-   (trace_io_test) and Copy. *)
+   bulky values in Short. Copy emits the EXECUTABLE plan (traceToPlan) so it round-
+   trips into Run trace; eventLogForm (string form) is kept for the text round-trip
+   (trace_io_test). *)
 SetAttributes[traceView, HoldFirst];
 traceView[trace_, short_ : False] := Column[{
   Style["Trace (condensed event log)", Bold],
@@ -273,7 +307,9 @@ traceView[trace_, short_ : False] := Column[{
         Style["(no steps yet)", Italic, GrayLevel[0.5]],
         Column[eventRow[#, short] & /@ trace, Spacings -> 0.15]]],
     {Automatic, 110}, Scrollbars -> Automatic],
-  Button["Copy trace \[SelectionPlaceholder]", CopyToClipboard[trace],
+  (* Copy the EXECUTABLE plan (traceToPlan), not the raw Association log: it pastes
+     straight back into the Run-trace field AND is the readable vis/tau form. *)
+  Button["Copy trace \[SelectionPlaceholder]", CopyToClipboard[traceToPlan[trace]],
     Enabled -> Dynamic[trace =!= {}]]}];
 
 (* ---------------------------------------------------------------------
@@ -562,31 +598,47 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                    cur = Last[w["states"]]; future = {}; inVals = <||>],
                  Enabled -> Dynamic[ValueQ[walkTests] && KeyExistsQ[walkTests, testSel]]]}],
 
-          (* Run an AD-HOC trace YOU type — a list of vis[…] / tau[…] entries. Runs
-             FROM THE INITIAL AGENT with "AutoTau" -> True, so you list only the
-             EXTERNAL (visible) actions and the internal syncs (the τ's) fire for you.
-             Same plan format as walkTests / "Run test". See walk.md "Typing your own
-             trace" for the syntax. The status text shows the parsed action count, or
-             a warning if it isn't a list of vis[…]/tau[…]. *)
+          (* Run an AD-HOC trace YOU type (or a Copy-trace you paste back) — a list of
+             vis[…] / tau[…] entries, or a raw event log (auto-converted). Runs FROM
+             THE INITIAL AGENT and HONOURS the maximal-progress checkbox, exactly like
+             manual stepping — so the trace path gives the SAME auto-/manual-τ choice:
+               • box ON  (auto)   : "AutoTau" -> True; any tau[…] you pasted are
+                                    DROPPED (maximal progress re-fires them) — noted
+                                    in the status as "N τ ignored".
+               • box OFF (manual) : "AutoTau" -> False; the tau[…] entries ARE driven,
+                                    so a full recorded trace replays literally.
+             (Run test, by contrast, is always auto — its walkTests are curated
+             external-only plans.) See walk.md "Typing your own trace". *)
           Row[{Style["Trace: ", Bold, GrayLevel[0.4]], Spacer[4],
                InputField[Dynamic[userPlan], String, FieldSize -> {44, 1},
                  FieldHint -> "{vis[\"set_mode\", practice], vis[\"story_recording_made\", \"a\"], vis[\"story_attempt_made\"]}"],
                Spacer[4],
                Button["Run trace \[FilledRightTriangle]",
-                 Module[{plan = Quiet[ToExpression[userPlan]]},
+                 Module[{plan = normalisePlan[Quiet[ToExpression[userPlan]]], run},
                    If[ListQ[plan],
-                     Module[{w = walkSteps[tf, agent, plan, "AutoTau" -> True]},
+                     (* auto mode: strip pasted τ's so they don't double-fire/stall *)
+                     run = If[TrueQ[maxprog], DeleteCases[plan, tau[_]], plan];
+                     Module[{w = walkSteps[tf, agent, run, "AutoTau" -> TrueQ[maxprog]]},
                        hist = Most[w["states"]]; trace = eventLog[w];
                        cur = Last[w["states"]]; future = {}; inVals = <||>]]],
                  Enabled -> Dynamic[StringQ[userPlan] && StringTrim[userPlan] =!= ""]],
                Spacer[6],
-               Dynamic[With[{p = Quiet[ToExpression[userPlan]]},
+               Dynamic[With[{plan = normalisePlan[Quiet[ToExpression[userPlan]]]},
                  Which[
                    ! StringQ[userPlan] || StringTrim[userPlan] === "", "",
-                   ListQ[p], Style[ToString[Length[p]] <> " actions", Darker[Green], 10],
-                   True, Style["\[WarningSign] not a list of vis[…]/tau[…]", Darker[Red], 10]]]]}],
-          Style["  list EXTERNAL actions only — the τ's auto-fire. vis[\"port\"] · vis[\"port\", value] · (rarely) tau[\"chan\"]; runs from the initial state.",
-                GrayLevel[0.45], 10],
+                   plan === $Failed, Style["\[WarningSign] not a list of vis[…]/tau[…]", Darker[Red], 10],
+                   True, With[{ntau = Count[plan, tau[_]]},
+                     Row[{Style[ToString[Length[plan]] <> " actions", Darker[Green], 10],
+                          If[ntau > 0,
+                            Style["  · " <> ToString[ntau] <> If[TrueQ[maxprog],
+                                    " \[Tau] ignored (auto mode)", " \[Tau] driven (manual mode)"],
+                                  GrayLevel[0.5], 10], ""]}]]]]]}],
+          Dynamic[Style["  runs from the initial state, " <>
+              If[TrueQ[maxprog],
+                 "AUTO-\[Tau] (box ticked): list external actions only — τ's auto-fire (pasted τ's ignored).",
+                 "MANUAL-\[Tau] (box clear): τ's in the trace are driven literally — tick the box above to auto-fire them instead."] <>
+              " vis[\"port\"] · vis[\"port\", value] · tau[\"chan\"].",
+            GrayLevel[0.45], 10]],
 
           Row[{Checkbox[Dynamic[shortTrace]], Spacer[4],
                Style["Short trace values (truncate bulky data)", GrayLevel[0.35], 11]}],


### PR DESCRIPTION
## Why
Pasting **Copy trace** output into the **Run trace** field broke the interface. Two distinct causes:

1. **Wrong element type.** Copy emitted the raw event log — a list of `eventOf` *Associations*. Run trace's `walkResolve` only knows `vis[…]`/`tau[…]`, so every entry → `Missing` → empty run. Worse, an Association-list passes `ListQ`, so the status text falsely showed green "N actions".
2. **The τ rows.** Even rewritten to vis/tau form, the copied internal-sync rows (`langRead`, `vocabUpsert`, `vocabRead`) double-fire under the field's hardcoded `AutoTau` and truncate the replay.

So the two were genuinely different artifacts: Copy = full annotated log; Run trace = executable external plan.

## Fix — restore the auto/manual-τ symmetry the user already has when stepping by hand
- **`traceToPlan[trace]`** — recover an executable plan from a recorded event log: `vis["p", value]` (values inline) and the internal τ's kept as `tau["chan"]`.
- **Copy trace** now copies `traceToPlan[trace]` — one artifact that pastes straight back into Run trace *and* is the readable vis/tau form (still shows the `langRead`/`vocabUpsert` τ's).
- **Run trace honours the Auto-advance (maximal-progress) checkbox**, exactly like manual stepping:
  - **box ON (auto-τ):** `AutoTau→True`; pasted `tau[…]` are **dropped** (they'd double-fire) — status notes *"N τ ignored (auto mode)"*.
  - **box OFF (manual-τ):** `AutoTau→False`; the `tau[…]` are **driven literally**, so a recorded trace replays step-for-step.
- **`normalisePlan`** — accept a typed plan, auto-convert a pasted raw event log, return `$Failed` on junk so the status **warns** instead of falsely showing green.
- Status text + helper line are mode-aware; `walkUI::usage` and `walk.md` updated.

`Run test` stays always-auto (its `walkTests` are curated external-only plans) — documented.

## Verification
- New `walk_test.wls` §7: `traceToPlan` round-trips **both** τ-modes to the **same event log AND views** as the original run; `normalisePlan` accept/convert/reject cases.
- Green: `walk_test`, `walk_sequences_test`, `story_reader_test`, `trace_io_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)