### PR TITLE
spec: ProgressTable recovery (stats/history data flow) + walkUI compression + driving notebook

### DIFF
--- a/spec/ClaudeDevTesting.nb
+++ b/spec/ClaudeDevTesting.nb
@@ -1,0 +1,175 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Wolfram 14.3' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       154,          7]
+NotebookDataLength[      6998,        167]
+NotebookOptionsPosition[      4526,        120]
+NotebookOutlinePosition[      4868,        135]
+CellTagsIndexPosition[      4825,        132]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+
+Cell[CellGroupData[{
+Cell["Miolingo spec \[LongDash] driving notebook", "Title",ExpressionUUID->"65003cc9-1e94-4b24-8df4-1578d8cd7ba9"],
+
+Cell["\<\
+Loads the L1 spec + walk harness from THIS notebook's directory, so it drives \
+whichever checkout it lives in. To drive a different checkout, set specDir to \
+that checkout's spec/ path instead.\
+\>", "Text",ExpressionUUID->"ec5dc349-252d-432f-a10c-9714a8da13a4"],
+
+Cell[CellGroupData[{
+
+Cell["Startup", "Section",ExpressionUUID->"7100d48d-c301-48b5-80b2-df764da0b79d"],
+
+Cell["\<\
+Fresh kernel first when reloading after engine or spec changes \
+(MiolingoSpec.wl is otherwise a clean full reload \[LongDash] it re-Gets the \
+engine, which resets agentDefs).\
+\>", "Text",ExpressionUUID->"40d8258f-ee2d-4040-8b2c-2ee87f713349"],
+
+Cell["Quit[]", "Input",ExpressionUUID->"9f6e5f78-e105-4293-816c-9d2082986a75"],
+
+Cell["specDir = NotebookDirectory[];", "Input",
+ InitializationCell->
+  True,ExpressionUUID->"cae8848f-f7fb-446e-b6e6-7bd88b7ed3a3"],
+
+Cell["Get[FileNameJoin[{specDir, \"MiolingoSpec.wl\"}]];", "Input",
+ InitializationCell->
+  True,ExpressionUUID->"27e349ed-39c5-4705-b429-5bcadcced29b"],
+
+Cell["Get[FileNameJoin[{specDir, \"walk.wl\"}]];", "Input",
+ InitializationCell->
+  True,ExpressionUUID->"176ba92d-25de-4e09-aceb-0f7a2e21d504"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Walk the composed system", "Section",ExpressionUUID->"6f844d3b-9ec6-4cc7-855b-b452f0ba1099"],
+
+Cell["\<\
+The call-based twin, stepped with transNamed \[LongDash] the compact layout: \
+toolbar (Reset / Back / Forward / auto-\[Tau] / build stamp), data view as \
+tabs (one per view port \[LongDash] click to recover the others), collapsible \
+cloud + runners + trace. Tick auto-\[Tau] so the internal syncs (langRead, \
+vocabRead, progressAppend, \[Ellipsis]) fire between your steps.\
+\>", "Text",ExpressionUUID->"5553da6f-1fe7-42ec-bf23-bcd88c8311c3"],
+
+Cell["walkUI[mioCoreD, \"TransitionFunction\" -> transNamed]", "Input",ExpressionUUID->"79bb0884-44fc-49f4-9ad0-7cabe3866958"],
+
+Cell["\<\
+Shorthands: walkMioD[] is the cell above; walkMio[] is the mu-term twin \
+(mioCore, transVP). The pre-compression stacked data view is \"DataLayout\" \
+-> \"Stack\":\
+\>", "Text",ExpressionUUID->"21709381-e58b-4970-9ed2-23772681737d"],
+
+Cell["\<\
+walkUI[mioCoreD, \"TransitionFunction\" -> transNamed, \"DataLayout\" -> \
+\"Stack\"]\
+\>", "Input",ExpressionUUID->"d0bccefa-509e-494a-9db3-19fd7733315b"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Inspect without the GUI", "Section",ExpressionUUID->"b8e7d755-a18b-4dbc-a6c8-b048b4b7ac60"],
+
+Cell["readyTransitions[transNamed, mioCoreD][[All, 1]] // Column", "Input",ExpressionUUID->"9f4bf985-047f-48cb-9305-2048b517a1b9"],
+
+Cell["viewProjections[transNamed, mioCoreD] // Map[Short[#, 2] &]", "Input",ExpressionUUID->"0bceb0ef-3901-4827-bbf5-859476aeed45"],
+
+Cell["\<\
+Run a curated plan headlessly and read the final projections (the same plans \
+as walkUI's Run-test menu):\
+\>", "Text",ExpressionUUID->"2e084dd7-10d9-4fd0-ba8f-5b4daefebdc7"],
+
+Cell["\<\
+w = walkSteps[transNamed, mioCoreD, walkTests[\"sync-progress\"], \"AutoTau\" \
+-> True];
+viewProjections[transNamed, Last[w[\"states\"]]][\"statsView\"]\
+\>", "Input",ExpressionUUID->"3e836241-f49f-4b66-a9c9-dc7d0dc74cbb"],
+
+Cell["?walkUI", "Input",ExpressionUUID->"fe011ae1-804f-4fbc-aa46-7b3cc4618b9c"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell["Headless tests", "Section",ExpressionUUID->"8142d81d-5029-4faf-b407-b0d7eff5ef42"],
+
+Cell["\<\
+The suite is spec/tests/*.wls, one wolframscript kernel each. From a shell:  \
+for f in spec/tests/*.wls; do wolframscript -file \"$f\"; done \[LongDash] or \
+run one from here:\
+\>", "Text",ExpressionUUID->"18d02192-ee59-4855-b51b-0cb64db9a79a"],
+
+Cell["\<\
+RunProcess[{\"wolframscript\", \"-file\", FileNameJoin[{specDir, \"tests\", \
+\"progress_flow_test.wls\"}]}][\"StandardOutput\"] // Print\
+\>", "Input",ExpressionUUID->"34617d76-82f5-4f17-8206-6da370fc7a2e"]
+}, Open  ]]
+}, Open  ]]
+},
+WindowSize->{1100, 850},
+FrontEndVersion->"14.3 for Mac OS X ARM (64-bit) (July 8, 2025)",
+StyleDefinitions->"Default.nb",
+ExpressionUUID->"ff674e7c-40ad-431a-901f-08ea1b2989a2"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[CellGroupData[{
+Cell[576, 22, 114, 0, 70, "Title",ExpressionUUID->"65003cc9-1e94-4b24-8df4-1578d8cd7ba9"],
+Cell[693, 24, 274, 4, 70, "Text",ExpressionUUID->"ec5dc349-252d-432f-a10c-9714a8da13a4"],
+Cell[CellGroupData[{
+Cell[992, 32, 81, 0, 70, "Section",ExpressionUUID->"7100d48d-c301-48b5-80b2-df764da0b79d"],
+Cell[1076, 34, 255, 4, 70, "Text",ExpressionUUID->"40d8258f-ee2d-4040-8b2c-2ee87f713349"],
+Cell[1334, 40, 78, 0, 70, "Input",ExpressionUUID->"9f6e5f78-e105-4293-816c-9d2082986a75"],
+Cell[1415, 42, 132, 2, 70, "Input",ExpressionUUID->"cae8848f-f7fb-446e-b6e6-7bd88b7ed3a3",
+ InitializationCell->True],
+Cell[1550, 46, 152, 2, 70, "Input",ExpressionUUID->"27e349ed-39c5-4705-b429-5bcadcced29b",
+ InitializationCell->True],
+Cell[1705, 50, 144, 2, 70, "Input",ExpressionUUID->"176ba92d-25de-4e09-aceb-0f7a2e21d504",
+ InitializationCell->True]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[1886, 57, 98, 0, 70, "Section",ExpressionUUID->"6f844d3b-9ec6-4cc7-855b-b452f0ba1099"],
+Cell[1987, 59, 456, 6, 70, "Text",ExpressionUUID->"5553da6f-1fe7-42ec-bf23-bcd88c8311c3"],
+Cell[2446, 67, 126, 0, 70, "Input",ExpressionUUID->"79bb0884-44fc-49f4-9ad0-7cabe3866958"],
+Cell[2575, 69, 244, 4, 70, "Text",ExpressionUUID->"21709381-e58b-4970-9ed2-23772681737d"],
+Cell[2822, 75, 165, 3, 70, "Input",ExpressionUUID->"d0bccefa-509e-494a-9db3-19fd7733315b"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3024, 83, 97, 0, 70, "Section",ExpressionUUID->"b8e7d755-a18b-4dbc-a6c8-b048b4b7ac60"],
+Cell[3124, 85, 130, 0, 70, "Input",ExpressionUUID->"9f4bf985-047f-48cb-9305-2048b517a1b9"],
+Cell[3257, 87, 131, 0, 70, "Input",ExpressionUUID->"0bceb0ef-3901-4827-bbf5-859476aeed45"],
+Cell[3391, 89, 185, 3, 70, "Text",ExpressionUUID->"2e084dd7-10d9-4fd0-ba8f-5b4daefebdc7"],
+Cell[3579, 94, 233, 4, 70, "Input",ExpressionUUID->"3e836241-f49f-4b66-a9c9-dc7d0dc74cbb"],
+Cell[3815, 100, 79, 0, 70, "Input",ExpressionUUID->"fe011ae1-804f-4fbc-aa46-7b3cc4618b9c"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[3931, 105, 88, 0, 70, "Section",ExpressionUUID->"8142d81d-5029-4faf-b407-b0d7eff5ef42"],
+Cell[4022, 107, 256, 4, 70, "Text",ExpressionUUID->"18d02192-ee59-4855-b51b-0cb64db9a79a"],
+Cell[4281, 113, 217, 3, 70, "Input",ExpressionUUID->"34617d76-82f5-4f17-8206-6da370fc7a2e"]
+}, Open  ]]
+}, Open  ]]
+}
+]
+*)
+

--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -58,6 +58,15 @@
    appear in the external ready set (it is internal); it is enabled as a tau only
    while a borrower waits at langRead? (currently: just after `autofill`). PS
    scoring is the next borrower to wire (b2).
+
+   ATTEMPT LOG (2026-07-06): ProgressTable (the user_progress store) is composed
+   in, resolving the † Stats/History incompleteness. progressAppend is RESTRICTED
+   with two writers — PS.attempt_made and StoryReader.story_attempt_made, whose
+   scoring chains are now attempt_made · langRead(τ) · progressAppend(τ) — so
+   every scored attempt lands in the store, as _persist_result does in the app.
+   The external ready set additionally shows progressRead (the raw SELECT
+   surface; no internal borrower yet) and the statsView / historyView query
+   projections (the Statistics / History tabs).
    ===================================================================== *)
 
 (* The component decomposition, named once and reused: by merge/mergeDefined to
@@ -69,14 +78,22 @@ mioComponents =
    "Vocab"       -> call["Vocab", signedIn, alpha, none, none],   (* (i): NO entries — they live in VocabTable *)
    "Helm"        -> call["Helm", "English", "fr", google, 250, system, base],
    "VocabTable"  -> call["VocabTable", {}],                       (* the persisted collection, owned here *)
-   "StoryReader" -> call["StoryReader", 0, 0, browse, none, none]};  (* narrative tab; practice mode
+   "StoryReader" -> call["StoryReader", 0, 0, browse, none, none],  (* narrative tab; practice mode
        mirrors PSActive, capturing via vocabUpsert + scoring via langRead — no NEW restricted channels *)
+   "ProgressTable" -> call["ProgressTable", {}]};  (* the attempt store (user_progress):
+       PS + StoryReader scoring APPEND via progressAppend (restricted); Statistics /
+       History are its statsView/historyView query projections — the † recovery *)
 
 mioRestricted = {label["goPractice"], label["langRead"],
                  (* the VocabTable channels: the Vocab tab and PS read/write the store
                     internally. vocabUpsert has two writers (tab add + PS capture). *)
                  label["vocabRead"], label["vocabUpsert"], label["vocabImport"],
-                 label["vocabRemove"], label["vocabAmend"]};
+                 label["vocabRemove"], label["vocabAmend"],
+                 (* the ProgressTable write channel: two writers (PS attempt_made +
+                    StoryReader story_attempt_made — both loops persist via
+                    _persist_result). progressRead stays EXTERNAL (no internal
+                    borrower yet), as do the statsView/historyView projections. *)
+                 label["progressAppend"]};
 
 mioCore = merge[mioComponents, mioRestricted];
 

--- a/spec/MiolingoSpec.wl
+++ b/spec/MiolingoSpec.wl
@@ -53,4 +53,7 @@ mioGet["PracticeSessionFunctions.wl"];
    agent — no control guard reads the language, so no restricted sync. *)
 mioGet["HelmFunctions.wl"];
 mioGet["StoryFunctions.wl"];   (* sceneOf (story-content boundary) + storyView *)
+mioGet["ProgressFunctions.wl"];   (* attempt-store functions; before MioCore for the
+                                     same eager-projection reason as HelmFunctions
+                                     (statsOf[{}]/historyOf[{}] compute at merge) *)
 mioGet["MioCore.wl"];

--- a/spec/PracticeSessionRecovered.wl
+++ b/spec/PracticeSessionRecovered.wl
@@ -108,10 +108,20 @@ defineAgent["PSActive", {phrases, pos, rec, res},
       precede[coLabel["recording_made", binding[audio]],
         call["PS", phrases, pos, recorded[audio], none]],
       choice[
+        (* scoring PERSISTS: the app saves every scored attempt immediately
+           (_persist_result -> save_practice, practice_tab.py:44), so the chain
+           is attempt_made · langRead(τ, borrow the language) · progressAppend(τ,
+           write the attempt to ProgressTable) — the write is part of scoring,
+           not a separate user action. Same mid-handoff NB as capture_vocab:
+           L3 must treat score-and-log as ATOMIC (no view flicker over the
+           two τ's). attemptRecord re-states the evaluate term (no let in
+           value-passing CCS); both occurrences compute identically. *)
         precede[coLabel["attempt_made"],
           precede[coLabel["langRead", binding[lp]],
-            call["PS", phrases, pos, rec,
-              scored[evaluate[targetOf[phrases, pos], rec, lp]]]]],
+            precede[label["progressAppend",
+                param[attemptRecord[targetOf[phrases, pos], rec, lp]]],
+              call["PS", phrases, pos, rec,
+                scored[evaluate[targetOf[phrases, pos], rec, lp]]]]]],
         precede[coLabel["clear_recording"],
           call["PS", phrases, pos, none, none]]]],
     if[pos < Length[phrases] - 1,

--- a/spec/ProgressFunctions.wl
+++ b/spec/ProgressFunctions.wl
@@ -1,0 +1,92 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — ProgressTable value-functions, RECOVERED (function pass)
+   ---------------------------------------------------------------------
+   The function-recovery pass for ProgressTable: the stubs named in
+   ProgressTableRecovered.wl (appendAttempt, statsOf, historyOf) and the
+   writers' record builder (attemptRecord) get bodies RECOVERED from
+   src/app_mysql.py (save_practice / get_user_stats / get_user_progress)
+   and src/ui/history_tab.py — NOT invented. See
+   spec/docs/function-recovery.md for the pass discipline.
+
+   ADDITIVE: attaches downvalues to stub symbols only; does not modify
+   ProgressTableRecovered.wl. Load AFTER it and BEFORE MioCore.wl (the
+   helmView rule: mioCore's merge computes the initial projections
+   eagerly, so statsOf[{}]/historyOf[{}] must already have bodies).
+
+   RECORD SHAPE (save_practice's INSERT columns, app_mysql.py:1660):
+     <|"language_code", "target_phrase", "recognized_phrase",
+       "similarity_score", "perfect_match", "target_phonemes",
+       "user_phonemes"|>
+   user_id and practice_date are OUT OF THE MODEL (single-user L1; the DB
+   stamps NOW[] — the clock is external; see the walk cloud).
+
+   HELD-UNTIL-CONCRETE (the recognisedOf discipline, commit "hold the
+   score symbolic"): while the ASR oracle is uninterpreted, evaluate[…]
+   stays a symbolic term — so attemptRow stays held (gated on _Association)
+   and the APPENDED RECORD is symbolic. The append τ still fires (the app
+   always inserts); the stats/history projections then compute over the
+   CONCRETE rows only and surface the symbolic ones as a "pending" count,
+   keeping the views honest Associations rather than warning-panel stubs.
+   ===================================================================== *)
+
+
+(* --- attemptRecord[target, rec, lp] : the row a scoring chain writes ------
+   What _persist_result (practice_tab.py:44) passes to save_practice, built
+   from the SAME evaluate the chain wraps in scored[…] (value-passing CCS has
+   no let; the duplicated evaluate term is the idiom, and with bodies loaded
+   both occurrences compute identically). lp is the BORROWED (source, target)
+   pair the chain just pulled on langRead — the record carries its language
+   (language_code = the target code), which is what lets reads filter
+   per-language WITHOUT borrowing at read time.
+   NB the app's recognized_phrase is the ASR transcript TEXT — an oracle
+   detail below the L1 boundary (function-recovery.md: L1 scores phonemes);
+   the recognised PHONEME string stands in for it here. *)
+attemptRow[r_Association, target_Association, lp_List] := <|
+  "language_code"     -> Last[lp],
+  "target_phrase"     -> Lookup[target, "text", ""],
+  "recognized_phrase" -> Lookup[r, "user", ""],
+  "similarity_score"  -> Lookup[r, "similarity", 0],
+  "perfect_match"     -> Lookup[r, "exact_match", False],
+  "target_phonemes"   -> Lookup[r, "target", ""],
+  "user_phonemes"     -> Lookup[r, "user", ""]|>;
+attemptRecord[target_, rec_, lp_List] :=
+  attemptRow[evaluate[target, rec, lp], target, lp];
+
+(* --- appendAttempt[records, r] : save_practice's INSERT (app_mysql.py:1628).
+   Plain append — NO dedup/upsert (every attempt is a new row; contrast
+   addEntry's INSERT … ON DUPLICATE KEY UPDATE). NOT gated on r_Association:
+   the insert always happens in the app, so the τ always extends the log —
+   a symbolic record is an honest "scored, oracle pending" row. *)
+appendAttempt[records_List, r_] := Append[records, r];
+
+(* --- statsOf[records] : get_user_stats (app_mysql.py:1736) ---------------
+   the row COUNT, SUM of perfect_match, AVG of similarity_score, and the AVG
+   over the last-10-by-practice_date subquery (insertion order stands in for
+   the date ordering — same total order, no external clock needed). Keys mirror
+   the app's dict ('total', 'perfect_count', 'avg_score', 'recent_avg').
+   Aggregates run over the CONCRETE rows; symbolic (oracle-pending) rows
+   are counted in "pending" rather than poisoning the numbers. No rows →
+   None (the tab's "No practice history yet"), not the app's 0.0 coercion
+   (a display choice, below L1). *)
+statsOf[records_List] := Module[
+  {c = Select[records, AssociationQ], scores},
+  scores = Lookup[#, "similarity_score", 0] & /@ c;
+  <|"total"         -> Length[records],
+    "perfect_count" -> Count[c, r_ /; TrueQ[Lookup[r, "perfect_match", False]]],
+    "avg_score"     -> If[scores === {}, None, Mean[scores]],
+    "recent_avg"    -> If[scores === {}, None,
+                          Mean[Take[scores, -Min[10, Length[scores]]]]],
+    "pending"       -> Length[records] - Length[c]|>];
+
+(* --- historyOf[records] : load_history (history_tab.py:20) ---------------
+   get_user_progress ORDER BY practice_date DESC (newest first; insertion
+   order reversed — same total order) with the per-practice fields the tab
+   renders (history_tab.py:34). The app's LIMIT 100 and group-by-date are
+   presentation over the external clock's stamp — below the L1 boundary.
+   Concrete rows tabulate; oracle-pending rows surface as a count. *)
+historyOf[records_List] := <|
+  "total"    -> Length[records],
+  "attempts" -> Reverse[Select[records, AssociationQ]],
+  "pending"  -> Count[records, Except[_Association]]|>;

--- a/spec/ProgressTableRecovered.wl
+++ b/spec/ProgressTableRecovered.wl
@@ -1,0 +1,94 @@
+(* ::Package:: *)
+
+(* =====================================================================
+   miolingo / L1 — ProgressTable (the attempt store), RECOVERED
+   ---------------------------------------------------------------------
+   Recovered from src/app_mysql.py (the `user_progress` MySQL table) +
+   src/ui/statistics_tab.py + src/ui/history_tab.py, NOT invented. Every
+   scored attempt in the app is persisted IMMEDIATELY by save_practice
+   (app_mysql.py:1628, an INSERT INTO user_progress) from practice_tab's
+   _persist_result (practice_tab.py:44) — and BOTH practice loops go
+   through it: Quick Practice and Story practice mode share
+   render_practice_interface (story_tab.py:279, quick_practice_tab.py:1030).
+   ProgressTable is the agent that OWNS that persisted attempt log.
+
+   (ProgressTable, per the ARCHITECTURE naming rule: store agents are named
+   after their TABLE — user_progress — as VocabTable is after vocab_entries.
+   This resolves the older "Ledger/AttemptTable" placeholder in the
+   Component Inventory.)
+
+   THE POINT (the † Stats/History note, ARCHITECTURE.md): stats and history
+   were the flagged incompleteness — "view ports backed by store queries,
+   not in-process state, not yet recovered". This is that recovery: the
+   store OWNS the records; Statistics and History are PUBLISHED QUERY
+   PROJECTIONS on the store (statsView / historyView), not standalone
+   interactive agents and not state held by PS. PS/StoryReader only WRITE,
+   through the restricted append channel — completing the data flow
+     attempt_made · langRead(τ) · progressAppend(τ)  →  records
+     → statsView!(statsOf records) / historyView!(historyOf records).
+
+   STATE: ProgressTable[records] — the persisted attempt log (list, in
+   insertion order; the app's practice_date DESC read = newest-first, so
+   reads reverse it).
+
+   PORTS (mirror the user_progress SQL surface):
+     progressRead!    always — emits the current records (a self-loop,
+                  never changing ProgressTable). ≈ get_user_progress SELECT
+                  (app_mysql.py:1700). No composed component pulls it yet,
+                  so it stays EXTERNAL (the raw query surface); the first
+                  internal borrower (e.g. a practise-weakest route) will
+                  restrict it exactly as vocabRead is.
+     progressAppend   record an attempt — save_practice's plain INSERT
+                  (append-only: NO upsert — every attempt is a new row,
+                  unlike vocabUpsert's dedup). ONE port, TWO writers sync
+                  on it (the vocabUpsert precedent): PS.attempt_made and
+                  StoryReader.story_attempt_made. RESTRICTED in mioCore —
+                  only the scoring chains write, matching the app (the
+                  insert happens inside _persist_result, not at any user-
+                  facing surface).
+     statsView!   always — get_user_stats (app_mysql.py:1736): total,
+                  perfect_count, avg_score, recent_avg (last 10). A
+                  query-backed view port (the Statistics tab's read).
+     historyView! always — get_user_progress newest-first (history_tab.py:20
+                  load_history). A query-backed view port (the History
+                  tab's read).
+
+   OUT OF THE MODEL (the walk cloud): user_id (L1 is single-user) and
+   practice_date (the DB stamps NOW[] at insert — the CLOCK is external).
+   Per-language filtering of the reads (get_user_stats/get_user_progress
+   filter by the CURRENT language) is presentation over the published
+   projection for now: records CARRY their language_code (baked in at
+   write time from the langRead borrow), so the projection can be filtered
+   downstream without borrowing at read time. The day a filtered-at-source
+   query port is wanted, it enters as a value-carrying read (a query
+   protocol) — the † rigging question, now concrete.
+
+   LEAF agent (every branch loops back to ProgressTable) — no sub-agent
+   expansion. Value-functions (appendAttempt/statsOf/historyOf/
+   attemptRecord) live in ProgressFunctions.wl, loaded after (the
+   *Functions.wl pattern); they resolve at step time.
+
+   LOAD ORDER: RCA_core.wl, discipline.wl, then this (alongside the other
+   recovered agents); ProgressFunctions.wl before MioCore.wl (mioCore's
+   merge eagerly computes the initial projections — the helmView rule).
+   ===================================================================== *)
+
+defineAgent["ProgressTable", {records},
+  choice[
+    (* @src app_mysql.py:1700 (get_user_progress) — SELECT * FROM user_progress … *)
+    precede[label["progressRead", param[records]],
+      call["ProgressTable", records]],
+    (* @src app_mysql.py:1628 (save_practice) — INSERT INTO user_progress …
+       (plain INSERT: append-only, no dedup). Two writers: PS.attempt_made and
+       StoryReader.story_attempt_made, both via _persist_result. *)
+    precede[coLabel["progressAppend", binding[r]],
+      call["ProgressTable", appendAttempt[records, r]]],
+    (* @src app_mysql.py:1736 (get_user_stats) — the Statistics tab's numbers
+       (statistics_tab.py:49): total, perfect_count, avg_score, recent_avg. *)
+    precede[label["statsView", param[statsOf[records]]],
+      call["ProgressTable", records]],
+    (* @src history_tab.py:20 (load_history) — newest-first attempt log
+       (grouping by practice_date is presentation over the external clock's
+       stamp, so it stays below the L1 boundary). *)
+    precede[label["historyView", param[historyOf[records]]],
+      call["ProgressTable", records]]]]

--- a/spec/StoryReaderRecovered.wl
+++ b/spec/StoryReaderRecovered.wl
@@ -95,10 +95,16 @@ defineAgent["StoryPractice", {scene, pos, rec, res},
       precede[coLabel["story_recording_made", binding[audio]],
         call["StoryReader", scene, pos, practice, recorded[audio], none]],
       choice[
+        (* scoring PERSISTS here too: story practice runs the SAME
+           render_practice_interface (story_tab.py:279) whose _persist_result
+           saves every attempt — so the SECOND writer on progressAppend (the
+           vocabUpsert two-writer precedent). Chain mirrors PSActive's. *)
         precede[coLabel["story_attempt_made"],
           precede[coLabel["langRead", binding[lp]],
-            call["StoryReader", scene, pos, practice, rec,
-              scored[evaluate[targetOf[sceneOf[scene], pos], rec, lp]]]]],
+            precede[label["progressAppend",
+                param[attemptRecord[targetOf[sceneOf[scene], pos], rec, lp]]],
+              call["StoryReader", scene, pos, practice, rec,
+                scored[evaluate[targetOf[sceneOf[scene], pos], rec, lp]]]]]],
         precede[coLabel["story_clear_recording"],
           call["StoryReader", scene, pos, practice, none, none]]]],
     if[pos < Length[sceneOf[scene]] - 1,

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -62,7 +62,8 @@ Two tiers: **interactive agents** (UI-facing) and **store agents** (the data tie
 | Session / language | `Helm` | Interactive — finite-choice settings; **owns the (source, target) language pair** | **recovered + composed** ‡ |
 | Vocab store | `VocabTable` | **Store** — the persisted vocab collection (DB `vocab_entries`) | **recovered + composed** |
 | Story Reader | `StoryReader` | Interactive — narrative nav + 3 modes; one shared position; practice mode mirrors `PSActive` | **recovered + composed** |
-| Stats / History † | (read projections over a `Ledger` store) | view ports backed by store queries — **not** standalone interactive agents | Medium |
+| Attempt store | `ProgressTable` | **Store** — the persisted attempt log (DB `user_progress`); PS + StoryReader scoring write it via restricted `progressAppend` | **recovered + composed** † |
+| Stats / History † | `statsView` / `historyView` **on `ProgressTable`** | view ports backed by store queries — **not** standalone interactive agents | **recovered** (as query projections) |
 | Mode Navigation | ~~`ModeSelector`~~ **eliminated** | each mode carries its own *visible* entry instead | — |
 
 Correction from the previous draft: the read-only "displays" are most likely *view ports on* the stateful agents (a published `view!` projection rendered by a skin), not agents in their own right. Promote one to a standalone agent only if it genuinely owns state; otherwise it is a presentation of another agent's projection. Decide this deliberately per component.
@@ -78,7 +79,7 @@ Store agents are named after their **table**, not generically, because table-fai
 | `chRead`/`chUpsert`/`chImport`/`chRemove`/`chAmend`, `vAdd` | `vocabRead`/`vocabUpsert`/`vocabImport`/`vocabRemove`/`vocabAmend` | table-scoped channels (multiple stores can't share generic `ch*` — a reader couldn't route). `vAdd` (PS capture) collapsed into `vocabUpsert` (same upsert, two writers) |
 | `vSView` (view port) | `vocabView` | follows the `decap[name]<>"View"` rule |
 
-`Helm` keeps its nautical name (it's a controller, not a store). Future store tables follow the same scheme (`Ledger`/`AttemptTable`… for stats/history).
+`Helm` keeps its nautical name (it's a controller, not a store). Store tables follow the same scheme: the stats/history store — placeholder-named `Ledger`/`AttemptTable` in earlier drafts — landed as **`ProgressTable`** (the table is `user_progress`), with table-scoped channels `progressRead`/`progressAppend` (append-only: `save_practice` is a plain INSERT, no upsert — contrast `vocabUpsert`).
 
 **‡ Helm and how the language reaches its consumers.** Helm is composed into
 `mioCore` as a **pure parallel** agent (no restricted sync): it *owns* the
@@ -110,7 +111,9 @@ depend on the language, **that** edge must enter the model as a restricted sync 
 and, being a guard over *borrowed* data, is the one case that may force a
 calculus extension (see below).
 
-**† Stats / History and the external store (a rigging issue).** Treating these as *view ports* is correct only under the current modelling assumption that each component stores its own domain data in-process. In any sensible implementation, stats and history are retrieved from an **external store**, not held by the component. Rigging that external store into the system — where the data lives, who reads/writes it, how a view port is backed by a *query* rather than in-process state — is a key **rig** concern, and the question of *how* it is done may itself need to enter the model (an external-store agent / port), not be left wholly to L3. Flagged for when stats/history (and persistence generally) are recovered.
+**† Stats / History and the external store (a rigging issue — now recovered, 2026-07-06).** Treating these as *view ports* is correct only under the current modelling assumption that each component stores its own domain data in-process. In any sensible implementation, stats and history are retrieved from an **external store**, not held by the component. Rigging that external store into the system — where the data lives, who reads/writes it, how a view port is backed by a *query* rather than in-process state — is a key **rig** concern, and the question of *how* it is done may itself need to enter the model (an external-store agent / port), not be left wholly to L3.
+
+*Resolution:* the store entered the model as **`ProgressTable`** (the `user_progress` table), on the VocabTable pattern. The data flow it completes: every scored attempt is **written as part of scoring** — the chain `attempt_made · langRead(τ) · progressAppend(τ)` in both practice loops (the app's `_persist_result` → `save_practice` runs inside the scoring path, with **two writers** on one channel, the `vocabUpsert` precedent) — and Statistics / History are the store's **query projections** `statsView!(statsOf records)` / `historyView!(historyOf records)`, not standalone agents and not PS state. `progressAppend` is restricted (only scoring writes, as in the app); `progressRead` (the raw SELECT surface) stays external until the first internal borrower restricts it, exactly as `vocabRead` was. Records **carry** their `language_code` (baked in from the `langRead` borrow at write time), so per-language filtering of the reads is presentation over the published projection — no borrow at read time; a filtered-at-source *query port* (a value-carrying read) is the remaining rig option if one is ever wanted. Out of the model, honestly in the cloud: `user_id` (L1 is single-user) and `practice_date` (the DB's clock stamps rows; insertion order stands in for date order). What remains of `†` generally is rigging the model stores to the *real* MySQL tables — see `walk.wl`'s cloud inventory. See `spec/docs/progress-table-recovery.md`.
 
 ## Borrowed vs Owned Data (decision)
 

--- a/spec/docs/PROVENANCE.md
+++ b/spec/docs/PROVENANCE.md
@@ -70,6 +70,7 @@ indexed below). Columns:
 | Helm (session/language) | `HelmRecovered.wl` | `helm-recovery.md` | recovered (table: back-fill pending) |
 | VocabTable (vocab store) | `VocabTableRecovered.wl` | `vocab-table-recovery.md` | recovered + composed |
 | Story Reader | `StoryReaderRecovered.wl` | `story-reader-recovery.md` | recovered + composed (one position — a deliberate deviation; loop written per-context, an engine boundary case) |
+| ProgressTable (attempt store) | `ProgressTableRecovered.wl` | `progress-table-recovery.md` | recovered + composed (table shipped with the recovery) |
 
 (Names per the 2026-06-03 rename — ARCHITECTURE.md "Naming": the tab is `Vocab`, the store `VocabTable`; channels are `vocab*`. The worked example below predates the rename and keeps its original names.)
 

--- a/spec/docs/progress-table-recovery.md
+++ b/spec/docs/progress-table-recovery.md
@@ -1,0 +1,100 @@
+# ProgressTable Recovery — the attempt store (stats / history)
+
+**Status: recovered + composed (2026-07-06).** This resolves the `†`
+Stats/History incompleteness flagged in `ARCHITECTURE.md` and carried in the
+walk cloud as "not yet recovered". Files: `ProgressTableRecovered.wl` (agent),
+`ProgressFunctions.wl` (function pass), writers wired in
+`PracticeSessionRecovered.wl` / `StoryReaderRecovered.wl`, composed in
+`MioCore.wl`, pinned by `spec/tests/progress_flow_test.wls`.
+
+## What was recovered, from where
+
+The app persists **every scored attempt immediately**: scoring runs
+`_persist_result` (`src/ui/practice_tab.py:44`) which calls `save_practice`
+(`src/app_mysql.py:1628`) — a plain `INSERT INTO user_progress`. Both practice
+loops go through the same interface (`render_practice_interface`:
+`story_tab.py:279`, `quick_practice_tab.py:1030`), so story practice persists
+identically. Reads are queries over the same table:
+
+| App read | Source | Spec recovery |
+|---|---|---|
+| Statistics tab numbers | `get_user_stats` (`app_mysql.py:1736`): total, perfect_count, avg_score, recent_avg (last 10 by date) | `statsView!(statsOf records)` |
+| History tab sessions | `load_history` (`history_tab.py:20`) over `get_user_progress` (newest first) | `historyView!(historyOf records)` |
+| Raw rows | `get_user_progress` (`app_mysql.py:1700`) | `progressRead!(records)` — the SELECT surface |
+
+## The shape (VocabTable pattern, per-table naming)
+
+`ProgressTable[records]` — a leaf store agent named after its table
+(`user_progress`), resolving the older `Ledger`/`AttemptTable` placeholder.
+Channels are table-scoped: `progressRead` / `progressAppend`. The append is
+**append-only** (every attempt is a new row) — deliberately *not* an upsert,
+unlike `vocabUpsert`'s dedup.
+
+**The write is part of scoring, not a user action.** Both scoring chains
+extend by one action:
+
+```
+attempt_made        · langRead?(lp) · progressAppend!(attemptRecord …) · PS′
+story_attempt_made  · langRead?(lp) · progressAppend!(attemptRecord …) · StoryReader′
+```
+
+- `progressAppend` is **restricted** in `mioCore` (an internal τ): only the
+  scoring chains write, matching the app (the insert lives inside
+  `_persist_result`, behind no user-facing surface). One port, **two
+  writers** — the `vocabUpsert` precedent.
+- The mid-handoff NB from `capture_vocab` extends: the chain holds PS/
+  StoryReader between `attempt_made` and the second τ, so L3 must treat
+  score-and-log as **atomic** (no view flicker).
+- Stats and History are **query projections on the store** — the Component
+  Inventory's "view ports backed by store queries, not standalone interactive
+  agents", made literal.
+
+## Decisions a reviewer should check
+
+1. **Naming.** `ProgressTable`, not `Ledger`/`AttemptTable`: the naming rule
+   ("store agents are named after their table") post-dates the placeholder
+   and wins. Rename is a one-file-set mechanical change if rejected.
+2. **Record shape.** `save_practice`'s INSERT columns minus `user_id`
+   (single-user L1) and `practice_date` (the clock is the DB's — insertion
+   order stands in for date order; both are cloud items now). The app's
+   `recognized_phrase` is the ASR transcript *text* — an oracle detail below
+   the L1 boundary — so the recognised *phoneme string* stands in.
+3. **Language at read time.** `get_user_stats`/`get_user_progress` filter by
+   the *current* language; a view self-loop cannot borrow (`langRead`) as a
+   projection prefix. Records instead **carry** `language_code` (baked in
+   from the write-time borrow), so filtering is presentation over the
+   published projection. If a filtered-at-source read is ever wanted, it
+   enters as a value-carrying **query port** — the remaining rig option.
+4. **Held-until-concrete.** With the ASR oracle uninterpreted, the appended
+   row stays a symbolic `attemptRow[…]` term (the append τ still fires — the
+   app always inserts). `statsOf`/`historyOf` aggregate the *concrete* rows
+   and surface symbolic ones as a `pending` count, so the views stay honest
+   Associations instead of warning-panel stubs. Consistent with "hold the
+   score symbolic when the ASR oracle is uninterpreted".
+5. **`progressRead` external.** No composed component pulls the raw rows yet,
+   so it is not restricted (a dead restricted port would be unfireable). The
+   first internal borrower — e.g. a practise-weakest-phrases route — restricts
+   it exactly as `vocabRead` was.
+
+## ProgressTable — provenance  (app src @ `504f8c8`, 2026-04-26)
+
+| Spec element | Kind | Source `file:line (fn)` | App construct | Note |
+|---|---|---|---|---|
+| `ProgressTable` | agent | `app_mysql.py:1628 (save_practice)` + the `user_progress` table | per-user per-language practice log | **faithful** — the store agent for the table, VocabTable pattern. Verified: `progress_flow_test`. |
+| `progressAppend` | sync (PS/StoryReader→ProgressTable τ) | `practice_tab.py:44 (_persist_result)` → `app_mysql.py:1628 (save_practice)` | INSERT on every scored attempt, inside the scoring path | **faithful** — restricted; ONE port, TWO writers (both loops share `render_practice_interface`: `story_tab.py:279`, `quick_practice_tab.py:1030`). Append-only (no upsert). Verified: `progress_flow_test` §2/§4, `maxprog_test`. |
+| `progressRead` | port (out) | `app_mysql.py:1700 (get_user_progress)` | SELECT of the rows | **faithful** — the raw read surface; external until the first internal borrower. Verified: `progress_flow_test` §1. |
+| `statsView` | projection | `app_mysql.py:1736 (get_user_stats)`, rendered `statistics_tab.py:49` | Statistics tab: total / perfect_count / avg_score / recent_avg | **simplified** — per-language *filtering* dropped at source (rows carry `language_code`; filtering is presentation). `pending` added for oracle-held rows (no app analogue — the app always has concrete scores). Verified: `progress_flow_test` §3/§5. |
+| `historyView` | projection | `history_tab.py:20 (load_history)` over `get_user_progress` | History tab: newest-first sessions | **simplified** — group-by-date and LIMIT 100 dropped (the date is the external clock's stamp, below L1); newest-first kept via insertion order. Verified: `progress_flow_test` §3/§5. |
+| `attemptRecord` / `attemptRow` | value-fn | `practice_tab.py:52-67 (_persist_result)` | the kwargs passed to `save_practice` | **simplified** — `user_id`/`practice_date` out of the model (single-user; external clock); `recognized_phrase` stands in as the recognised *phoneme* string (the transcript text is an oracle detail). Held until the score is concrete. Verified: `progress_flow_test` §5. |
+| `appendAttempt` | value-fn | `app_mysql.py:1660` (the INSERT) | plain INSERT | **faithful** — `Append`, no dedup. Verified: `progress_flow_test` §2. |
+| `statsOf` / `historyOf` | value-fn | `app_mysql.py:1736` / `history_tab.py:27-41` | the two queries | **simplified** — aggregates over concrete rows only, `None` (not `0.0`) when empty; last-10 by insertion order. Verified: `progress_flow_test` §3/§5. |
+
+## What it pins (progress_flow_test.wls)
+
+On **both** compositions (`mioCore`/`transVP`, `mioCoreD`/`transNamed`):
+boundary (append restricted, query surface external); the write (one
+`progressAppend` τ per scored attempt, store total grows); the held
+discipline (pending count, `None` averages, the symbolic row carries the
+borrowed target code); two writers (story path appends via the same
+channel); and — with a test ASR downvalue — the concrete numeric pipeline
+(perfect_count / averages / tabulated row with `language_code`).

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -49,7 +49,7 @@ $minEngineSha = "5bcc031";
 
 mioGet::usage = "mioGet[\"file.wl\"] Gets a spec file by name, relative to $specDir (this spec directory, derived from paths.wl's own location).";
 loadEngine::usage = "loadEngine[] Gets the RCA engine ($rca = $RCA_CORE env var, else the canonical checkout) AND asserts (git merge-base --is-ancestor) that the checkout contains $minEngineSha, aborting loudly on divergence. The shared coordinate between the spec and engine repos.";
-loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the recovered agents (PracticeSessionRecovered.wl, VocabRecovered.wl, HelmRecovered.wl, VocabTableRecovered.wl) in order — the common base every spec consumer loads first. MioCore composes PS/Vocab/Helm; VocabTable is defined here and composed at the (i) migration.";
+loadRecoveredBase::usage = "loadRecoveredBase[] loads discipline.wl + the recovered agents (PracticeSessionRecovered.wl, VocabRecovered.wl, HelmRecovered.wl, VocabTableRecovered.wl, StoryReaderRecovered.wl, ProgressTableRecovered.wl) in order — the common base every spec consumer loads first. MioCore composes them all.";
 
 mioGet[file_String] := Get[$specDir <> file];
 
@@ -82,4 +82,7 @@ loadRecoveredBase[] := (
   mioGet["HelmRecovered.wl"];    (* third recovered agent; MioCore composes it *)
   mioGet["VocabTableRecovered.wl"];    (* the external store; defined here, composed
                                          into MioCore at the (i) migration (PR-2) *)
-  mioGet["StoryReaderRecovered.wl"]);  (* narrative tab; practice mode mirrors PSActive *)
+  mioGet["StoryReaderRecovered.wl"];   (* narrative tab; practice mode mirrors PSActive *)
+  mioGet["ProgressTableRecovered.wl"]);  (* the attempt store (user_progress); PS +
+                                         StoryReader scoring write it, stats/history
+                                         are its query projections *)

--- a/spec/paths.wl
+++ b/spec/paths.wl
@@ -42,10 +42,14 @@ $rca = With[{e = Environment["RCA_CORE"]},
   If[StringQ[e] && e =!= "", e,
      "/Users/matthew/Projects/private/Mathematica/RCA/RCA_core.wl"]];
 
-(* Oldest engine commit this spec requires — PR #36 (walk + replayTrace),
-   which descends from native guard/choice (#33), substVv guard-ground (#34)
-   and transNamed[relabel] (#35). Bump when adopting newer engine capability. *)
-$minEngineSha = "5bcc031";
+(* Oldest engine commit this spec requires — the comprehension capture fix
+   + compiled transVP/transNamed (branch compiled-trans-capture-fix; the
+   spec's binders ps/m/s were mangled in value-sync successors before it,
+   and walk_sequences_test needs the compiled speed). Descends from PR #36
+   (walk + replayTrace) <- #35 transNamed[relabel] <- #34 substVv
+   guard-ground <- #33 native guard/choice. Bump when adopting newer
+   engine capability. *)
+$minEngineSha = "fd7afae9f";
 
 mioGet::usage = "mioGet[\"file.wl\"] Gets a spec file by name, relative to $specDir (this spec directory, derived from paths.wl's own location).";
 loadEngine::usage = "loadEngine[] Gets the RCA engine ($rca = $RCA_CORE env var, else the canonical checkout) AND asserts (git merge-base --is-ancestor) that the checkout contains $minEngineSha, aborting loudly on divergence. The shared coordinate between the spec and engine repos.";

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -37,7 +37,8 @@ Print[hr]; Print["2. transGroup / inputsFirst"]; Print[hr];
 (* a real tau transition: drive capture_vocab so vocabUpsert is pending *)
 sV = Last[walkSteps[transVP, mioCore,
    {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
-    vis["recording_made", "audio"], vis["attempt_made"], tau["langRead"], vis["capture_vocab", "chat"]}]["states"]];
+    vis["recording_made", "audio"], vis["attempt_made"],
+    tau["langRead"], tau["progressAppend"], vis["capture_vocab", "chat"]}]["states"]];
 tauTr = SelectFirst[readyTransitions[transVP, sV], isTauAct[First[#]] &];
 assert["a tau transition groups into internal (tau)",
   transGroup[pm, tauTr] === "internal (\[Tau])"];
@@ -54,11 +55,12 @@ Print[hr]; Print["3. the SETTLED mioCore ready set partitions cleanly (no 'other
 (* Vocab gates behind open_vocab so it contributes that; StoryReader is live (browse
    mode) so it contributes its view/mode/nav ports; PS (empty) and Helm contribute
    too. VocabTable's ports are all restricted (internal τ), so it never appears in the
-   external grouping. *)
+   external grouping. ProgressTable DOES appear: its append is restricted but its
+   query surface (progressRead + statsView/historyView) is external. *)
 sInit = Last[walkSteps[transVP, mioCore, {}, "AutoTau" -> True]["states"]];
 grp = GroupBy[readyTransitions[transVP, sInit], transGroup[pm, #] &];
-assert["groups are exactly {Vocab, PS, Helm, StoryReader}",
-  Sort[Keys[grp]] === {"Helm", "PS", "StoryReader", "Vocab"}];
+assert["groups are exactly {Vocab, PS, Helm, StoryReader, ProgressTable}",
+  Sort[Keys[grp]] === Sort[{"Helm", "PS", "ProgressTable", "StoryReader", "Vocab"}]];
 assert["no port falls into 'other'", ! KeyExistsQ[grp, "other"]];
 
 Print[hr]; Print["4. auto-grouping registry — walkUI groups known systems by default"]; Print[hr];
@@ -75,8 +77,16 @@ asrItem    = SelectFirst[$walkCloud, #["item"] === "recognisePhonemes" &];
 assert["enrichOracle active when autofill is ready",  cloudActiveQ[enrichItem, {"autofill", "delete"}]];
 assert["enrichOracle NOT active without autofill",  ! cloudActiveQ[enrichItem, {"add", "set_sort"}]];
 assert["recognisePhonemes active on attempt_made",   cloudActiveQ[asrItem, {"attempt_made"}]];
-assert["stats/history never auto-active (not modelled, no ports)",
-  ! cloudActiveQ[SelectFirst[$walkCloud, #["item"] === "stats / history" &], {"add", "attempt_made", "autofill"}]];
+(* the "stats / history — not yet recovered" item is GONE (ProgressTable owns the
+   log now; the cloud shrinks as owners are modelled); what remains external is
+   the real DB and the clock/user identity, which light on the writing ports *)
+assert["stats/history item retired from the cloud (recovered)",
+  ! MemberQ[#["item"] & /@ $walkCloud, "stats / history"]];
+clockItem = SelectFirst[$walkCloud, #["item"] === "clock + user identity" &];
+assert["clock/user-identity active on attempt_made (the row is stamped at insert)",
+  cloudActiveQ[clockItem, {"attempt_made"}]];
+assert["clock/user-identity NOT active on a non-writing port",
+  ! cloudActiveQ[clockItem, {"add", "set_sort"}]];
 assert["cloudPanel builds (Head OpenerView)", Head[cloudPanel[transVP, mioCore]] === OpenerView];
 
 Print[hr];

--- a/spec/tests/maxprog_test.wls
+++ b/spec/tests/maxprog_test.wls
@@ -33,9 +33,12 @@ readyTaus[tf_, s_] := Select[readyTransitions[tf, s], isTauAct[First[#]] &];
    its vocabRead prefix, so an internal tau is pending. Under the (i) store form the
    capture relay is a SEQUENCE of taus: vocabRead (Vocab reads) → vocabUpsert (PS→Vocab) → vocabUpsert
    (Vocab→store) → vocabRead — autoTau fires them to stability, landing the word in the
-   store. (Setup plan keeps the explicit langRead; it is PS-side, no AutoTau.) *)
+   store. (Setup plan keeps the explicit langRead AND progressAppend — the scoring
+   chain is attempt_made · langRead · progressAppend since the ProgressTable
+   recovery, and both are PS-side, no AutoTau.) *)
 plan = {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
-        vis["recording_made", "audio"], vis["attempt_made"], tau["langRead"], vis["capture_vocab", "chat"]};
+        vis["recording_made", "audio"], vis["attempt_made"],
+        tau["langRead"], tau["progressAppend"], vis["capture_vocab", "chat"]};
 
 check[label_, tf_, s0_] := Module[{s, a, stable},
   Print[hr]; Print[label]; Print[hr];

--- a/spec/tests/progress_flow_test.wls
+++ b/spec/tests/progress_flow_test.wls
@@ -1,0 +1,118 @@
+#!/usr/bin/env wolframscript
+(* =====================================================================
+   spec/tests/progress_flow_test.wls
+   ---------------------------------------------------------------------
+   THE ATTEMPT-LOG FLOW, made a CHECKED CONTRACT.
+
+   ProgressTable OWNS the persisted attempt log (the app's user_progress
+   table); every scored attempt is WRITTEN to it as part of scoring — the
+   chain attempt_made · langRead(τ) · progressAppend(τ) — and Statistics /
+   History are the store's query projections (statsView / historyView),
+   not state held by PS. This was the † Stats/History incompleteness
+   (ARCHITECTURE.md); this test pins the recovered flow so a future
+   re-derivation that drops the write, lets PS hoard the log, or exposes
+   the append channel externally fails LOUDLY.
+
+   What it pins (both compositions — mioCore/transVP, mioCoreD/transNamed):
+     1. BOUNDARY   : progressAppend is RESTRICTED (not in the external
+                     ready set); progressRead / statsView / historyView ARE
+                     external (the query surface).
+     2. THE WRITE  : attempt_made fires the progressAppend τ; the store's
+                     projections then show total = 1.
+     3. HELD       : with the ASR oracle uninterpreted the appended row is
+                     SYMBOLIC — statsView stays an honest Association
+                     (total counts it, pending marks it, averages None) and
+                     the row still CARRIES the borrowed language pair.
+     4. TWO WRITERS: story_attempt_made appends through the SAME channel
+                     (the vocabUpsert two-writer precedent).
+     5. CONCRETE   : with a test ASR downvalue the numeric pipeline runs
+                     end-to-end — perfect_count / avg_score / recent_avg
+                     compute, historyView tabulates the row, and the row's
+                     language_code is the borrowed target.
+
+   Run headless:  wolframscript -file spec/tests/progress_flow_test.wls
+   ===================================================================== *)
+
+$dir = ParentDirectory[DirectoryName[$InputFileName]] <> "/";
+Get[$dir <> "MiolingoSpec.wl"];
+Get[$dir <> "walk.wl"];
+
+allOk = True;
+assert[lbl_, b_] := (allOk = allOk && TrueQ[b]; Print["   ", If[TrueQ[b], "ok  ", "FAIL "], lbl]);
+hr = StringRepeat["=", 70];
+
+ph = {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>};
+appends[w_] := Cases[w["actions"], tag[_, "progressAppend", _]];
+proj[tf_, w_] := viewProjections[tf, Last[w["states"]]];
+
+Do[Module[{tf = pair[[1]], sys = pair[[2]], nm = pair[[3]], names, w, p, st, hi},
+
+  Print[hr]; Print["=== on ", nm]; Print[hr];
+
+  Print["1. boundary — append restricted, query surface external"];
+  names = ToString /@ portName /@ First /@ readyTransitions[tf, sys];
+  assert["progressAppend is NOT externally ready (restricted)",
+    ! MemberQ[names, "progressAppend"]];
+  assert["progressRead / statsView / historyView ARE external",
+    SubsetQ[names, {"progressRead", "statsView", "historyView"}]];
+
+  Print["2. the write — scoring appends to the store"];
+  w = walkSteps[tf, sys,
+        {vis["load_material", ph], vis["recording_made", "a"], vis["attempt_made"]},
+        "AutoTau" -> True];
+  assert["walk completed", ! w["stuck"]];
+  assert["exactly one progressAppend τ fired", Length[appends[w]] === 1];
+  p = proj[tf, w];
+  st = p["statsView"];
+  assert["statsView.total = 1 (the attempt is in the store)", st["total"] === 1];
+
+  Print["3. held — symbolic row while the oracle is uninterpreted"];
+  assert["the row is oracle-pending, not fake-scored", st["pending"] === 1];
+  assert["averages stay None (no concrete score to aggregate)",
+    st["avg_score"] === None && st["recent_avg"] === None];
+  hi = p["historyView"];
+  assert["historyView counts it but does not tabulate it",
+    hi["total"] === 1 && hi["attempts"] === {} && hi["pending"] === 1];
+  assert["the pending row CARRIES the borrowed target code \"fr\"",
+    MemberQ[Cases[w["actions"], tag[_, "progressAppend", s_] :> (r /. s)],
+      row_ /; ! FreeQ[row, "fr"]]];
+
+  Print["4. two writers — story practice appends via the SAME channel"];
+  w = walkSteps[tf, sys,
+        {vis["set_mode", practice], vis["story_recording_made", "a"],
+         vis["story_attempt_made"]},
+        "AutoTau" -> True];
+  assert["story walk completed", ! w["stuck"]];
+  assert["story_attempt_made fired progressAppend", Length[appends[w]] === 1];
+  assert["the store shows the story attempt (total = 1)",
+    proj[tf, w]["statsView"]["total"] === 1]],
+
+  {pair, {{transVP, mioCore, "mioCore (transVP)"},
+          {transNamed, mioCoreD, "mioCoreD (transNamed)"}}}];
+
+Print[hr]; Print["5. concrete — test ASR downvalue, numeric pipeline end-to-end"]; Print[hr];
+(* the world plays back a perfect transcript: the recognised phonemes ARE the
+   target IPA (the speaker_test round-trip shape, as a plain test downvalue) *)
+recognisePhonemes[audio_String, lang_String] := "ʃa";
+w5 = walkSteps[transNamed, mioCoreD,
+       {vis["load_material", ph], vis["recording_made", "a"], vis["attempt_made"]},
+       "AutoTau" -> True];
+p5 = proj[transNamed, w5];
+st5 = p5["statsView"]; hi5 = p5["historyView"];
+assert["total 1, nothing pending", st5["total"] === 1 && st5["pending"] === 0];
+assert["perfect match counted", st5["perfect_count"] === 1];
+assert["avg_score = 1. (exact repetition)", st5["avg_score"] == 1];
+assert["recent_avg = 1.", st5["recent_avg"] == 1];
+row5 = First[hi5["attempts"], None];
+assert["historyView tabulates the row", AssociationQ[row5]];
+assert["row carries the borrowed language_code \"fr\"",
+  AssociationQ[row5] && row5["language_code"] === "fr"];
+assert["row records the target phrase",
+  AssociationQ[row5] && row5["target_phrase"] === "chat"];
+assert["row records both phoneme strings",
+  AssociationQ[row5] && row5["target_phonemes"] === "ʃa" && row5["user_phonemes"] === "ʃa"];
+
+Print[hr];
+Print["ALL ASSERTIONS: ", If[allOk, "OK", "*** FAIL ***"]];
+Print[hr];
+If[!allOk, Exit[1]];

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -9,7 +9,8 @@
      vis["port"]          take a visible action by port name (no value)
      vis["port", value]   take a value-carrying input port, supplying value
    The internal syncs (vocabUpsert / goPractice / langRead / vocabRead — the VocabTable reads
-   and writes) are fired AUTOMATICALLY between steps by walkSteps' maximal-progress
+   and writes — and progressAppend, the attempt-log write after scoring) are fired
+   AUTOMATICALLY between steps by walkSteps' maximal-progress
    mode ("AutoTau" -> True) — so plans stay readable and robust as new internal
    syncs are added (no plan edits). (A plan MAY still force a specific sync with
    tau["chan"] when a step is genuinely ambiguous; none need to here.)
@@ -198,6 +199,21 @@ walkTests = <|
     vis["add", <|"word" -> "casa", "translation" -> "house"|>],
     vis["set_sort", recent],
     vis["export"]},
+
+  (* --- sync: scoring APPENDS to the attempt store (progressAppend) -------
+     every scored attempt is persisted (the app's _persist_result); after two
+     attempts the store's query projections (statsView / historyView) publish
+     the log. The view steps are self-loops — they just take the output. *)
+  "sync-progress" -> {
+    vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>,
+                          <|"text" -> "chien", "translation" -> "dog", "ipa" -> "ʃjɛ̃"|>}],
+    vis["recording_made", "audio-A"],
+    vis["attempt_made"],                            (* langRead + progressAppend auto-fire *)
+    vis["next_item_requested"],
+    vis["recording_made", "audio-B"],
+    vis["attempt_made"],                            (* second row appended *)
+    vis["statsView"],
+    vis["historyView"]},
 
   (* --- full end-to-end: both syncs in one run ------------------------- *)
   "full-roundtrip" -> {

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -40,7 +40,7 @@ traceView::usage = "traceView[traceSymbol] renders the condensed event log of a 
 traceToPlan::usage = "traceToPlan[trace] turns a recorded event log (list of eventOf Associations) BACK into an executable plan \[LongDash] a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"] entries, values inline. The FULL trace is kept, INCLUDING the internal \[Tau]'s (as tau[chan]): in manual-\[Tau] mode they replay literally; in auto-\[Tau] mode Run trace drops them and re-fires them itself. Inverse of eventLog for replay.";
 normalisePlan::usage = "normalisePlan[expr] canonicalises a typed/pasted trace to a plan list, or returns $Failed. Accepts a list of vis/tau entries as-is, OR a pasted raw event log (list of eventOf Associations) which it converts via traceToPlan.";
 stateDisplay::usage = "stateDisplay[s] gives a compact render of the CCS process state s (foldAgentDisplay \:043e normalizeSC) \[LongDash] where you are / where a transition leads.";
-walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests (\"Run test\") OR an ad-hoc trace you type in the \"Trace:\" field (\"Run trace\"), step Back/Forward through a run, and record a trace. The Trace field takes a plan — a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"], or a pasted Copy-trace — and runs it from the initial agent, HONOURING the maximal-progress checkbox just like manual stepping: box ON = auto-τ (external actions only, pasted τ's dropped); box OFF = manual-τ (the τ's in the trace are driven literally). Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
+walkUI::usage = "walkUI[agent, opts] is the interactive Dynamic harness: drive the simulation, type real values into ready input ports, see the data-compaction views + current state + per-transition derivative, run value-carrying test sequences from walkTests (\"Run test\") OR an ad-hoc trace you type in the \"Trace:\" field (\"Run trace\"), step Back/Forward through a run, and record a trace. The COMPRESSED layout is the default: a single toolbar row (Reset/Back/Forward, the maximal-progress toggle, the build stamp), the data view as a TabView (one tab per view port; \"DataLayout\" -> \"Stack\" restores the stacked panels), and the runners + trace folded into openers (the trace opener shows a live event count) — everything recovers on click. The Trace field takes a plan — a list of vis[\"port\"] / vis[\"port\", value] / tau[\"chan\"], or a pasted Copy-trace — and runs it from the initial agent, HONOURING the maximal-progress checkbox just like manual stepping: box ON = auto-τ (external actions only, pasted τ's dropped); box OFF = manual-τ (the τ's in the trace are driven literally). Option \"TransitionFunction\" -> transVP (mu-term, e.g. mioCore) | transNamed (call form, e.g. mioCoreD).";
 
 (* ---------------------------------------------------------------------
    readyTransitions[tf, s] : the enabled transitions at state s as a list
@@ -252,6 +252,26 @@ dataView[tf_, s_] := Module[{projs = viewProjections[tf, s]},
     Style["(no view ports ready)", Italic, GrayLevel[0.5]],
     Column[KeyValueMap[viewPanel[#1, forceProj[#2]] &, projs], Spacings -> 0.8]]];
 
+(* dataViewTabs[tf, s, Dynamic[sel]] : the COMPRESSED data view — one tab per
+   view port instead of a stack of panels. With six view ports in mioCore
+   (pSView / vocabView / helmView / storyReaderView / statsView / historyView)
+   the stacked panels dominated the harness; tabs show ONE projection and
+   recover the rest on click (compress-then-recover). Keys are sorted so a tab
+   keeps its position across steps; `sel` (a Dynamic index, persisted by
+   walkUI) is clamped when the ready view-port set shrinks (e.g. PS
+   mid-handoff). The stacked dataView remains available via walkUI's
+   "DataLayout" -> "Stack". *)
+dataViewTabs::usage = "dataViewTabs[tf, s, sel] renders the state's published projections as a TabView (one tab per view port, selection sel persisting across steps) — the compressed form of dataView.";
+SetAttributes[dataViewTabs, HoldRest];
+dataViewTabs[tf_, s_, sel_] := Module[{projs = viewProjections[tf, s], ks},
+  If[projs === <||>,
+    Style["(no view ports ready)", Italic, GrayLevel[0.5]],
+    ks = Sort[Keys[projs]];
+    If[! (1 <= sel <= Length[ks]), sel = 1];
+    TabView[
+      (# -> viewPanel[#, forceProj[projs[#]]]) & /@ ks,
+      Dynamic[sel], ImageSize -> Automatic]]];
+
 (* Per-event render: port + polarity glyph + the value as a NAKED expression
    (no ToString — Wolfram boxes read fine), dropping the {} wrapper for <=1
    parameter (eventOf wraps every value in a list; we unwrap the singleton).
@@ -300,9 +320,10 @@ normalisePlan[expr_] := Which[
    bulky values in Short. Copy emits the EXECUTABLE plan (traceToPlan) so it round-
    trips into Run trace; eventLogForm (string form) is kept for the text round-trip
    (trace_io_test). *)
-SetAttributes[traceView, HoldFirst];
-traceView[trace_, short_ : False] := Column[{
-  Style["Trace (condensed event log)", Bold],
+(* traceBody: the log pane + Copy button WITHOUT the title, so walkUI can put
+   the title on a collapsible opener (with a live event count) instead. *)
+SetAttributes[{traceBody, traceView}, HoldFirst];
+traceBody[trace_, short_ : False] := Column[{
   Pane[Dynamic[If[trace === {},
         Style["(no steps yet)", Italic, GrayLevel[0.5]],
         Column[eventRow[#, short] & /@ trace, Spacings -> 0.15]]],
@@ -311,6 +332,9 @@ traceView[trace_, short_ : False] := Column[{
      straight back into the Run-trace field AND is the readable vis/tau form. *)
   Button["Copy trace \[SelectionPlaceholder]", CopyToClipboard[traceToPlan[trace]],
     Enabled -> Dynamic[trace =!= {}]]}];
+traceView[trace_, short_ : False] := Column[{
+  Style["Trace (condensed event log)", Bold],
+  traceBody[trace, short]}];
 
 (* ---------------------------------------------------------------------
    walkUI[agent, opts] : the integrated harness. Drive the sim, PLAY THE
@@ -444,26 +468,63 @@ walkVersion[dir_] := Module[{run, sha, subj, date, dirty, pr},
     If[dirty, " \[CenterDot] +local edits", ""]]];
 $walkDir = DirectoryName[$InputFileName];
 
-Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> Automatic};
+Options[walkUI] = {"TransitionFunction" -> transVP, "Components" -> Automatic,
+  (* "Tabs" (default): the data view is a TabView, one tab per view port —
+     the compressed layout. "Stack": the original stacked panels. *)
+  "DataLayout" -> "Tabs"};
 walkUI[agent_, opts : OptionsPattern[]] := With[
   {tf = OptionValue["TransitionFunction"],
    (* Automatic (the default): group if `agent` is a registered composed system,
       else flat. An explicit list / {} overrides. *)
-   components = Replace[OptionValue["Components"], Automatic :> defaultComponents[agent]]},
+   components = Replace[OptionValue["Components"], Automatic :> defaultComponents[agent]],
+   dataLayout = OptionValue["DataLayout"]},
   With[{pmap = If[components === {}, <||>, componentPortMap[components]],
         ver = walkVersion[$walkDir]},
   DynamicModule[{cur = agent, trace = {}, hist = {}, inVals = <||>, future = {},
      maxprog = False, stateOpen = False, cloudOpen = False,
      shortTrace = True, prevCloudActive = cloudActiveNames[tf, agent],
      testSel = First[Keys[If[ValueQ[walkTests], walkTests, <||>]], None],
-     userPlan = ""},
+     userPlan = "", dataTab = 1, runnersOpen = False, traceOpen = False},
     Dynamic[
       Module[{trans = readyTransitions[tf, cur]},
         Framed[Column[{
 
-          (* build stamp (captured when THIS cell was created) \[LongDash] confirms which
-             spec build you're running; a stale cell shows an old PR#/SHA *)
-          Style["spec build: " <> ver, GrayLevel[0.35], 13],
+          (* toolbar: build stamp (captured when THIS cell was created — a stale
+             cell shows an old PR#/SHA), the run controls, and the maximal-
+             progress toggle, in ONE row. Back pushes the current step onto a
+             `future` stack; Forward replays it; a fresh step clears `future`
+             (you've branched off the redo line). The maxprog checkbox is a
+             SIMULATION strategy (auto-fire internal syncs between your
+             actions), not a language change; switching it ON also settles the
+             current state. The system plays the SYSTEM for you; you still play
+             the user (and the world). *)
+          Row[{
+            Button["Reset \[CenterDot]", cur = agent; hist = {}; trace = {};
+               future = {}; inVals = <||>],
+            Spacer[2],
+            Button["\[LeftArrow] Back",
+              If[hist =!= {},
+                AppendTo[future, {cur, Last[trace]}];
+                cur = Last[hist]; hist = Most[hist]; trace = Most[trace];
+                inVals = <||>],
+              Enabled -> Dynamic[hist =!= {}]],
+            Spacer[2],
+            Button["Forward \[RightArrow]",
+              If[future =!= {},
+                Module[{f = Last[future]},
+                  AppendTo[hist, cur]; cur = f[[1]]; AppendTo[trace, f[[2]]];
+                  future = Most[future]; inVals = <||>]],
+              Enabled -> Dynamic[future =!= {}]],
+            Spacer[10],
+            Checkbox[Dynamic[maxprog, (maxprog = #;
+                 If[TrueQ[#],
+                   With[{a = autoTau[tf, cur]},
+                     hist = Join[hist, a["states"]];
+                     trace = Join[trace, a["events"]]; cur = a["state"]]]) &]],
+            Spacer[4],
+            Style["auto-\[Tau] (maximal progress)", GrayLevel[0.35], 11],
+            Spacer[14],
+            Style["spec build: " <> ver, GrayLevel[0.45], 11]}],
 
           (* collapsible (default closed) so the process term doesn't eat space;
              open state persists across steps via stateOpen *)
@@ -473,7 +534,12 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
             Dynamic[stateOpen]],
 
           Style["Data view \[LongDash] published projections", Bold, 13],
-          dataView[tf, cur],
+          (* compressed by default: one tab per view port (six in mioCore);
+             the other projections recover on click. "DataLayout" -> "Stack"
+             restores the original stacked panels. *)
+          If[dataLayout === "Stack",
+            dataView[tf, cur],
+            dataViewTabs[tf, cur, dataTab]],
 
           (* the cloud: external data the agents read but don't own (collapsible;
              open state persists across steps via cloudOpen); items light up when
@@ -481,18 +547,6 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
           cloudPanel[tf, cur, Dynamic[cloudOpen]],
 
           Style["Transitions \[LongDash] click to step; type into input ports", Bold, 13],
-          (* maximal-progress toggle: a SIMULATION strategy (auto-fire internal
-             syncs between your actions), not a language change. Switching it ON
-             also settles the current state. The system plays the SYSTEM for you;
-             you still play the user (and the world). *)
-          Row[{Checkbox[Dynamic[maxprog, (maxprog = #;
-                 If[TrueQ[#],
-                   With[{a = autoTau[tf, cur]},
-                     hist = Join[hist, a["states"]];
-                     trace = Join[trace, a["events"]]; cur = a["state"]]]) &]],
-               Spacer[4],
-               Style["Auto-advance internal syncs (maximal progress)",
-                 GrayLevel[0.35], 11]}],
           If[trans === {},
             Style["(deadlocked \[LongDash] no transitions)", Italic, GrayLevel[0.5]],
             With[{row = Function[tr,
@@ -558,26 +612,12 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                     KeyExistsQ[grp, #] &],
                   Spacings -> 0.5]]]]],
 
-          (* Back / Forward scrub the run: Back pushes the current step onto a
-             `future` stack; Forward replays it. A fresh step or Run test clears
-             `future` (you've branched off the redo line). *)
-          Row[{
-            Button["\[LeftArrow] Back",
-              If[hist =!= {},
-                AppendTo[future, {cur, Last[trace]}];
-                cur = Last[hist]; hist = Most[hist]; trace = Most[trace];
-                inVals = <||>],
-              Enabled -> Dynamic[hist =!= {}]],
-            Spacer[4],
-            Button["Forward \[RightArrow]",
-              If[future =!= {},
-                Module[{f = Last[future]},
-                  AppendTo[hist, cur]; cur = f[[1]]; AppendTo[trace, f[[2]]];
-                  future = Most[future]; inVals = <||>]],
-              Enabled -> Dynamic[future =!= {}]],
-            Spacer[6],
-            Button["Reset \[CenterDot]", cur = agent; hist = {}; trace = {};
-               future = {}; inVals = <||>]}],
+          (* the RUNNERS (Run test / Run trace), folded away until wanted \[LongDash]
+             they are setup gestures, not stepping gestures, so they don't earn
+             standing space. Opener state persists via runnersOpen. *)
+          OpenerView[{
+            Style["Run a test / a typed trace \[Ellipsis]", Bold, 13],
+            Column[{
 
           (* Run a value-carrying test sequence from walkTests \[LongDash] no typing:
              replays the chosen plan FROM THE INITIAL AGENT, setting the trace
@@ -595,7 +635,8 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                Spacer[4],
                Button["Run test \[FilledRightTriangle]",
                  (* "AutoTau" -> True : the plans list only external actions, so
-                    fire the internal syncs (vocabUpsert/goPractice/langRead/vocabRead) for us *)
+                    fire the internal syncs (vocabUpsert/goPractice/langRead/
+                    vocabRead/progressAppend) for us *)
                  Module[{w = walkSteps[tf, agent, walkTests[testSel], "AutoTau" -> True]},
                    hist = Most[w["states"]]; trace = eventLog[w];
                    cur = Last[w["states"]]; future = {}; inVals = <||>],
@@ -641,11 +682,21 @@ walkUI[agent_, opts : OptionsPattern[]] := With[
                  "AUTO-\[Tau] (box ticked): list external actions only — τ's auto-fire (pasted τ's ignored).",
                  "MANUAL-\[Tau] (box clear): τ's in the trace are driven literally — tick the box above to auto-fire them instead."] <>
               " vis[\"port\"] · vis[\"port\", value] · tau[\"chan\"].",
-            GrayLevel[0.45], 10]],
+            GrayLevel[0.45], 10]]
 
-          Row[{Checkbox[Dynamic[shortTrace]], Spacer[4],
-               Style["Short trace values (truncate bulky data)", GrayLevel[0.35], 11]}],
-          traceView[trace, shortTrace]
+            }, Spacings -> 0.8]},
+            Dynamic[runnersOpen]],
+
+          (* the TRACE, folded with a live event count on the opener label \[LongDash]
+             glance at the count, recover the log on click. Opener state
+             persists via traceOpen. *)
+          OpenerView[{
+            Dynamic[Style[Row[{"Trace (", Length[trace], " events)"}], Bold, 13]],
+            Column[{
+              Row[{Checkbox[Dynamic[shortTrace]], Spacer[4],
+                   Style["Short trace values (truncate bulky data)", GrayLevel[0.35], 11]}],
+              traceBody[trace, shortTrace]}, Spacings -> 0.5]},
+            Dynamic[traceOpen]]
 
         }, Spacings -> 1.2], FrameStyle -> GrayLevel[0.7], RoundingRadius -> 4]],
       TrackedSymbols :> {cur, inVals, testSel, future, maxprog, shortTrace, userPlan}]]]];

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -388,12 +388,15 @@ $walkCloud = {
   <|"item" -> "recognisePhonemes", "owner" -> "external ASR / acoustic model",
     "why" -> "PS scoring recognises audio -> phonemes outside the model; only the target-language pull (langRead) is in it.",
     "ports" -> {"attempt_made"}|>,
-  <|"item" -> "vocab persistence", "owner" -> "external store (DB)",
-    "why" -> "entries are modelled in Vocab state in-process; really an external store. To become a DB agent (ARCHITECTURE \[Dagger]).",
-    "ports" -> {"add", "import_bulk", "delete", "update", "update_notes", "autofill"}|>,
-  <|"item" -> "stats / history", "owner" -> "external store (query-backed views)",
-    "why" -> "not yet recovered; will be queries/views on the external store, not in-process state.",
-    "ports" -> {}|>};
+  <|"item" -> "DB persistence", "owner" -> "the real MySQL tables",
+    "why" -> "VocabTable + ProgressTable model the stores IN the system; the actual vocab_entries / user_progress tables (connections, SQL, durability) stay outside. Rigging the model stores to the real DB is the \[Dagger] rig concern.",
+    "ports" -> {"add", "import_bulk", "delete", "update", "update_notes", "autofill", "capture_vocab", "story_capture_vocab"}|>,
+  <|"item" -> "clock + user identity", "owner" -> "the DB / auth layer",
+    "why" -> "user_progress rows are stamped practice_date = NOW[] and keyed by user_id at insert; L1 is single-user with no clock, so ProgressTable's insertion order stands in for the date order and both columns stay outside.",
+    "ports" -> {"attempt_made", "story_attempt_made"}|>};
+(* (the former "stats / history — not yet recovered" item is GONE: ProgressTable
+   now owns the attempt log and statsView/historyView are its query projections —
+   the cloud shrinks as owners are modelled, as langRead removed the language.) *)
 cloudActiveQ[item_Association, readyNames_List] := IntersectingQ[item["ports"], readyNames];
 cloudActiveQ::usage = "cloudActiveQ[item, readyPortNames] is True iff a currently-ready port would consult this external item (so the cloud panel highlights it).";
 (* the set of cloud-item names CONSULTED at state s — walkUI pops the panel open


### PR DESCRIPTION
## What

Completes the flagged **† Stats/History** gap in the L1 spec — the one data flow the recovered agents had not captured — and compresses the walkUI harness now that the composed system has six view ports. Spec-only: no app code touched (hence `--skip-version-check`).

### 1. ProgressTable — the attempt store, recovered (`234da91`)

Scored attempts previously evaporated; in the app every one is persisted (`_persist_result` → `save_practice`, an INSERT into `user_progress`). Now recovered:

- **`ProgressTable[records]`** (VocabTable pattern, table-faithful name — resolves the `Ledger`/`AttemptTable` placeholder): `progressRead!` (SELECT surface, external), `progressAppend` (INSERT, **restricted** — only scoring writes), and `statsView!`/`historyView!` **query projections** (`get_user_stats` / `load_history`) — "view ports backed by store queries", made literal.
- Both scoring chains persist: `attempt_made · langRead(τ) · progressAppend(τ)` in PS **and** StoryReader — one channel, two writers (the `vocabUpsert` precedent).
- **Held-until-concrete**: with the ASR oracle uninterpreted the appended row stays symbolic; the views aggregate concrete rows and report a `pending` count.
- Out of the model, into the cloud: `user_id` (single-user L1) and `practice_date` (the DB's clock). Records **carry** `language_code` from the write-time borrow, so per-language filtering is presentation, not a read-time borrow.

**Review here first:** `spec/docs/progress-table-recovery.md` § *Decisions a reviewer should check* (5 decisions), plus the provenance table (@ app src `504f8c8`).

### 2. walkUI compression (`b406068`)

One toolbar row (Reset / Back / Forward / auto-τ / build stamp); data view as a **TabView** — one tab per view port, `"DataLayout" -> "Stack"` restores the stacked panels; runners and trace folded into openers (trace shows a live event count). Substrate untouched.

### 3. Clean driving notebook (`cc332a4`)

`spec/ClaudeDevTesting.nb` — loads from `NotebookDirectory[]`, `walkUI[mioCoreD, "TransitionFunction" -> transNamed]` front and centre. Round-tripped through the FE headlessly to canonical form.

## Testing

Full headless suite (18 `.wls` files) green on **both** `mioCore`/`transVP` and `mioCoreD`/`transNamed`, including the new 30-assertion `progress_flow_test.wls` (boundary, the write, held discipline, two writers, concrete numeric pipeline). One pre-existing, unrelated failure: `g2p_test` (espeak-ng stress-mark stripping) — tracked as bead `miolingo-eff`.

## Engine finding (for the RCA repo)

The 6th parallel component pushed `transVP` mu-term walks off a cliff: `vs-capture` **2m11s** on `mioCore` vs **6s** on `mioCoreD` (~20×; `walk_sequences_test` now ~19 min). All plans pass on both — the standing invariant holds — but worth an engine-side look before component #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)