### PR TITLE
Clean phone-comparison display + dual-channel scoring fixes

### DIFF
--- a/docs/dev-docs/UX_BRIDGE_PROTOCOL.md
+++ b/docs/dev-docs/UX_BRIDGE_PROTOCOL.md
@@ -63,13 +63,31 @@ text read from the page, layout observations, anything unexpected>"
 - `bd show <id>` → read the REPORT, make code fixes.
 - Append a follow-up `REQUEST:` for re-test, or `bd close <id>` when done.
 
-## The irreducible human step
+## The trigger — minimise what the human pastes
 
-Neither agent is notified when the other writes. So **one nudge per cycle**:
-- to the browser agent: *"check the ux-bridge"* (it runs `bd list --label ux-bridge`)
-- to Claude Code: *"report's in"* (it runs `bd show <id>`)
+Neither agent is notified when the other writes, so the human gives **one FIXED
+trigger per cycle — never crafted, always the same constant phrase**:
 
-That nudge is the only relay — no content is copy-pasted between agents.
+- to the browser agent: **`check the ux-bridge`**
+- to Claude Code: **`report's in`**
+
+For this to work, the bd issue must be **fully self-contained**: Claude Code
+writes the URL, steps, and checklist INTO the issue, so the browser agent needs
+NO pasted instructions — it learns everything by reading the issue. The human
+never copies content between agents; the three-word trigger is the entire relay.
+
+**Browser agent, on hearing `check the ux-bridge`, does exactly:**
+
+```bash
+bd list --label ux-bridge --status open   # find the open exchange
+bd show <id>                               # read EVERYTHING: URL, steps, checklist
+# perform it on the running app, then:
+bd update <id> --append-notes "REPORT: <answers, verbatim page text, observations>"
+```
+
+No further prompting needed. If the mic is blocked (agent-driven browser), open
+the debug "🧪 inject test audio (no mic)" expander near the record button and
+pick a saved recording to stand in for a live capture, then proceed.
 
 ## Scope
 

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -133,6 +133,38 @@ def save_current_session():
 
 
 # ---------------------------------------------------------------------------
+# Debug audio injection — feed a saved .wav in place of the mic (miolingo-7w3)
+# ---------------------------------------------------------------------------
+
+def _maybe_inject_test_audio(key_prefix):
+    """In debug mode, offer a picker of saved .wav files to stand in for a live
+    recording (mic is unavailable when an agent drives the shared browser).
+    Returns a BytesIO of the chosen wav (so .getvalue() works like st.audio_input),
+    or None. The dir is MIO_AUDIO_DUMP_DIR if set, else scratchpad recordings."""
+    import os
+    import streamlit as st
+    if not st.session_state.get("settings", {}).get("debug_mode", False):
+        return None
+    test_dir = os.environ.get("MIO_AUDIO_DUMP_DIR", "")
+    if not test_dir or not os.path.isdir(test_dir):
+        return None
+    wavs = sorted(f for f in os.listdir(test_dir) if f.lower().endswith(".wav"))
+    if not wavs:
+        return None
+    with st.expander("🧪 Debug: inject test audio (no mic)", expanded=False):
+        choice = st.selectbox("Saved recording to use as the recording",
+                              ["(none)"] + wavs, key=f"{key_prefix}_test_audio_pick")
+        if choice and choice != "(none)":
+            with open(os.path.join(test_dir, choice), "rb") as fh:
+                import io
+                buf = io.BytesIO(fh.read())
+                buf.name = choice  # mimic UploadedFile
+                st.caption(f"Using {choice} in place of the microphone.")
+                return buf
+    return None
+
+
+# ---------------------------------------------------------------------------
 # render_practice_interface
 # ---------------------------------------------------------------------------
 
@@ -169,6 +201,14 @@ def render_practice_interface(text, key_prefix="practice"):
 
     # Streamlit's built-in audio input with dynamic key (unique per mode)
     audio_data = st.audio_input("Click to record", key=f"{key_prefix}_audio_input_{st.session_state[audio_key_name]}")
+
+    # DEBUG audio-injection (miolingo-7w3): when the mic is unavailable (e.g. an
+    # agent driving the shared browser), let a saved .wav stand in for a live
+    # recording so the full Results flow can be exercised. Debug-mode only; the
+    # injected audio is a REAL prior recording, replayed — not fabricated.
+    _injected = _maybe_inject_test_audio(key_prefix)
+    if _injected is not None:
+        audio_data = _injected
 
     # Show recording tip after the recording widget (mobile-friendly)
     language_name = st.session_state.language

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -145,13 +145,20 @@ def _maybe_inject_test_audio(key_prefix):
     import streamlit as st
     if not st.session_state.get("settings", {}).get("debug_mode", False):
         return None
-    test_dir = os.environ.get("MIO_AUDIO_DUMP_DIR", "")
-    if not test_dir or not os.path.isdir(test_dir):
-        return None
-    wavs = sorted(f for f in os.listdir(test_dir) if f.lower().endswith(".wav"))
-    if not wavs:
-        return None
     with st.expander("🧪 Debug: inject test audio (no mic)", expanded=False):
+        # Directory of saved .wav files: env var default, else type a path here
+        # (agent-drivable in the browser; no env-var prefix needed).
+        default_dir = os.environ.get("MIO_AUDIO_DUMP_DIR", "")
+        test_dir = st.text_input("Folder of .wav recordings", value=default_dir,
+                                 key=f"{key_prefix}_test_audio_dir")
+        if not test_dir or not os.path.isdir(test_dir):
+            if test_dir:
+                st.caption("Folder not found.")
+            return None
+        wavs = sorted(f for f in os.listdir(test_dir) if f.lower().endswith(".wav"))
+        if not wavs:
+            st.caption("No .wav files in that folder.")
+            return None
         choice = st.selectbox("Saved recording to use as the recording",
                               ["(none)"] + wavs, key=f"{key_prefix}_test_audio_pick")
         if choice and choice != "(none)":

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -143,9 +143,13 @@ def _maybe_inject_test_audio(key_prefix):
     or None. The dir is MIO_AUDIO_DUMP_DIR if set, else scratchpad recordings."""
     import os
     import streamlit as st
-    if not st.session_state.get("settings", {}).get("debug_mode", False):
+    _dbg = st.session_state.get("settings", {}).get("debug_mode", False)
+    # Diagnostic breadcrumb: always emit a one-liner so an agent can see WHY the
+    # injector is/ isn't shown (distinguishes "gate False" from "code not running").
+    st.caption(f"[injector gate] debug_mode={_dbg}")
+    if not _dbg:
         return None
-    with st.expander("🧪 Debug: inject test audio (no mic)", expanded=False):
+    with st.expander("🧪 Debug: inject test audio (no mic)", expanded=True):
         # Directory of saved .wav files: env var default, else type a path here
         # (agent-drivable in the browser; no env-var prefix needed).
         default_dir = os.environ.get("MIO_AUDIO_DUMP_DIR", "")

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -502,42 +502,53 @@ def render_practice_results(result, key_prefix="practice"):
                 st.write("(no IPA available)")
             st.caption("Your Pronunciation")
 
-        target_ipa_no_space = "".join(correct_ipa.split())
-        user_ipa_no_space = "".join(user_ipa.split())
+        # Diff over PHONES using the SAME normalization the scorer uses
+        # (scoring.phone_distance.segment → _clean strips stress, '-', ties,
+        # spaces). This keeps the displayed comparison consistent with the score
+        # and removes stray artefacts (no leftover stress marks, clitic '-', or
+        # filler glyphs that look like phones). (miolingo-7w3)
+        from scoring.phone_distance import segment as _segment
+        target_segs = _segment(correct_ipa)
+        user_segs = _segment(user_ipa)
 
-        st.write("**Detailed IPA comparison (whitespace ignored):**")
-        if target_ipa_no_space and target_ipa_no_space == user_ipa_no_space:
-            st.success("🎯 IPA is identical!")
-        elif target_ipa_no_space or user_ipa_no_space:
-            # Legend for color-coded diff
-            st.caption("**Legend:** 🟦 Different sound · 🟩 Sound you added · 🟥 Sound missing from target")
+        st.write("**Detailed phone comparison:**")
+        if target_segs and target_segs == user_segs:
+            st.success("🎯 Phones are identical!")
+        elif target_segs or user_segs:
+            # Legend — use a vertical bar separator so it can't be confused with
+            # any in-diff marker; missing/added phones are shown as a gap '∅'.
+            st.caption("**Legend:** 🟦 different sound │ 🟩 sound you added │ 🟥 sound missing │ ∅ = gap (nothing there)")
 
-            def _colorize_diff(target: str, user: str) -> tuple[str, str]:
+            GAP = "∅"
+
+            def _colorize_diff(target: list, user: list) -> tuple[str, str]:
                 # replace: light blue, insert: light green, delete: light pink.
                 matcher_local = SequenceMatcher(None, target, user)
                 target_chunks: list[str] = []
                 user_chunks: list[str] = []
 
+                def _join(segs):
+                    return _html.escape(" ".join(segs))
+
                 for tag, i1, i2, j1, j2 in matcher_local.get_opcodes():
                     t_seg = target[i1:i2]
                     u_seg = user[j1:j2]
-
                     if tag == 'equal':
-                        target_chunks.append(_html.escape(t_seg))
-                        user_chunks.append(_html.escape(u_seg))
+                        target_chunks.append(_join(t_seg))
+                        user_chunks.append(_join(u_seg))
                     elif tag == 'replace':
-                        target_chunks.append(f'<span style="background-color: #ADD8E6; padding: 0 2px;">{_html.escape(t_seg)}</span>')
-                        user_chunks.append(f'<span style="background-color: #ADD8E6; padding: 0 2px;">{_html.escape(u_seg)}</span>')
+                        target_chunks.append(f'<span style="background-color: #ADD8E6; padding: 0 2px;">{_join(t_seg)}</span>')
+                        user_chunks.append(f'<span style="background-color: #ADD8E6; padding: 0 2px;">{_join(u_seg)}</span>')
                     elif tag == 'insert':
-                        target_chunks.append(f'<span style="background-color: #90EE90; padding: 0 2px;">{_html.escape("·" * len(u_seg))}</span>')
-                        user_chunks.append(f'<span style="background-color: #90EE90; padding: 0 2px;">{_html.escape(u_seg)}</span>')
+                        target_chunks.append(f'<span style="background-color: #90EE90; padding: 0 2px;">{GAP}</span>')
+                        user_chunks.append(f'<span style="background-color: #90EE90; padding: 0 2px;">{_join(u_seg)}</span>')
                     elif tag == 'delete':
-                        target_chunks.append(f'<span style="background-color: #FFB6C6; padding: 0 2px;">{_html.escape(t_seg)}</span>')
-                        user_chunks.append(f'<span style="background-color: #FFB6C6; padding: 0 2px;">{_html.escape("·" * len(t_seg))}</span>')
+                        target_chunks.append(f'<span style="background-color: #FFB6C6; padding: 0 2px;">{_join(t_seg)}</span>')
+                        user_chunks.append(f'<span style="background-color: #FFB6C6; padding: 0 2px;">{GAP}</span>')
 
-                return ''.join(target_chunks), ''.join(user_chunks)
+                return ' '.join(c for c in target_chunks if c), ' '.join(c for c in user_chunks if c)
 
-            matcher = SequenceMatcher(None, target_ipa_no_space, user_ipa_no_space)
+            matcher = SequenceMatcher(None, target_segs, user_segs)
             operations = matcher.get_opcodes()
             substitutions = [op for op in operations if op[0] == 'replace']
             insertions = [op for op in operations if op[0] == 'insert']
@@ -545,17 +556,17 @@ def render_practice_results(result, key_prefix="practice"):
             matches = sum(i2 - i1 for tag, i1, i2, j1, j2 in operations if tag == 'equal')
             st.write(f"**Operations:** {matches} matches, {len(substitutions)} substitutions, {len(insertions)} insertions, {len(deletions)} deletions")
 
-            target_html, user_html = _colorize_diff(target_ipa_no_space, user_ipa_no_space)
+            target_html, user_html = _colorize_diff(target_segs, user_segs)
             mono_wrap_start = '<div style="font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \'Liberation Mono\', \'Courier New\', monospace; white-space: pre-wrap;">'
             mono_wrap_end = '</div>'
 
             col_t, col_u = st.columns(2)
             with col_t:
                 st.markdown(mono_wrap_start + target_html + mono_wrap_end, unsafe_allow_html=True)
-                st.caption("Target (normalized) - substitutions/insertions/deletions highlighted")
+                st.caption("Target phones — differences highlighted")
             with col_u:
                 st.markdown(mono_wrap_start + user_html + mono_wrap_end, unsafe_allow_html=True)
-                st.caption("Your Pronunciation (normalized) - substitutions/insertions/deletions highlighted")
+                st.caption("Your phones — differences highlighted")
         else:
             st.info("No IPA available for detailed comparison.")
 

--- a/src/ui/practice_tab.py
+++ b/src/ui/practice_tab.py
@@ -577,23 +577,17 @@ def render_practice_results(result, key_prefix="practice"):
         else:
             st.info("No IPA available for detailed comparison.")
 
-        with st.expander("Technical: eSpeak phoneme codes used for scoring", expanded=False):
-            st.write("**eIPA (eSpeak -x) with word spacing:**")
-            col_xa, col_xb = st.columns(2)
-            with col_xa:
-                st.code(result.get('correct_phonemes', ''), language=None)
-                st.caption("Target")
-            with col_xb:
-                st.code(result.get('user_phonemes', ''), language=None)
-                st.caption("Your Pronunciation")
-
-            target_phonemes_no_space = result.get('correct_phonemes_normalized', '')
-            user_phonemes_no_space = result.get('user_phonemes_normalized', '')
-            st.write("**eIPA used for scoring (whitespace removed):**")
-            col_n1, col_n2 = st.columns(2)
-            with col_n1:
-                st.code(target_phonemes_no_space, language=None)
-                st.caption("Target (normalized)")
-            with col_n2:
-                st.code(user_phonemes_no_space, language=None)
-                st.caption("Your Pronunciation (normalized)")
+        # Raw eSpeak -x ASCII phoneme codes (e.g. "mErs'i") are an internal
+        # scoring representation, NOT IPA — confusing next to the clean IPA, and
+        # now inconsistent (the accuracy channel's user side is IPA, the target
+        # is -x codes). Show this only in debug mode, clearly labelled as codes.
+        if st.session_state.get('settings', {}).get('debug_mode', False):
+            with st.expander("Technical (debug): eSpeak -x ASCII phoneme codes", expanded=False):
+                st.caption("These are eSpeak's internal ASCII codes, not IPA — for scoring diagnostics only.")
+                col_xa, col_xb = st.columns(2)
+                with col_xa:
+                    st.code(result.get('correct_phonemes', ''), language=None)
+                    st.caption("Target (eSpeak -x)")
+                with col_xb:
+                    st.code(result.get('user_phonemes', ''), language=None)
+                    st.caption("Your Pronunciation")


### PR DESCRIPTION
Follow-on fixes toward a clean, artefact-free phoneme comparison (miolingo-7w3):

- Phone-level diff via the scorer's segment() so the displayed comparison matches the score and carries no stray artefacts (stress, clitic '-', liaison tie, spaces stripped).
- Replace confusing '·' filler with a clear '∅' gap marker; fix legend separator collision ('│').
- Hide eSpeak -x ASCII phoneme codes (e.g. 'mErs\'i') outside debug mode — they read as garbled next to IPA.
- Inject-audio picker takes a typed folder path (no env-var prefix needed); agent-drivable for mic-free testing.
- Injector gate breadcrumb + open-by-default (diagnostic for an injector-not-rendering issue).
- UX-bridge protocol: fixed 3-word trigger; issue is self-contained.

Verified: 28 scoring tests pass; app boots clean. Visual verification of the non-match diff path (gaps/legend/dual-channel row) pending via the UX bridge once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)