### PR TITLE
research(phonetics): phone-recognizer survey + CP-FR bake-off (miolingo-0x9/2yv)

### DIFF
--- a/docs/research/phonetics/phone_recognizer_survey_2026-07.md
+++ b/docs/research/phonetics/phone_recognizer_survey_2026-07.md
@@ -1,0 +1,149 @@
+# Phone-recognizer survey — candidates to beat the `fb` fallback
+
+**Date:** 2026-07-01
+**Method:** deep-research harness (6 search angles, 23 sources fetched, 25 claims
+adversarially 3-vote verified, 24 confirmed / 1 killed).
+**Feeds:** miolingo-0x9 (decision gate), miolingo-7w3 (root-cause: score must read
+the waveform), miolingo-2yv (bake-off).
+**Context:** the "accuracy channel" (`src/audio/phone_recognizer.py`) derives IPA
+directly from audio. French is solved (`Cnam-LMSSC/wav2vec2-french-phonemizer`,
+~0.015 weighted err). Every other language falls back to
+`facebook/wav2vec2-lv-60-espeak-cv-ft` (`fb`) — a *fallback*, not a champion. This
+survey asks, per language: is there a specialist that beats `fb`?
+
+---
+
+## Headline
+
+The strongest answer is **not** a per-language zoo but a **single 2025 multilingual
+model, ZIPA**, which beats the `fb` fallback class and — crucially — covers the two
+product-critical languages Common Phone cannot (**Dutch and Portuguese**).
+
+---
+
+## Candidate models
+
+### ZIPA — lead candidate (universal)
+- **IDs:** models `anyspeech/zipa-*` (HF); code `github.com/lingjzhu/zipa` (MIT);
+  paper ACL 2025 `aclanthology.org/2025.acl-long.961/` / arXiv `2505.23170`.
+- **Arch:** Zipformer, trained from scratch on IPAPack++ (17,132h). **CTC variant
+  (ZIPA-CR)** exposes per-phone posteriors (needed for abstention); transducer
+  variant (ZIPA-T) also exists.
+- **Output:** native **IPA** directly from waveform; 127-symbol IPA unigram tokenizer.
+- **Accuracy (controlled, same params):** ZIPA-CR-large (300M) **3.14 PFER** vs the
+  `fb`-sibling `W2V2P-xlsr-53-ft` (300M) **11.88** — ~3.8× better. ZIPA-CR-small
+  (**64M, ~256MB**) at 5.62 PFER still beats the 300M baseline → **on-device viable**.
+- **Coverage:** seen-language benchmark includes `dut` (Dutch) and `por` (Portuguese).
+- **Caveats:**
+  1. Portuguese is a **single `por` head, no pt-BR/pt-PT split**; paper flags a
+     Portuguese phone-set mismatch (é→[a]). May not serve both PT variants cleanly.
+  2. **Licence unresolved:** code MIT, paper CC BY-NC-ND (non-commercial), **HF
+     weights have *undeclared* licence metadata** → confirm commercial use with
+     authors before shipping. ONNX fp32/fp16/int8 variants exist.
+
+### pklumpp/Wav2Vec2_CommonPhone — specialist for the benchmarkable tier
+- **ID:** `huggingface.co/pklumpp/Wav2Vec2_CommonPhone`.
+- **Arch:** XLSR-53 + linear CTC over 101 IPA symbols + blank; IPA from audio.
+- **Trained on:** the Common Phone corpus (Mozilla Common Voice, CC0).
+- **Accuracy:** **9.2% avg PER** — EN 11.0, FR 9.9, DE 9.8, IT 9.1, ES 8.8, **RU 6.6**
+  (self-reported, clean read speech). Far better than the 18.1% base-CP baseline.
+- **Fit:** covers de/es/it/en + Russian (curiosity lang, its *best* language).
+
+### Clementapa/wav2vec2-base-960h-phoneme-reco-dutch — weak Dutch fallback
+- Emits espeak-convention IPA (phonemizer/espeak targets → zero-integration map).
+- **20.8% test PER** (clean) — weak; **no licence stated** (deployment blocker).
+- Use only if ZIPA's Dutch fails; prefer ZIPA.
+
+### BranchShine — tiny on-device option
+- 33.38M params (~134MB), raw-audio→IPA CTC (E-Branchformer). 3rd place (9.19% CER)
+  behind both ZIPA CTC variants. Single unreplicated preprint (arXiv 2606.22824).
+- Framed as a lightweight alternative if ZIPA-small is still too big.
+
+### Allosaurus — universal fallback, licence risk
+- 2000+ languages, per-language inventory masks, audio→IPA CTC. **GPL-3.0** —
+  copyleft concern for a shipped desktop app (legal review / process isolation).
+- Older/weaker than ZIPA (which uses it as the standard baseline).
+
+### fb (`facebook/wav2vec2-lv-60-espeak-cv-ft`) — current fallback, characterized
+- wav2vec2-large-lv60 phoneme-CTC, espeak-convention IPA from 16kHz via argmax over
+  CTC logits, ~392-phoneme espeak vocab. A legitimate baseline, beaten by ZIPA.
+- Because it already emits espeak-IPA, **any IPA-emitting replacement drops into the
+  existing pipeline with minimal integration.**
+
+---
+
+## Per-language recommendation
+
+| Tier | Language | Recommendation |
+|------|----------|----------------|
+| Product-critical | **nl / nl-be** | Adopt **ZIPA** (`dut`). Fallback: Clementapa (weak, 20.8% PER, no licence) — prefer ZIPA. |
+| Product-critical | **pt-BR / pt-PT** | **ZIPA interim**, but single `por` head + é→[a] mismatch → likely needs a fine-tune or dedicated eval before trust. Weakest-covered need. |
+| Benchmarkable | **de, es, it, en** | **pklumpp/Wav2Vec2_CommonPhone** (9.2% avg PER). Compare head-to-head with ZIPA on CP gold. |
+| Curiosity | **ru** | pklumpp (6.6% PER — its best). |
+| Done | **fr** | Keep **Cnam-LMSSC**. Nothing clearly superior found. |
+| On-device tiebreak | any | **BranchShine** (33M) if ZIPA-small too big; 3rd in accuracy. |
+| Universal fallback | any | **Allosaurus** viable but **GPL-3.0** — legal review needed. |
+
+---
+
+## Evaluation corpora for the no-gold languages (answers brief part c)
+
+Common Phone = `{de, en, es, fr, it, ru}` only — **no nl, no pt**. To evaluate the
+product-critical languages, build gold via forced alignment:
+
+- **pt-BR:** **UFPAlign** (free Kaldi phone-level forced alignment for Brazilian
+  Portuguese) + **CORAA NURC-SP** (~18h spontaneous BR speech).
+- **nl / nl-be:** **JASMIN-CGN** (~90h Dutch/Flemish, incl. a Flemish nl-BE subset
+  and — valuable — **non-native/L2 speech**); **IFADV + Dutch MLS** via WebMAUS.
+- **General:** Common Voice + **Montreal Forced Aligner** (JRMeyer precomputed set).
+- **Interim:** ZIPA's own `dut`/`por` test partitions work as a relative-ranking
+  harness before true gold exists.
+
+---
+
+## Cross-cutting caveats
+
+- The "44–45% IPA-CER for wav2vec2" figures in the BranchShine paper are **explicitly
+  disclaimed by its authors** (baselines not retrained) — not `fb`'s true accuracy.
+  The load-bearing evidence is the controlled **3.14 vs 11.88 PFER**.
+- All PER/PFER figures are **clean read speech, self-reported** — expect degradation
+  on the app's real **L2/accented** domain. No source validated posterior
+  *calibration* quality empirically.
+- Metrics mix **PFER** (feature distance) and **IPA-CER** (character error) — absolute
+  magnitudes not directly comparable across papers.
+- IPAPack++ "gold" is **G2P-normalized (PHOIBLE), not hand-annotated**; ranks models
+  but is not a true phonetic ground truth for pt/nl. Common Phone IS hand/force-aligned
+  gold, but only for its 6 languages.
+
+---
+
+## Open questions (logged on miolingo-0x9)
+
+1. Does ZIPA's single `por` head handle pt-BR vs pt-PT acceptably, or do we need two
+   specialists/heads given the BR/PT split and the é→[a] mismatch?
+2. **Actual licence of the ZIPA HF weights** (undeclared) — commercial-use OK for a
+   shipped desktop app?
+3. How do ZIPA / pklumpp / `fb` compare on **accented/L2** audio (the app's real
+   domain), not the clean read-speech benchmarks these numbers come from?
+4. For pt-BR/nl, which real-audio eval to build first — CV+MFA, MLS(pt), JASMIN(nl),
+   or purpose-collected L2 — and can ZIPA's `dut`/`por` partitions serve as interim?
+5. Do any per-language **Meta MMS** phoneme heads beat `fb`, or is ZIPA strictly
+   dominant (making the MMS branch moot)?
+
+## Next step
+
+Bake-off (miolingo-2yv): add **ZIPA-CR** and **pklumpp** to
+`research/phonetics/phone_poc/bench.py`, score both vs `fb` on the existing Common
+Phone French set with the **weighted_phone** metric; separately stand up a pt-BR
+(UFPAlign) or nl (JASMIN) eval so the two gap languages stop being blind spots.
+
+---
+
+### Sources (primary)
+- ZIPA: aclanthology.org/2025.acl-long.961 · arXiv 2505.23170 · github.com/lingjzhu/zipa
+- pklumpp/Wav2Vec2_CommonPhone (HF) · Dieck 2022 Interspeech (Common Phone) · arXiv 2201.05912
+- fb: huggingface.co/facebook/wav2vec2-lv-60-espeak-cv-ft
+- Clementapa Dutch (HF) · github.com/ASR-project/Multilingual-PR
+- Allosaurus: github.com/xinjli/allosaurus · arXiv 2002.11800
+- BranchShine: arXiv 2606.22824
+- Corpora: UFPAlign (s13634-022-00844-9) · CORAA NURC-SP · JASMIN-CGN · JRMeyer CV forced alignments · WebMAUS (IFADV/MLS)

--- a/docs/research/phonetics/phone_recognizer_survey_2026-07.md
+++ b/docs/research/phonetics/phone_recognizer_survey_2026-07.md
@@ -21,6 +21,27 @@ product-critical languages Common Phone cannot (**Dutch and Portuguese**).
 
 ---
 
+## Bake-off result (CP-FR, 150 utt, weighted metric) — 2026-07-01
+
+Committed harness `research/phonetics/phone_poc/cp_eval.py` (miolingo-2yv), scoring
+audio-derived IPA vs espeak-G2P reference with the app's `weighted_phone` metric
+(mean 1 − similarity; lower = better):
+
+| model | mean weighted error | vs prior 0x9 | status |
+|-------|--------------------:|--------------|--------|
+| **cnam** (French specialist, shipped) | **0.0126** | 0.015 ✓ | 150/150 clean |
+| **fb** (multilingual fallback) | **0.0719** | 0.066 ✓ | 150/150 clean |
+| pklumpp | — | — | **failed 150/150** |
+
+**The specialist beats the fallback ~5.7× on real audio**, reproducing the earlier
+scratch numbers → the reproducible harness is validated. Both *new* candidates were
+non-drop-in: **ZIPA** is k2/Zipformer + undeclared licence (excluded by design);
+**pklumpp** ships weights only (no processor/vocab on HF) → `AutoProcessor` fails.
+pklumpp integration tracked as **miolingo-dky** (needs the author's 101-symbol vocab
++ hand-built processor).
+
+---
+
 ## Candidate models
 
 ### ZIPA — lead candidate (universal)

--- a/research/phonetics/phone_poc/cp_eval.py
+++ b/research/phonetics/phone_poc/cp_eval.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Common Phone bake-off: score phone recognizers on REAL audio with the app's
+own weighted_phone metric (miolingo-2yv, feeds decision gate miolingo-0x9).
+
+Unlike the older bench.py (synthetic espeak audio, plain Levenshtein), this runs
+on the Common Phone corpus (real Mozilla Common Voice speech) and scores each
+recognizer's audio-derived IPA against an espeak-G2P reference using
+src/scoring/phone_distance.score (panphon feature distance + fold-map), i.e. the
+SAME metric the shipped app uses. Weighted error = 1 - similarity.
+
+Reference choice: espeak-G2P of the transcript text (same IPA convention as the
+recognizers; matches the prior 0x9 re-scoring so numbers stay comparable). The
+Common Phone TextGrid gold (MAU tier) is a truer phonetic reference but lives in
+a different symbol set and is left as a future refinement.
+
+Models (all emit espeak-convention IPA from the waveform via wav2vec2 CTC):
+  fb      facebook/wav2vec2-lv-60-espeak-cv-ft   (current multilingual fallback)
+  cnam    Cnam-LMSSC/wav2vec2-french-phonemizer  (French specialist, shipped)
+  pklumpp pklumpp/Wav2Vec2_CommonPhone           (XLSR-53, CP-trained, 9.2% avg PER)
+ZIPA is deliberately NOT here: it is Zipformer/k2 (not AutoModelForCTC) and its
+shipped-weight licence is undeclared -- a separate spike + licence clearance.
+
+Usage:
+  venv/bin/python research/phonetics/phone_poc/cp_eval.py --n 150 [--lang fr] \
+      [--models fb,cnam,pklumpp] [--cp-root ~/datasets/common_phone/CP]
+Writes results/cp_eval_<lang>.json and prints a table.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]                       # research/phonetics/phone_poc -> repo
+RESULTS = HERE / "results"
+RESULTS.mkdir(exist_ok=True)
+sys.path.insert(0, str(REPO / "src"))        # import the app's own modules
+
+# App modules (reused so the bake-off measures exactly what the app measures).
+from audio import phone_recognizer as pr     # noqa: E402  (_load, _load_audio_16k)
+from scoring.phonemes import get_ipa         # noqa: E402  espeak G2P reference
+from scoring.phone_distance import score     # noqa: E402  weighted_phone metric
+
+# Recognizer registry: label -> HuggingFace CTC model id.
+MODELS = {
+    "fb": "facebook/wav2vec2-lv-60-espeak-cv-ft",
+    "cnam": "Cnam-LMSSC/wav2vec2-french-phonemizer",
+    "pklumpp": "pklumpp/Wav2Vec2_CommonPhone",
+}
+
+
+def recognize(model_id: str, wav_path: str) -> str:
+    """Audio -> space-separated IPA via the app's loader + CTC argmax decode."""
+    import torch
+
+    processor, model = pr._load(model_id)
+    audio = pr._load_audio_16k(wav_path)
+    inputs = processor(audio, sampling_rate=16000, return_tensors="pt").input_values
+    with torch.no_grad():
+        logits = model(inputs).logits
+    ids = torch.argmax(logits, dim=-1)
+    text = processor.batch_decode(ids)[0]
+    return " ".join(text.split())
+
+
+def load_items(cp_lang_dir: Path, split: str, n: int) -> list[dict]:
+    """First n rows of <split>.csv paired with their wav/<stem>.wav path."""
+    items, csv_path = [], cp_lang_dir / f"{split}.csv"
+    with csv_path.open(encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            stem = Path(row["audio file"]).stem
+            wav = cp_lang_dir / "wav" / f"{stem}.wav"
+            if wav.exists():
+                items.append({"wav": str(wav), "text": row["text"]})
+            if len(items) >= n:
+                break
+    return items
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=150)
+    ap.add_argument("--lang", default="fr")
+    ap.add_argument("--split", default="test")
+    ap.add_argument("--models", default="fb,cnam,pklumpp")
+    ap.add_argument("--cp-root", default=str(Path.home() / "datasets/common_phone/CP"))
+    args = ap.parse_args()
+
+    cp_lang_dir = Path(os.path.expanduser(args.cp_root)) / args.lang
+    if not cp_lang_dir.exists():
+        sys.exit(f"Common Phone lang dir not found: {cp_lang_dir}")
+    wanted = [m.strip() for m in args.models.split(",") if m.strip()]
+    for m in wanted:
+        if m not in MODELS:
+            sys.exit(f"unknown model {m!r}; known: {sorted(MODELS)}")
+
+    items = load_items(cp_lang_dir, args.split, args.n)
+    print(f"Loaded {len(items)} {args.lang}/{args.split} utterances from {cp_lang_dir}")
+
+    # espeak-G2P reference IPA per item (voice = lang; fr for French).
+    for it in items:
+        it["ref_ipa"] = get_ipa(it["text"], args.lang)
+
+    summary = {}
+    for label in wanted:
+        model_id = MODELS[label]
+        print(f"\n=== {label} ({model_id}) ===")
+        t0, werr, per_plain, fails = time.time(), [], [], 0
+        for i, it in enumerate(items, 1):
+            try:
+                hyp = recognize(model_id, it["wav"])
+            except Exception as e:  # noqa: BLE001 - record and continue
+                fails += 1
+                if fails <= 3:
+                    print(f"  ! {Path(it['wav']).name}: {e}")
+                continue
+            r = score(hyp, it["ref_ipa"], args.lang)
+            werr.append(1.0 - r.similarity)
+            if i % 25 == 0:
+                print(f"  {i}/{len(items)} mean_werr={sum(werr)/len(werr):.4f}")
+        n_ok = len(werr)
+        mean_werr = sum(werr) / n_ok if n_ok else float("nan")
+        summary[label] = {
+            "model_id": model_id,
+            "n_scored": n_ok,
+            "n_failed": fails,
+            "mean_weighted_error": round(mean_werr, 4),
+            "load_and_run_s": round(time.time() - t0, 1),
+        }
+        print(f"  -> mean_weighted_error={mean_werr:.4f}  ({n_ok} ok, {fails} failed)")
+
+    out = {
+        "corpus": "common_phone",
+        "lang": args.lang,
+        "split": args.split,
+        "n_requested": args.n,
+        "n_items": len(items),
+        "reference": "espeak-G2P of transcript (weighted_phone metric)",
+        "metric": "mean 1 - phone_distance.similarity",
+        "results": summary,
+    }
+    out_path = RESULTS / f"cp_eval_{args.lang}.json"
+    out_path.write_text(json.dumps(out, ensure_ascii=False, indent=2) + "\n", "utf-8")
+    print(f"\nwrote {out_path}")
+    print("\nRANKING (lower = better):")
+    for label, r in sorted(summary.items(), key=lambda kv: kv[1]["mean_weighted_error"]):
+        print(f"  {label:8} {r['mean_weighted_error']:.4f}  ({r['model_id']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/phonetics/phone_poc/cp_eval.py
+++ b/research/phonetics/phone_poc/cp_eval.py
@@ -51,6 +51,10 @@ from scoring.phone_distance import score     # noqa: E402  weighted_phone metric
 MODELS = {
     "fb": "facebook/wav2vec2-lv-60-espeak-cv-ft",
     "cnam": "Cnam-LMSSC/wav2vec2-french-phonemizer",
+    # pklumpp ships WEIGHTS ONLY (no processor/tokenizer/vocab in the HF repo), so
+    # AutoProcessor.from_pretrained fails. Decoding its CTC output needs the
+    # author's exact 101-IPA-symbol vocab + a hand-built Wav2Vec2Processor -- see
+    # follow-up bead. Left registered so the harness records the blocker.
     "pklumpp": "pklumpp/Wav2Vec2_CommonPhone",
 }
 
@@ -111,12 +115,13 @@ def main() -> None:
     for label in wanted:
         model_id = MODELS[label]
         print(f"\n=== {label} ({model_id}) ===")
-        t0, werr, per_plain, fails = time.time(), [], [], 0
+        t0, werr, fails, last_err = time.time(), [], 0, None
         for i, it in enumerate(items, 1):
             try:
                 hyp = recognize(model_id, it["wav"])
             except Exception as e:  # noqa: BLE001 - record and continue
                 fails += 1
+                last_err = str(e)
                 if fails <= 3:
                     print(f"  ! {Path(it['wav']).name}: {e}")
                 continue
@@ -125,15 +130,18 @@ def main() -> None:
             if i % 25 == 0:
                 print(f"  {i}/{len(items)} mean_werr={sum(werr)/len(werr):.4f}")
         n_ok = len(werr)
-        mean_werr = sum(werr) / n_ok if n_ok else float("nan")
-        summary[label] = {
+        mean_werr = round(sum(werr) / n_ok, 4) if n_ok else None
+        rec = {
             "model_id": model_id,
             "n_scored": n_ok,
             "n_failed": fails,
-            "mean_weighted_error": round(mean_werr, 4),
+            "mean_weighted_error": mean_werr,
             "load_and_run_s": round(time.time() - t0, 1),
         }
-        print(f"  -> mean_weighted_error={mean_werr:.4f}  ({n_ok} ok, {fails} failed)")
+        if mean_werr is None:
+            rec["error"] = last_err
+        summary[label] = rec
+        print(f"  -> mean_weighted_error={mean_werr}  ({n_ok} ok, {fails} failed)")
 
     out = {
         "corpus": "common_phone",
@@ -149,8 +157,13 @@ def main() -> None:
     out_path.write_text(json.dumps(out, ensure_ascii=False, indent=2) + "\n", "utf-8")
     print(f"\nwrote {out_path}")
     print("\nRANKING (lower = better):")
-    for label, r in sorted(summary.items(), key=lambda kv: kv[1]["mean_weighted_error"]):
-        print(f"  {label:8} {r['mean_weighted_error']:.4f}  ({r['model_id']})")
+    ranked = sorted(summary.items(),
+                    key=lambda kv: (kv[1]["mean_weighted_error"] is None,
+                                    kv[1]["mean_weighted_error"] or 0.0))
+    for label, r in ranked:
+        val = r["mean_weighted_error"]
+        cell = f"{val:.4f}" if val is not None else f"FAILED ({r.get('error','')[:40]})"
+        print(f"  {label:8} {cell}  ({r['model_id']})")
 
 
 if __name__ == "__main__":

--- a/research/phonetics/phone_poc/results/cp_eval_fr.json
+++ b/research/phonetics/phone_poc/results/cp_eval_fr.json
@@ -1,0 +1,33 @@
+{
+  "corpus": "common_phone",
+  "lang": "fr",
+  "split": "test",
+  "n_requested": 150,
+  "n_items": 150,
+  "reference": "espeak-G2P of transcript (weighted_phone metric)",
+  "metric": "mean 1 - phone_distance.similarity",
+  "results": {
+    "fb": {
+      "model_id": "facebook/wav2vec2-lv-60-espeak-cv-ft",
+      "n_scored": 150,
+      "n_failed": 0,
+      "mean_weighted_error": 0.0719,
+      "load_and_run_s": 34.5
+    },
+    "cnam": {
+      "model_id": "Cnam-LMSSC/wav2vec2-french-phonemizer",
+      "n_scored": 150,
+      "n_failed": 0,
+      "mean_weighted_error": 0.0126,
+      "load_and_run_s": 15.3
+    },
+    "pklumpp": {
+      "model_id": "pklumpp/Wav2Vec2_CommonPhone",
+      "n_scored": 0,
+      "n_failed": 150,
+      "mean_weighted_error": null,
+      "load_and_run_s": 464.4,
+      "error": "Unrecognized processing class in pklumpp/Wav2Vec2_CommonPhone. Can't instantiate a processor, a tokenizer, an image processor, a video processor or a feature extractor for this model. Make sure the repository contains the files of at least one of those processing classes."
+    }
+  }
+}


### PR DESCRIPTION
## What

The audio→phones accuracy channel currently routes only French to a specialist (Cnam) and everything else to the `facebook/wav2vec2-lv-60-espeak-cv-ft` (`fb`) **fallback**. This surveys replacements and validates the specialist-beats-fallback thesis on **real audio** with the app's own weighted metric.

Feeds decision gate **miolingo-0x9**; bake-off tracked as **miolingo-2yv**.

## Contents (3 commits)

1. **Survey** (`docs/research/phonetics/phone_recognizer_survey_2026-07.md`) — deep-research over 23 sources, 25 claims adversarially 3-vote verified. Per-language recommendations, no-gold eval corpora (UFPAlign/CORAA for pt-BR, JASMIN for nl), and the ZIPA licensing blocker.
2. **Harness** (`research/phonetics/phone_poc/cp_eval.py`) — self-contained CP-FR bake-off; scores audio-derived IPA vs espeak-G2P reference with `scoring.phone_distance` (the shipped `weighted_phone` metric). Imports app modules; **no app code changed**.
3. **Results** (`research/phonetics/phone_poc/results/cp_eval_fr.json`).

## Result — 150 real Common Phone FR utterances, weighted error (lower = better)

| model | mean weighted error | vs prior 0x9 | status |
|-------|--------------------:|--------------|--------|
| **cnam** (French specialist, shipped) | **0.0126** | 0.015 ✓ | 150/150 |
| **fb** (multilingual fallback) | **0.0719** | 0.066 ✓ | 150/150 |
| pklumpp | — | — | failed 150/150 |

**The specialist beats the fallback ~5.7×**, reproducing the earlier scratch numbers → the now-reproducible harness is validated.

## Key findings

- **ZIPA** (ACL 2025, Zipformer IPA-CTC) is the strongest candidate on paper — beats the `fb` class, covers nl+pt — but is **not a drop-in** (k2, not `AutoModelForCTC`) and its **HF weight licence is undeclared** (code MIT, paper CC BY-NC-ND). Needs a spike + licence clearance; excluded here.
- **pklumpp/Wav2Vec2_CommonPhone** ships **weights only** (no processor/vocab) → `AutoProcessor` fails. Custom vocab+processor needed — tracked in **miolingo-dky**.

## Follow-ups filed

- **miolingo-dky** — build pklumpp custom processor to benchmark it (de/es/it/en/ru specialist).
- **miolingo-0x9** — updated with survey, ZIPA licence blocker, no-gold-eval plan for pt-BR/nl.

## Notes

- Base is `claude/weighted-phone-scorer` (matches PRs #180–184), not the stale `pr-config.env` default (`claude/spec`) — left untouched per request.
- Docs/research only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)