### PR TITLE
docs: UX bridge — report, agent runbooks, human protocol

### DIFF
--- a/docs/dev-docs/bridge/BRIDGE_PROTOCOL_human.md
+++ b/docs/dev-docs/bridge/BRIDGE_PROTOCOL_human.md
@@ -1,0 +1,75 @@
+# The UX bridge — a guide for the human in the loop
+
+You sit between two AI agents in VS Code that can't talk to each other directly:
+
+- **Claude Code** — writes and runs the code, but **can't see the app's screen**.
+- **GitHub Copilot Chat** — **can see and click the running app** (via "Sharing
+  with Agent"), but can't see Claude Code or the code's behaviour.
+
+The bridge lets them collaborate on "does this actually look/work right?" Your
+job is small: **pass two fixed signals** and merge a PR when asked. You never
+copy content between the two chat panes.
+
+## What you actually do (per round)
+
+1. Claude Code makes a change and (for code changes) **commits, pushes, opens a
+   PR, merges, pulls, and restarts the app**. It may ask you to confirm a merge.
+2. Claude Code says it has written a request. You turn to the **Copilot** pane and
+   type exactly:
+
+   > **check the ux-bridge**
+
+3. Copilot reads the request, tests the running app, and writes its findings back.
+   When it's done, you turn to the **Claude Code** pane and type exactly:
+
+   > **report's in**
+
+4. Claude Code reads the findings and either fixes more (back to step 1) or
+   declares the cycle done.
+
+That's it. Two three-word phrases. Everything substantive — the request, the
+test findings, the analysis — travels between the agents automatically; you don't
+relay any of it.
+
+## How the agents pass messages: Beads, in one paragraph
+
+The agents have no shared chat, so they use **Beads** (`bd`) as a mailbox. Beads
+is this project's issue tracker (a small database, the same one used for task
+tracking). For each test cycle the agents open one Beads issue tagged
+`ux-bridge`: Claude Code writes the request into it, Copilot appends its report to
+it, and they take turns adding notes — so the issue becomes their shared
+conversation thread. Because Beads is durable and both agents can read/write it,
+it's a reliable post-box that survives even if a chat is closed. You don't need to
+touch Beads; it's just where their notes live.
+
+## The discipline that makes it reliable (and why)
+
+Two rules were learned the hard way; they're why the agents sometimes do extra
+steps before asking you to nudge:
+
+- **Always publish before testing.** A code change must be committed → pushed →
+  merged → pulled → and the app **restarted** before Copilot tests it. Otherwise
+  Copilot may test an old running version while Claude Code thinks it's testing
+  the new one — they then report contradictory things. (This caused a long,
+  confusing debugging detour once.)
+- **Confirm the build stamp.** In debug mode the app shows a small `build <code>`
+  tag under the title. Copilot checks this matches the version Claude Code expects
+  *before* reporting, so the two agents are provably looking at the same code. If
+  it doesn't match, Copilot stops and says so rather than reporting on stale code.
+
+## A couple of practical notes
+
+- **Microphone:** Copilot can't use the mic in the shared browser, so for
+  pronunciation tests it uses a hidden debug control that plays a **saved
+  recording** instead. Real audio, replayed — not faked.
+- **Debug mode must be ON** for the build stamp and the audio-injector to appear.
+- **If Copilot says "nothing to do" or "no request":** Claude Code hasn't written
+  the next request yet — wait for it, then nudge.
+
+## What this can and can't do automatically
+
+The agents can carry the *content* themselves, but **neither can trigger the
+other** — Copilot in particular can't be put on a timer or made to act on its own.
+So your two nudges per round are, for now, irreducible. Removing them entirely
+would need a small custom VS Code extension that watches Beads and pokes Copilot;
+that's a future option, not built yet.

--- a/docs/dev-docs/bridge/REPORT_foreign_agent_bridge.md
+++ b/docs/dev-docs/bridge/REPORT_foreign_agent_bridge.md
@@ -1,0 +1,148 @@
+# Developing foreign-agent cooperation in VS Code: the Miolingo UX bridge
+
+*A report on building and operating a two-agent testing channel — Claude Code
+and GitHub Copilot Chat — coordinating through Beads, June 2026.*
+
+## The problem
+
+Two AI agents run side by side in one VS Code window, each able to do what the
+other cannot:
+
+- **Claude Code** edits code, runs the app, reads the filesystem and Beads — but
+  **cannot see the rendered browser**. It has no screen/pixel input.
+- **GitHub Copilot Chat** (with a page shared via "Sharing with Agent") can
+  **read and control the rendered app** — click, type, snapshot — but cannot see
+  Claude Code's runtime, and cannot self-schedule.
+
+Neither can message the other directly. For UX work — "does this fix render
+correctly?" — Claude Code is blind exactly where it matters. The goal was a loop
+where Claude Code fixes, Copilot tests the rendered result, Claude Code reads the
+findings and iterates — with **minimal human relay** (no copy-pasting screenshots
+or instructions between two chat panes).
+
+## What was built
+
+A **mailbox over Beads**. There is no new service or extension: the bridge is a
+*convention* for using infrastructure both agents already have (`bd`, the
+Dolt-backed issue tracker).
+
+- One **bd issue per test cycle**, labelled `ux-bridge`, title prefixed
+  `UX-BRIDGE:`.
+- Claude Code writes the **request** (URL, steps, checklist) into the issue.
+- Copilot **appends its report** with `bd update <id> --append-notes "REPORT: …"`.
+- Follow-ups append again, so the issue's notes become the threaded conversation.
+- Discovery is by label: `bd list --label ux-bridge --status open`.
+
+Beads was the right mailbox because it is (a) **shared** — both agents run `bd`
+in the same workspace; (b) **durable** — backed by a Dolt DB, persistent across
+sessions and syncable; (c) **append-only-friendly** — `--append-notes` threads a
+conversation onto one record; (d) **discoverable** — labels let each side find
+the active exchange without being told an ID. A plain shared file (`request.md`/
+`report.md`) was the fallback design, but Beads adds persistence and structure
+for free.
+
+## How it operates
+
+**Claude Code's full loop (the long flow):**
+
+```
+write → commit → push → PR → merge → pull → restart → bd request → (human nudge)
+       → wait for Copilot report → analyse → repeat
+```
+
+**Copilot's loop (the short flow):** on hearing `check the ux-bridge` —
+
+```
+bd list --label ux-bridge --status open → bd show <id> → act on rendered app
+       → bd update <id> --append-notes "REPORT: …"
+```
+
+The human types one fixed phrase per direction (`check the ux-bridge` to Copilot,
+`report's in` to Claude Code) — never crafted, never content.
+
+## Glitches encountered, and why each step exists
+
+Each step of the long flow earned its place by fixing a real failure:
+
+1. **Mic blocked in the shared browser.** Copilot could drive the app but the OS
+   denied microphone access, so the Results panel — the UX we needed — never
+   rendered. → **Audio-injection debug hook**: a saved `.wav` substitutes for the
+   mic, replaying real prior audio. The whole Results flow became agent-drivable.
+
+2. **The score/display normalisation mismatch.** The detailed phone comparison
+   was computed on a different normalisation than the score, so it showed stray
+   artefacts (stress marks, an espeak clitic `-`, filler `·` middots that looked
+   like phones) the scorer had already ignored. → Diff rewritten to use the
+   scorer's own `segment()`, with a clear `∅` gap marker. *(This is the bug class
+   the bridge exists to catch: a thing that looks fine in code but renders wrong.)*
+
+3. **eSpeak `-x` ASCII codes shown as if IPA** (`mErs'i`). → Hidden outside debug
+   mode, relabelled as codes-not-IPA.
+
+4. **Perfect-match path bypassed the diff block.** A test whose audio matched the
+   target scored 100% and skipped the very UI we wanted to verify. → Tests must
+   use a deliberate **mismatch** to render the diff. *(Lesson: design the test
+   input to exercise the path under test.)*
+
+5. **The injector "not rendering."** The decisive, maddening glitch. Copilot
+   reported the injector absent; the code was clearly present. Root cause: Copilot
+   **conflates two views** — the rendered app and the on-disk source — and they
+   had **drifted**, because the running server was a snapshot from an earlier
+   checkout while files kept changing under it. Claude Code had also been asking
+   Copilot to verify *uncommitted/unmerged* edits. → Two fixes:
+   - **The commit→push→PR→merge→pull→restart discipline**, so the served code is
+     provably the current merged source before any request.
+   - **A `build <git-hash>` UI stamp** (debug mode): Copilot reads it off the
+     *rendered* page and confirms it matches the expected hash before reporting.
+     Render and source can no longer silently disagree.
+
+6. **`cd` not persisting across calls.** Claude Code ran `git add/commit` from the
+   wrong directory (cwd reverted between shell calls), silently staging nothing.
+   → Always `git -C <worktree>` for worktree ops; never assume an earlier `cd`
+   holds.
+
+The recurring theme: **every glitch was a hidden disagreement between two
+representations** — score vs display, code vs render, intended cwd vs actual,
+matching-audio vs the path under test. The bridge's value is that it *surfaces*
+these, because a second agent looking at the real rendered artefact contradicts
+the first agent's confident assumption.
+
+## Minimising human intervention: goal vs outcome
+
+**Goal:** a no-human loop. **Outcome:** semi-automatic — one fixed nudge per
+round each direction.
+
+A capability probe (run *through the bridge itself* — pleasingly recursive)
+established the ceiling honestly: **Copilot cannot self-schedule, poll on a
+timer, or be auto-triggered into a chat turn by a file change.** It only acts on
+an incoming message. It *can* write completion markers to Beads, which an
+*external* watcher could detect. Claude Code can self-pace (via `/loop`), but
+Copilot's half cannot.
+
+So full autonomy is **not achievable from the agents alone** — it requires an
+external orchestrator/watcher (a small VS Code extension or daemon watching Beads
+for new `ux-bridge` notes and injecting a chat turn). We judged that
+disproportionate to the problem mid-development and did not build it.
+
+**How well the goal was met:** the human relay was reduced from *crafting and
+pasting full instructions + screenshots both ways* to **two fixed three-word
+phrases** — a large reduction, and the substantive content (requests, reports,
+analysis) flows agent-to-agent through Beads with no human handling. The
+irreducible residue is one nudge per direction per round, which only a custom
+watcher could remove.
+
+## Assessment
+
+The exercise worked: two foreign agents, with no native channel between them,
+cooperated productively on a task neither could complete alone, coordinating
+through a shared durable store. The design is **portable** — the skill, the
+protocol, the permissions baseline, and the build-stamp pattern drop into any
+repo; only the app URL differs. The main cost was discovering, the hard way, that
+**both agents must be pinned to the same source of truth** before their reports
+can be trusted — which the commit-cycle discipline and the build stamp now
+guarantee.
+
+The deeper lesson is general to multi-agent work: cooperation fails not on the
+*channel* but on **shared ground truth**. Give two agents a durable mailbox and a
+freshness handshake, and they coordinate; omit either and they generate
+confident, contradictory nonsense.

--- a/docs/dev-docs/bridge/RUNBOOK_agents.md
+++ b/docs/dev-docs/bridge/RUNBOOK_agents.md
@@ -1,0 +1,88 @@
+# UX bridge — agent runbooks
+
+How each agent actually runs the bridge. Two separate runbooks: one for **Claude
+Code**, one for **GitHub Copilot Chat**. Keep them mentally separate — each agent
+does only its own list.
+
+The mailbox is Beads: one issue per cycle, label `ux-bridge`, title `UX-BRIDGE:`.
+Request lives in the issue; reports are appended with `--append-notes`.
+
+---
+
+## Runbook A — Claude Code (the long flow)
+
+Mnemonic: **"Write, Ship, Serve, Ask, Wait, Read."**
+
+For any cycle that involves a **code change**, never skip the Ship/Serve steps —
+that is what keeps Copilot testing the real merged code, not a stale snapshot.
+
+1. **Write** — make the code change.
+2. **Ship** — `commit → push → PR → merge`. (Worktree git: use
+   `git -C <worktree> …`; cwd does not persist across shell calls.)
+3. **Serve** — `pull` into the checkout the app serves from, then **restart** the
+   server (e.g. `bash scripts/dev_server.sh stop 8601` then `… 8601`). Now the
+   running app == merged source.
+4. **Ask** — write a self-contained request into a `ux-bridge` issue:
+   ```bash
+   bd create --type task --labels ux-bridge --title "UX-BRIDGE: <topic>" \
+     --design "URL: http://localhost:8601
+   EXPECT build: <current git short-hash>   # freshness handshake
+   Report only what the RENDERED page shows — do NOT reason from source files.
+   STEPS: 1) … 2) …
+   CHECK (quote verbatim): - [ ] … - [ ] …
+   Append: bd update <id> --append-notes \"REPORT: …\""
+   ```
+   Always include: the **expected build hash**, the **rendered-only** instruction,
+   concrete **steps**, and a **verbatim-quote checklist**. For anything needing a
+   recording, tell Copilot to use the **🧪 inject test audio** debug expander
+   (mic is blocked for it); to render the diff block, use a **mismatched** target
+   vs injected wav.
+5. **Wait** — the human will say `report's in`. Then `bd show <id>`, read the
+   `REPORT:`. If it references a screenshot under `scratchpad/ux-bridge/`, Read it.
+6. **Read & repeat** — analyse; either append a follow-up `REQUEST:` (and go to
+   step 1 if more code changes) or `bd close <id>` when the topic is resolved.
+   **Never leave an issue open with no pending REQUEST** — Copilot will idle.
+
+Discipline checks:
+- Phrase shell commands to MATCH the allowlist (relative paths, simple commands,
+  no `VAR=` prefixes, no compound `;`/`&`/redirects) — see the shell-hygiene memory.
+- A code-change request without a fresh build hash is invalid — fix the cycle first.
+
+---
+
+## Runbook B — GitHub Copilot Chat (the short flow)
+
+Mnemonic: **"Find, Freshness, Do, Report."**
+
+On hearing the human say **`check the ux-bridge`**:
+
+1. **Find** the open exchange:
+   ```bash
+   bd list --label ux-bridge --status open
+   bd show <id>          # read EVERYTHING: URL, expected build, steps, checklist
+   ```
+2. **Freshness** — open the app URL, hard-refresh, ensure Debug Mode is ON, and
+   read the `build <hash>` caption under the title. If it does **not** match the
+   request's `EXPECT build`, STOP and append a note saying the server is stale —
+   do not test against stale code.
+3. **Do** — perform the steps on the **rendered** app. Mic is blocked for you:
+   use the **🧪 Debug: inject test audio (no mic)** expander to substitute a saved
+   `.wav`. Report only what you SEE rendered; do **not** infer from source files.
+4. **Report** — append findings, answering each checklist item verbatim:
+   ```bash
+   bd update <id> --append-notes "REPORT: <answers; quote exact page text>"
+   ```
+   Optionally save a screenshot to `scratchpad/ux-bridge/` and note the path.
+
+You cannot self-loop or poll — you act only when the human nudges you. That is
+expected; one nudge per round is the design.
+
+---
+
+## Shared rules (both agents)
+
+- The bd issue is the single source of truth for a cycle — read it fully, don't
+  assume.
+- Reports describe the **rendered page**, never the source code.
+- Confirm the **build hash** before trusting any code-change test.
+- One topic per issue; close when done.


### PR DESCRIPTION
Three audience-specific docs for the Claude Code ⇄ Copilot UX bridge (docs/dev-docs/bridge/):

1. **REPORT_foreign_agent_bridge.md** — generation & operation, Beads-as-mailbox, the glitches and the reason for each step, and the minimise-human-intervention goal vs outcome (framed as foreign-agent cooperation in VS Code).
2. **RUNBOOK_agents.md** — separate runbooks: Claude Code's long flow (Write→Ship→Serve→Ask→Wait→Read) and Copilot's short flow (Find→Freshness→Do→Report).
3. **BRIDGE_PROTOCOL_human.md** — human-in-the-loop guide with a succinct Beads description and the publish/build-stamp discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)