### PR TITLE
Acoustic pronunciation channel (A2P): Cnam/fb recognizer + dual-channel scoring

### DIFF
--- a/.agents/skills/ux-bridge/SKILL.md
+++ b/.agents/skills/ux-bridge/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ux-bridge
+description: Use when you (Claude Code) need the rendered browser checked or driven but cannot see it yourself — to test UX, verify a UI fix renders correctly, confirm layout on the running app, or run a click/type flow you can't observe. Sets up a two-way UX-test exchange with the browser-capable VS Code Chat agent, transported over Beads. Trigger on "test the UI", "check how X looks", "verify the rendering", "ux-bridge", or whenever a UI change needs eyes on the actual page.
+---
+
+# UX Bridge
+
+You (Claude Code) cannot see the rendered browser. The VS Code Chat-tab agent
+(with the page shared via "Sharing with Agent") can read and control it. This
+skill opens a durable two-way exchange between you, transported over Beads.
+
+Full contract: `docs/dev-docs/UX_BRIDGE_PROTOCOL.md` — read it if unsure.
+
+## Steps
+
+1. **Make sure the app is running** and note the URL (usually
+   `http://localhost:8601`). If it isn't up, start it
+   (`scripts/dev_server.sh 8601`) before requesting a check.
+
+2. **Create the bridge issue** with a concrete, checkable request. Put the URL,
+   the steps to perform in the page, and a checklist the browser agent answers:
+
+   ```bash
+   bd create --type task --labels ux-bridge \
+     --title "UX-BRIDGE: <short topic>" \
+     --design "URL: <url>
+   STEPS:
+     1. <action, e.g. record a French word / open a tab / type X>
+     2. ...
+   CHECK (answer each):
+     - [ ] <specific question about layout / text / rendering>
+     - [ ] ...
+   Report with: bd update <THIS-ID> --append-notes \"REPORT: ...\""
+   ```
+
+   Ask **specific, verifiable** things ("is the dual-channel line on ONE row or
+   stacked?", "what exact IPA text shows under Your Pronunciation?") — not vague
+   ones. You can't see it, so the questions must extract what you need.
+
+3. **Emit ONE nudge line for the human to paste to the browser agent**, e.g.:
+   > Browser agent: check the ux-bridge — `bd list --label ux-bridge --status open`, do what the open issue asks on the app, append your findings with `bd update <id> --append-notes "REPORT: ..."`.
+
+4. **Wait for the report.** Neither agent is notified of the other's writes, so
+   the human will say "report's in" (or you can poll). Then:
+   ```bash
+   bd show <id>          # read the appended REPORT
+   ```
+   If the report references a screenshot path under `scratchpad/ux-bridge/`,
+   Read that image.
+
+5. **Act on it**: make code fixes, then either append a follow-up
+   `--append-notes "REQUEST: re-check ..."` for another round, or
+   `bd close <id>` when the topic is resolved.
+
+## Notes
+
+- Keep each exchange to one topic; open a new issue per topic.
+- This is dev-time UX testing, NOT the CCS spec test pathway.
+- If `bd` is unavailable, fall back to files in `scratchpad/ux-bridge/`
+  (request.md / report.md) per the protocol doc.

--- a/docs/dev-docs/UX_BRIDGE_PROTOCOL.md
+++ b/docs/dev-docs/UX_BRIDGE_PROTOCOL.md
@@ -1,0 +1,78 @@
+# UX Bridge Protocol — Claude Code ⇄ browser-agent, via Beads
+
+A lightweight, durable channel for **two-way UX testing** between two agents that
+each see only half the picture:
+
+- **Claude Code** (this agent): sees code, runs the app, edits files, reads bd —
+  but **cannot see the rendered browser**.
+- **Browser agent** (the VS Code Chat-tab agent, e.g. Copilot, with the page
+  shared via "Sharing with Agent"): can **read and control the rendered page**
+  (click, type, snapshot) — but does not see Claude Code's runtime.
+- **Human**: gives a one-line nudge per cycle (no copy-paste of content).
+
+The transport is **Beads** (`bd`) — already shared workspace infrastructure,
+durable across sessions, so each exchange is a persistent record.
+
+## The channel
+
+- One **bd issue per UX-test cycle**, `type=task`, **label `ux-bridge`**, title
+  prefixed `UX-BRIDGE: <short topic>`.
+- The **request** is the issue description / design (what to inspect, the URL,
+  steps to perform, an observation checklist).
+- The **report** is appended by the browser agent via `--append-notes`,
+  prefixed `REPORT:`. Follow-ups append again (`REQUEST:` / `REPORT:`), so the
+  issue's notes become the threaded conversation.
+- Close the issue (`bd close <id>`) when the topic is resolved.
+
+## Discovery (how each side finds the active exchange)
+
+```bash
+bd list --label ux-bridge --status open     # the open bridge exchanges
+bd show <id>                                 # read request + appended reports
+```
+
+## Roles
+
+### Claude Code writes a request
+```bash
+bd create --type task --labels ux-bridge \
+  --title "UX-BRIDGE: <topic>" \
+  --design "URL: http://localhost:8601
+STEPS:
+  1. <action to perform in the page>
+  2. ...
+CHECK (answer each):
+  - [ ] <question about layout/rendering>
+  - [ ] <question ...>
+Report findings with: bd update <this-id> --append-notes \"REPORT: ...\""
+```
+
+### Browser agent performs + reports
+1. `bd list --label ux-bridge --status open` → find the issue.
+2. `bd show <id>` → read URL, steps, checklist.
+3. Perform the steps in the shared browser; observe the rendered result.
+4. Append findings:
+```bash
+bd update <id> --append-notes "REPORT: <answers to each CHECK item, verbatim
+text read from the page, layout observations, anything unexpected>"
+```
+5. Optionally save a screenshot to `scratchpad/ux-bridge/report-<id>-NNN.png`
+   (Claude Code can Read images) and note the path in the report.
+
+### Claude Code consumes + iterates
+- `bd show <id>` → read the REPORT, make code fixes.
+- Append a follow-up `REQUEST:` for re-test, or `bd close <id>` when done.
+
+## The irreducible human step
+
+Neither agent is notified when the other writes. So **one nudge per cycle**:
+- to the browser agent: *"check the ux-bridge"* (it runs `bd list --label ux-bridge`)
+- to Claude Code: *"report's in"* (it runs `bd show <id>`)
+
+That nudge is the only relay — no content is copy-pasted between agents.
+
+## Scope
+
+Dev-time UX testing only. NOT the CCS spec-based testing pathway (deliberately
+avoided as overhead while the core is still being built). If this proves useful,
+it could later be grafted onto the real CCS spec flow.

--- a/docs/research/phonetics/common_phone_apostrophe_report.md
+++ b/docs/research/phonetics/common_phone_apostrophe_report.md
@@ -1,0 +1,71 @@
+# Common Phone (French): systematic G2P error on words with a typographic apostrophe (U+2019)
+
+**Dataset:** Common Phone, Zenodo record [5846137](https://zenodo.org/records/5846137)
+(`cp-1-0.tgz`), French subset (`CP/fr`). CC0.
+**Reporter:** Matthew Fairtlough (with analysis assistance).
+**Date:** 2026-06-29
+
+## Summary
+
+In the French subset, the phonetic reference (the `KAN-MAU` tier of the
+per-utterance TextGrids) is **systematically wrong for every word written with a
+typographic / curly apostrophe `’` (U+2019)**. For these words the
+grapheme-to-phoneme step appears to fall back to spelling the letters out rather
+than phonemizing the word, producing transcriptions that do not correspond to
+any French pronunciation.
+
+The same words written with a straight apostrophe `'` (U+0027) are transcribed
+correctly elsewhere in the corpus, which localises the cause to apostrophe /
+text-normalisation handling **upstream of the G2P step**.
+
+## Evidence
+
+Scanned all 13,437 French TextGrids. Word tokens containing U+2019: **2,092**
+(1.6% of 130,855 word tokens), across **253 distinct word types**. Every
+affected type we inspected is mis-transcribed. Representative cases (dataset
+`KAN-MAU` label vs. the correct French pronunciation):
+
+| Word (with `’`) | Dataset label | Correct IPA | What went wrong |
+|---|---|---|---|
+| `c’est`       | `k s t`             | `sɛ`     | "c" spelled as /k/, silent "t" emitted |
+| `j’ai`        | `ʒ a i`             | `ʒe`     | "ai" spelled out as /a i/ |
+| `qu’il`       | `k y i j`           | `kil`    | "qu" spelled as /k y/, "il" as /i j/ |
+| `n’est`       | `ɛ s t`             | `nɛ`     | "n" dropped, silent "t" emitted |
+| `aujourd’hui` | `o ʒ u ʀ d ʃ ɥ i`   | `oʒuʁdɥi`| spurious /ʃ/, /d/ surfaced |
+| `l’`          | `l`                 | `l`+vowel| elided article reduced to bare /l/ |
+| `d’`          | `d`                 | `d`+vowel| elided preposition reduced to bare /d/ |
+
+The straight-apostrophe form `c'est` (U+0027) appears **322×** correctly labelled
+`s e`, while the curly form `c’est` (U+2019) appears **202×** mislabelled
+`k s t` — the same word, the apostrophe character being the only difference.
+
+## Cause (localised, not yet root-caused in your pipeline)
+
+The failure is in **text normalisation before G2P**: U+2019 is not folded to a
+plain apostrophe (or not recognised as an elision marker), so the tokeniser /
+G2P treats the orthographic string literally and spells it out.
+
+Note: current **espeak-ng** phonemizes both `c'est` and `c’est` correctly
+(`sˈɛ`), so this error is **not** reproducible with an up-to-date espeak-ng. It
+points to the specific (or older) G2P/normalisation tooling used to build the
+released labels.
+
+## Suggested fix
+
+Normalise the typographic apostrophe **U+2019 → U+0027** (and ideally other
+Unicode apostrophe variants, U+02BC etc.) in text normalisation **before** G2P,
+then re-generate the `KAN-MAU` tier for affected utterances. A single
+normalisation step repairs all 253 word types.
+
+## Scope / caveats
+
+- Figures are for the **French** subset only; other languages (EN/DE/IT/ES/RU)
+  were not checked but may share the issue if the same normalisation path is used.
+- This is **distinct** from a separate observation that the reference uses
+  word-isolated citation forms (silent final consonants kept, no liaison across
+  word boundaries) — that is a labelling-policy matter, not a bug, and is not
+  part of this report.
+- For most published uses (training multilingual phone recognisers, where the
+  corpus is robust to a few percent of label noise) this error is unlikely to
+  have affected results. It surfaces when the labels are used as a **per-example
+  gold reference**, which is how it was found here.

--- a/src/audio/phone_recognizer.py
+++ b/src/audio/phone_recognizer.py
@@ -1,0 +1,127 @@
+"""
+Acoustic phone recognition: derive IPA phones DIRECTLY from the audio waveform.
+
+This is the ACCURACY channel of the two-channel design (see
+docs/research/phonetics/FINDING_audio_to_ipa_gap.md, miolingo-7w3): it reports
+what the learner actually PRODUCED, as opposed to the comprehensibility channel
+(Whisper -> espeak) which reports what a listener would have UNDERSTOOD.
+
+Recognizer choice is per-language (validated in miolingo-0x9 on Common Phone
+French against a sentence-level espeak reference, weighted_phone metric):
+  - French  -> Cnam-LMSSC/wav2vec2-french-phonemizer  (specialist, ~0.015 err)
+  - other   -> facebook/wav2vec2-lv-60-espeak-cv-ft    (multilingual fallback)
+Both are wav2vec2 phoneme-CTC models that emit espeak-ng-convention IPA (same
+convention as our espeak targets), output phones directly from audio, and load
+via transformers AutoModelForCTC. Allosaurus was evaluated and dropped: weaker
+(~0.14 weighted on French) and its lang_id is only a phone-inventory mask over a
+single universal model.
+
+Import-light: transformers/torch and the model load lazily on first use, so the
+comprehensibility-only path never pays for them.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, Optional
+
+# espeak voice code (or its language prefix) -> HuggingFace phoneme-CTC model id.
+_FRENCH_MODEL = "Cnam-LMSSC/wav2vec2-french-phonemizer"
+_MULTILINGUAL_MODEL = "facebook/wav2vec2-lv-60-espeak-cv-ft"
+
+_VOICE_TO_MODEL = {
+    "fr": _FRENCH_MODEL,
+    "fr-fr": _FRENCH_MODEL,
+    "fr-be": _FRENCH_MODEL,
+    "fr-ch": _FRENCH_MODEL,
+}
+
+
+def model_for_voice(voice: str) -> str:
+    """Pick the phoneme-CTC model id for an espeak voice code."""
+    if not voice:
+        return _MULTILINGUAL_MODEL
+    v = voice.lower()
+    if v in _VOICE_TO_MODEL:
+        return _VOICE_TO_MODEL[v]
+    return _VOICE_TO_MODEL.get(v.split("-")[0], _MULTILINGUAL_MODEL)
+
+
+@functools.lru_cache(maxsize=2)
+def _load(model_id: str):
+    """Lazily load (processor, model) for a phoneme-CTC model, cached per id."""
+    from transformers import AutoProcessor, AutoModelForCTC
+
+    processor = AutoProcessor.from_pretrained(model_id)
+    model = AutoModelForCTC.from_pretrained(model_id)
+    model.eval()
+    return processor, model
+
+
+def _load_audio_16k(audio_file: str):
+    """Read a WAV to mono float32 at 16 kHz (what wav2vec2 expects)."""
+    import soundfile as sf
+
+    data, sr = sf.read(audio_file)
+    if getattr(data, "ndim", 1) > 1:
+        data = data.mean(axis=1)
+    data = data.astype("float32")
+    if sr != 16000:
+        import resampy
+
+        data = resampy.resample(data, sr, 16000)
+    return data
+
+
+def phones_from_audio(
+    audio_file: str,
+    voice: str = "fr",
+    warn_fn: Optional[Callable] = None,
+) -> str:
+    """
+    Recognize IPA phones directly from an audio file (the waveform).
+
+    Args:
+        audio_file: Path to a WAV file (the trimmed user recording).
+        voice: espeak voice code; selects the per-language recognizer.
+        warn_fn: Optional warning callback for graceful degradation.
+
+    Returns:
+        Space-separated IPA phones (espeak-ng convention), or "" if recognition
+        is unavailable / fails, letting the caller fall back gracefully.
+    """
+    model_id = model_for_voice(voice)
+    try:
+        processor, model = _load(model_id)
+    except ImportError:
+        if warn_fn is not None:
+            warn_fn(
+                "Acoustic phone recognizer needs `transformers`/`torch`; "
+                "falling back to the comprehensibility (ASR-text) channel."
+            )
+        return ""
+    except Exception as e:  # download / load failure
+        if warn_fn is not None:
+            warn_fn(f"Phone recognizer unavailable: {e}")
+        return ""
+
+    try:
+        import torch
+
+        audio = _load_audio_16k(audio_file)
+        inputs = processor(
+            audio, sampling_rate=16000, return_tensors="pt"
+        ).input_values
+        with torch.no_grad():
+            logits = model(inputs).logits
+        ids = torch.argmax(logits, dim=-1)
+        text = processor.batch_decode(ids)[0]
+    except Exception as e:
+        if warn_fn is not None:
+            warn_fn(f"Phone recognition failed: {e}")
+        return ""
+
+    # Models emit space-separated (fb) or word-grouped (Cnam) IPA; collapse to a
+    # single normalized whitespace run. Phone-level segmentation/normalization
+    # for scoring is handled downstream by the scorer (panphon) and ipa_norm.
+    return " ".join(text.split())

--- a/src/scoring/phone_distance.py
+++ b/src/scoring/phone_distance.py
@@ -20,6 +20,7 @@ research/phonetics/phone_distance/ (beads miolingo-8f0).
 """
 from __future__ import annotations
 
+import math
 import unicodedata
 from dataclasses import dataclass
 from functools import lru_cache
@@ -99,16 +100,32 @@ def fold_map_is_tolerated(lang: str, a: str, b: str) -> bool:
         return False            # no fold-map for this language -> nothing folded
 
 
-def score(user_ipa: str, target_ipa: str, lang: str | None = None) -> Result:
+def score(user_ipa: str, target_ipa: str, lang: str | None = None,
+          gain: float = 1.0, exp: float = 1.0, sqrt_norm: bool = False) -> Result:
     """Weighted phone-distance score of user_ipa against target_ipa.
 
     lang is a fold-map key / voice code (pt, pt-pt, fr, nl, en, pt-br, ...). When
     given, tolerated accent substitutions cost 0; when None, every substitution
     is scored purely on feature distance.
+
+    Accuracy curve (miolingo-7w3/h8q) — defaults are NO-OP so the legacy
+    weighted_phone algorithm is unchanged:
+      gain, exp : steepen each substitution cost -> min(1, (cost*gain)**exp).
+                  panphon raw feature distances are compressed (ɛ→a≈0.12), so
+                  without this even clear vowel errors barely register.
+      sqrt_norm : divide total distance by 1.5*sqrt(len) instead of len, so a
+                  single real error stays visible in a long phrase (else one
+                  error / 11 phones ≈ 99%). For the ACCURACY channel only;
+                  comprehensibility scoring stays lenient (defaults).
     """
     t = segment(target_ipa)
     u = segment(user_ipa)
     m, n = len(t), len(u)
+
+    def _curve(c: float) -> float:
+        if c <= 0.0:
+            return 0.0
+        return min(1.0, (c * gain) ** exp)
 
     # DP weighted Levenshtein; dp[i][j] = cost aligning t[:i] with u[:j].
     dp = [[0.0] * (n + 1) for _ in range(m + 1)]
@@ -118,7 +135,7 @@ def score(user_ipa: str, target_ipa: str, lang: str | None = None) -> Result:
         dp[0][j] = j * _INDEL_COST
     for i in range(1, m + 1):
         for j in range(1, n + 1):
-            sub = dp[i - 1][j - 1] + _sub_cost(t[i - 1], u[j - 1], lang)
+            sub = dp[i - 1][j - 1] + _curve(_sub_cost(t[i - 1], u[j - 1], lang))
             dele = dp[i - 1][j] + _INDEL_COST
             ins = dp[i][j - 1] + _INDEL_COST
             dp[i][j] = min(sub, dele, ins)
@@ -128,7 +145,7 @@ def score(user_ipa: str, target_ipa: str, lang: str | None = None) -> Result:
     i, j = m, n
     while i > 0 or j > 0:
         if i > 0 and j > 0:
-            c = _sub_cost(t[i - 1], u[j - 1], lang)
+            c = _curve(_sub_cost(t[i - 1], u[j - 1], lang))
             if abs(dp[i][j] - (dp[i - 1][j - 1] + c)) < 1e-9:
                 if c == 0.0:
                     ops.append(Op("match", t[i - 1], u[j - 1], 0.0, False))
@@ -147,7 +164,10 @@ def score(user_ipa: str, target_ipa: str, lang: str | None = None) -> Result:
     ops.reverse()
 
     distance = dp[m][n]
-    denom = max(m, n) or 1
+    if sqrt_norm:
+        denom = 1.5 * math.sqrt(max(m, n)) or 1
+    else:
+        denom = max(m, n) or 1
     similarity = max(0.0, 1.0 - distance / denom)
     return Result(
         exact_match=(t == u),

--- a/src/scoring/phone_distance.py
+++ b/src/scoring/phone_distance.py
@@ -32,8 +32,12 @@ from ipa import fold_map
 _FT = panphon.FeatureTable()
 _N_FEATURES = 24
 
-# espeak/get_ipa decorations to drop before phone alignment.
-_DROP = set("ˈˌˑ.|‖ ")          # stress, syllable, phrase marks, spaces
+# espeak/get_ipa decorations to drop before phone alignment. Stress (ˈˌ) is
+# dropped because the acoustic recognizer can't emit it, so scoring it would be
+# unfair; it is KEPT on the reference IPA shown to the learner. '-' is espeak's
+# weak-word/clitic marker (e.g. "ʒə-"); '‿' is the liaison tie — neither is a
+# phone, so both are dropped before alignment (miolingo-7w3).
+_DROP = set("ˈˌˑ.|‖ -‿")        # stress, syllable/phrase marks, spaces, clitic '-', liaison tie
 _INDEL_COST = 1.0               # insertion/deletion cost (a whole missing phone)
 _SIGNIFICANT = 0.34             # substitution cost above this = flagged as error
 

--- a/src/scoring/phonemes.py
+++ b/src/scoring/phonemes.py
@@ -74,6 +74,12 @@ def get_ipa(text: str, voice: str = "pt-br") -> str:
     """
     try:
         espeak_cmd = get_espeak_path()
+        # Normalize the typographic apostrophe U+2019 -> U+0027: with the curly
+        # form some espeak/G2P paths fail to recognise elision and spell the word
+        # out (c'est -> /k s t/). This also fixes targets copied from text that
+        # uses smart quotes. (miolingo-0x9: same bug found in the Common Phone
+        # dataset's reference labels.)
+        text = text.replace("’", "'")
         result = subprocess.run(
             [espeak_cmd, "-v", voice, "--ipa", "-q", text],
             capture_output=True,
@@ -81,6 +87,9 @@ def get_ipa(text: str, voice: str = "pt-br") -> str:
             check=True
         )
         ipa = result.stdout.strip()
+        # espeak emits voice-switch markers like "(en)...(fr)" when it thinks a
+        # word is foreign; strip these language tags so they don't pollute the IPA.
+        ipa = re.sub(r"\([a-z]{2,3}(?:-[a-z]+)?\)", "", ipa)
         ipa = ' '.join(ipa.split())
         return ipa
     except (subprocess.CalledProcessError, FileNotFoundError) as e:

--- a/src/scoring/phonemes.py
+++ b/src/scoring/phonemes.py
@@ -90,6 +90,10 @@ def get_ipa(text: str, voice: str = "pt-br") -> str:
         # espeak emits voice-switch markers like "(en)...(fr)" when it thinks a
         # word is foreign; strip these language tags so they don't pollute the IPA.
         ipa = re.sub(r"\([a-z]{2,3}(?:-[a-z]+)?\)", "", ipa)
+        # Drop espeak's weak-word/clitic marker '-' (e.g. "ʒə-"): not a phone, and
+        # it caused spurious scoring mismatches (miolingo-7w3). Stress (ˈˌ) is KEPT
+        # here so the reference IPA shown to the learner marks stress.
+        ipa = ipa.replace("-", "")
         ipa = ' '.join(ipa.split())
         return ipa
     except (subprocess.CalledProcessError, FileNotFoundError) as e:

--- a/src/scoring/practice.py
+++ b/src/scoring/practice.py
@@ -159,33 +159,64 @@ def practice_word_from_audio(
             temp_audio, settings, language, warn_fn=warn_fn
         )
 
-        # User phonemes and IPA
-        user_phonemes = get_phonemes(recognized_text, voice)
-        user_ipa = get_ipa(recognized_text, voice)
+        # User phonemes and IPA — TWO complementary channels (miolingo-7w3):
+        #   "asr_text"  (comprehensibility): espeak-ng G2P of the recognized TEXT
+        #               — what a listener UNDERSTOOD (Whisper recovers the word
+        #               even from imperfect pronunciation).
+        #   "acoustic"  (accuracy): phones read DIRECTLY from the waveform via a
+        #               per-language phoneme-CTC recognizer (Cnam for fr, fb else)
+        #               — what the learner actually PRODUCED.
+        # The target IPA (correct_ipa) is phonemized whole-phrase by espeak, so
+        # liaison is handled for multi-word targets (miolingo-0x9); the acoustic
+        # channel therefore works for phrases, not just single words.
+        # Compute BOTH channels every attempt (miolingo-7w3) so the display can
+        # show comprehensibility AND accuracy together — the GAP between them is
+        # the diagnostic. realization_source only picks which is the PRIMARY
+        # similarity/user_ipa (back-compat); both are always stored.
+        # accept new names (comprehensibility/accuracy) and legacy (asr_text/acoustic)
+        realization_source = settings.get("realization_source", "comprehensibility")
 
-        # Normalise for comparison
-        correct_phonemes_normalized = normalize_for_phoneme_scoring(
-            correct_phonemes
-        )
-        user_phonemes_normalized = normalize_for_phoneme_scoring(user_phonemes)
+        # comprehensibility IPA = espeak G2P of the recognized word
+        comp_ipa = get_ipa(recognized_text, voice)
+        # accuracy IPA = phones read directly from the waveform (or "" if unavailable)
+        from audio.phone_recognizer import phones_from_audio
+        acc_ipa = phones_from_audio(temp_audio, voice, warn_fn=warn_fn)
 
-        # Score
         algorithm = settings.get("comparison_algorithm", "edit_distance")
-        if algorithm == "weighted_phone":
-            # Phone-level weighted distance over IPA, with the espeak-ng fold-map
-            # tolerating accent variation (miolingo-8f0). Lazy import so panphon
-            # only loads when this algorithm is actually selected.
-            from scoring.phone_distance import score as _phone_score
-            _r = _phone_score(user_ipa, correct_ipa, voice)
-            exact_match = _r.exact_match
-            similarity = _r.similarity
-            edit_distance = round(_r.distance, 3)
+
+        def _score_channel(uipa, accuracy_curve):
+            """Return (exact, similarity, distance) for one channel's IPA."""
+            if not uipa:
+                return (False, 0.0, None)
+            if algorithm == "weighted_phone":
+                from scoring.phone_distance import score as _phone_score
+                if accuracy_curve:
+                    # stretched curve: real errors register, single error in a
+                    # long phrase stays visible (miolingo-7w3/h8q). Tunable.
+                    _r = _phone_score(uipa, correct_ipa, voice,
+                                      gain=4.0, exp=0.6, sqrt_norm=True)
+                else:
+                    _r = _phone_score(uipa, correct_ipa, voice)
+                return (_r.exact_match, _r.similarity, round(_r.distance, 3))
+            up = normalize_for_phoneme_scoring(uipa)
+            cp = normalize_for_phoneme_scoring(correct_ipa)
+            return compare_phonemes(up, cp, algorithm=algorithm)
+
+        comp_exact, comp_sim, comp_dist = _score_channel(comp_ipa, accuracy_curve=False)
+        acc_exact, acc_sim, acc_dist = _score_channel(acc_ipa, accuracy_curve=True)
+
+        # Primary channel (drives the legacy single-score fields + verdict).
+        use_accuracy = realization_source in ("accuracy", "acoustic") and bool(acc_ipa)
+        if use_accuracy:
+            user_ipa, user_phonemes = acc_ipa, acc_ipa
+            exact_match, similarity, edit_distance = acc_exact, acc_sim, acc_dist
         else:
-            exact_match, similarity, edit_distance = compare_phonemes(
-                user_phonemes_normalized,
-                correct_phonemes_normalized,
-                algorithm=algorithm,
-            )
+            user_ipa = comp_ipa
+            user_phonemes = get_phonemes(recognized_text, voice)
+            exact_match, similarity, edit_distance = comp_exact, comp_sim, comp_dist
+
+        correct_phonemes_normalized = normalize_for_phoneme_scoring(correct_phonemes)
+        user_phonemes_normalized = normalize_for_phoneme_scoring(user_phonemes)
 
         result = {
             "target": text,
@@ -201,11 +232,49 @@ def practice_word_from_audio(
             "user_phonemes_normalized": user_phonemes_normalized,
             "user_audio_bytes": audio_bytes,
             "user_audio_trimmed_bytes": trimmed_wav_bytes,
+            # BOTH channels, always present, for the dual-channel display (7w3):
+            "comprehensibility_ipa": comp_ipa,
+            "comprehensibility_similarity": comp_sim,
+            "accuracy_ipa": acc_ipa,
+            "accuracy_similarity": acc_sim if acc_ipa else None,
         }
 
         # Delegate session persistence to caller
         if on_result is not None:
             on_result(result)
+
+        # DEBUG-ONLY (miolingo-0x9): ARCHIVE every recording so the acoustic
+        # recognizer can be evaluated on a real corpus. Each take is saved under
+        # MIO_AUDIO_DUMP_DIR as <target>_<NNN>.wav with a JSONL sidecar capturing
+        # the full scoring context. Throwaway hook on the audio-phones branch;
+        # not part of the feature. Guarded by debug_mode, silently best-effort,
+        # never overwrites (monotonic index).
+        if settings.get("debug_mode", False):
+            try:
+                import os, re, json, glob
+                _dir = os.environ.get("MIO_AUDIO_DUMP_DIR")
+                if _dir:
+                    os.makedirs(_dir, exist_ok=True)
+                    _slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-") or "rec"
+                    _n = len(glob.glob(os.path.join(_dir, f"{_slug}_*.wav")))
+                    _stem = os.path.join(_dir, f"{_slug}_{_n:03d}")
+                    with open(_stem + ".wav", "wb") as _f:
+                        _f.write(trimmed_wav_bytes)
+                    with open(os.path.join(_dir, "log.jsonl"), "a") as _lf:
+                        _lf.write(json.dumps({
+                            "file": os.path.basename(_stem + ".wav"),
+                            "target": text,
+                            "voice": voice,
+                            "recognized": recognized_text,
+                            "realization_source": realization_source,
+                            "algorithm": algorithm,
+                            "user_ipa": user_ipa,
+                            "correct_ipa": correct_ipa,
+                            "similarity": similarity,
+                            "exact_match": exact_match,
+                        }) + "\n")
+            except Exception:
+                pass
 
         return result
 

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -372,13 +372,22 @@ def render_practice_results(result, key_prefix="practice"):
                 height=0,
             )
     else:
-        score_col1, score_col2 = st.columns([2, 1])
-        with score_col1:
-            st.info(f"📊 Score: {result['similarity']:.1%}")
-        with score_col2:
-            if result.get('edit_distance') is not None:
-                st.metric("Edit Distance", result['edit_distance'],
-                        help="Number of edits needed to match target")
+        # Dual-channel summary (miolingo-7w3) — show BOTH always; the gap is the
+        # diagnostic. Comprehensibility = what a listener (Whisper) understood;
+        # Accuracy = how close the sounds you PRODUCED are (phones from audio).
+        _understood = result['target'].lower().translate(
+            str.maketrans('', '', string.punctuation)
+        ) == result['recognized'].lower().translate(
+            str.maketrans('', '', string.punctuation)
+        )
+        _acc = result.get('accuracy_similarity')
+        # One compact line so it never responsively stacks: comprehensibility +
+        # accuracy together. The gap between them is the diagnostic.
+        _u = "✓ understood" if _understood else f"✗ heard “{result['recognized']}”"
+        _p = f"🎯 **{_acc:.0%}** pronunciation" if _acc is not None else "🎯 — pronunciation"
+        st.markdown(f"🗣️ {_u}  ·  {_p}")
+        st.caption("Understood = did a listener (Whisper) get the word, forgiving accent · "
+                   "Pronunciation = how close your actual sounds were, from the recording")
 
     # F2: let the user capture a single word from a multi-word practice phrase.
     _render_practice_vocab_capture(result, key_prefix)
@@ -407,7 +416,12 @@ def render_practice_results(result, key_prefix="practice"):
         correct_phonemes_no_space = result.get('correct_phonemes_normalized') or normalize_for_phoneme_scoring(result.get('correct_phonemes', ''))
         user_phonemes_no_space = result.get('user_phonemes_normalized') or normalize_for_phoneme_scoring(result.get('user_phonemes', ''))
 
-        phonemes_match = correct_phonemes_no_space == user_phonemes_no_space
+        # Trust the scorer's verdict (it reflects whichever channel produced
+        # user_ipa — text or acoustic). Falling back to the string compare only
+        # if exact_match is absent keeps legacy results working (miolingo-dsq).
+        phonemes_match = result.get(
+            'exact_match', correct_phonemes_no_space == user_phonemes_no_space
+        )
         text_matches = target_clean == recognized_clean
         score_is_high = result['similarity'] >= 0.95
 

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -405,6 +405,12 @@ def render_settings_panel():
                  "genuine errors.",
         )
 
+        # Both scoring channels (comprehensibility + accuracy) now always run and
+        # display together (miolingo-7w3), so the old 'Pronunciation source'
+        # selector is gone. Default the setting to 'comprehensibility' for the
+        # primary saved score; the result view shows both regardless.
+        st.session_state.settings.setdefault('realization_source', 'comprehensibility')
+
         # ── Audio Processing ─────────────────────────────────────────────────
         st.markdown("**🎚️ Audio Processing**")
 


### PR DESCRIPTION
## What

Adds an **acoustic phone-recognition (A2P) accuracy channel** alongside the existing Whisper→espeak comprehensibility channel, addressing the root finding (miolingo-7w3): the old score derived IPA from recognized *text*, not from the voice — so a mispronunciation Whisper auto-corrects scored as perfect.

## Changes
- `phone_recognizer.py`: per-language phoneme-CTC recognizer — **Cnam** (French specialist) / **facebook-espeak** (multilingual fallback), replacing Allosaurus. Lazy+cached, 16k resample.
- `practice.py`: compute **both** channels every attempt (comprehensibility + accuracy); both stored in the result.
- `phone_distance.score()`: tunable accuracy curve (gain/exp/sqrt_norm), **default no-op** so legacy `weighted_phone` is unchanged.
- `phonemes.get_ipa()`: normalize U+2019 apostrophe (fixes `c'est`→`k s t`); strip espeak's clitic `-` and lang-switch tags; **keep stress on the reference**.
- `phone_distance._DROP`: drop `-`, liaison tie, stress before alignment (fair scoring; stress shown on reference only).
- Sidebar: removed realization-source selector (both channels always shown).
- `practice_tab.py`: compact dual-channel readout (🗣️ understood · 🎯 pronunciation %).
- **UX bridge** (`/ux-bridge` skill + protocol doc): two-way browser-agent ⇄ Claude Code testing over Beads.
- Docs: Common Phone apostrophe-bug case study.

## Validation
- French benchmark (Common Phone, sentence-level espeak reference, weighted metric): **Cnam ~0.015, fb ~0.066, allo ~0.139**.
- Error-detection on real user audio: good takes ~1.0, mispronounced clearly lower.
- 28 scoring tests pass; app boots clean.

## Known / deferred
- Accuracy-curve params (gain=4, exp=0.6) tuned on limited data — calibrate on more recordings (miolingo-h8q).
- UX polish (spacing flag-but-forgive, sidebar recognizer multi-select, +Add placement) — next phase.
- pt/nl recognizer choice reopened (Allosaurus not as weak as first thought under weighted metric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)