### PR TITLE
spec: Helm targetRead — narrow the scoring borrow (source-independence of practice records)

### DIFF
--- a/spec/HelmRecovered.wl
+++ b/spec/HelmRecovered.wl
@@ -21,8 +21,16 @@
    PORTS (sidebar controls):
      view!         always — the helmView projection everyone reads
      langRead!     always — INTERNAL read port (restricted in mioCore): emits
-                   {source, target} for a borrower that pulls it at point of use
-                   (Vocab.autofill, PS.attempt_made scoring). Not a UI control.
+                   the full {source, target} pair for a borrower that needs
+                   BOTH halves at point of use — enrichment renders INTO the
+                   source (Vocab.autofill only). Not a UI control.
+     targetRead!   always — INTERNAL read port (restricted in mioCore): emits
+                   ONLY the target code — the app's read_target_code
+                   (language_state.py). The SCORING borrow (PS.attempt_made,
+                   StoryReader.story_attempt_made): practice identity is the
+                   TARGET; narrowing the borrow makes "a source switch cannot
+                   affect a practice record" a property of the port structure
+                   (ARCHITECTURE.md "The language pair is asymmetric").
      set_source    set the source (native) language name
      set_target    set the target language code (target_language mirrors it)
      set_tts       set the TTS engine
@@ -46,13 +54,19 @@ defineAgent["Helm", {source, target, tts, speed, asr, asrModel},
   choice[
     precede[label["view", param[helmView[source, target, tts, speed, asr, asrModel]]],
       call["Helm", source, target, tts, speed, asr, asrModel]],
-    (* internal READ port (restricted in mioCore): borrowers PULL the
-       (source, target) pair fresh at the point of use. A self-loop — always
-       offered, never changing Helm — so a consumer waiting at langRead?(lp)
-       is forced (by its own sequencing) to take it and gets Helm's CURRENT
-       value; no cached copy, no staleness. See ARCHITECTURE.md "Borrowed vs
-       owned data". Distinct from the external `view` projection. *)
+    (* internal READ ports (restricted in mioCore): borrowers PULL fresh at
+       the point of use. Self-loops — always offered, never changing Helm —
+       so a consumer waiting at the read is forced (by its own sequencing)
+       to take it and gets Helm's CURRENT value; no cached copy, no
+       staleness. See ARCHITECTURE.md "Borrowed vs owned data". Distinct
+       from the external `view` projection. TWO reads, matching the app's
+       read functions AND the asymmetry of the pair: langRead = the full
+       pair (enrichment needs both); targetRead = the target code only
+       (@src language_state.py read_target_code — scoring's borrow, so a
+       practice record provably cannot depend on the source). *)
     precede[label["langRead", param[{source, target}]],
+      call["Helm", source, target, tts, speed, asr, asrModel]],
+    precede[label["targetRead", param[target]],
       call["Helm", source, target, tts, speed, asr, asrModel]],
     precede[coLabel["set_source", binding[s]],
       call["Helm", s, target, tts, speed, asr, asrModel]],

--- a/spec/MioCore.wl
+++ b/spec/MioCore.wl
@@ -61,12 +61,21 @@
 
    ATTEMPT LOG (2026-07-06): ProgressTable (the user_progress store) is composed
    in, resolving the † Stats/History incompleteness. progressAppend is RESTRICTED
-   with two writers — PS.attempt_made and StoryReader.story_attempt_made, whose
-   scoring chains are now attempt_made · langRead(τ) · progressAppend(τ) — so
+   with two writers — PS.attempt_made and StoryReader.story_attempt_made — so
    every scored attempt lands in the store, as _persist_result does in the app.
    The external ready set additionally shows progressRead (the raw SELECT
    surface; no internal borrower yet) and the statsView / historyView query
    projections (the Statistics / History tabs).
+
+   NARROWED SCORING BORROW (2026-07-06, targetRead): the language pair is
+   ASYMMETRIC — source is an authoring parameter (enrichment renders into it),
+   target is the practice identity (what is presented, scored, and keyed in
+   user_progress). Scoring consumes ONLY the target code, so its borrow is the
+   narrow targetRead (also restricted), not the langRead pair: the chains are
+   attempt_made · targetRead(τ) · progressAppend(τ). Consequence, now a
+   PROPERTY OF THE PORT STRUCTURE: a bilingual user switching the source
+   mid-practice cannot affect a practice record — the dependency does not
+   exist. langRead (the full pair) remains the enrichment borrow (autofill).
    ===================================================================== *)
 
 (* The component decomposition, named once and reused: by merge/mergeDefined to
@@ -79,12 +88,12 @@ mioComponents =
    "Helm"        -> call["Helm", "English", "fr", google, 250, system, base],
    "VocabTable"  -> call["VocabTable", {}],                       (* the persisted collection, owned here *)
    "StoryReader" -> call["StoryReader", 0, 0, browse, none, none],  (* narrative tab; practice mode
-       mirrors PSActive, capturing via vocabUpsert + scoring via langRead — no NEW restricted channels *)
+       mirrors PSActive, capturing via vocabUpsert + scoring via targetRead — no NEW restricted channels *)
    "ProgressTable" -> call["ProgressTable", {}]};  (* the attempt store (user_progress):
        PS + StoryReader scoring APPEND via progressAppend (restricted); Statistics /
        History are its statsView/historyView query projections — the † recovery *)
 
-mioRestricted = {label["goPractice"], label["langRead"],
+mioRestricted = {label["goPractice"], label["langRead"], label["targetRead"],
                  (* the VocabTable channels: the Vocab tab and PS read/write the store
                     internally. vocabUpsert has two writers (tab add + PS capture). *)
                  label["vocabRead"], label["vocabUpsert"], label["vocabImport"],

--- a/spec/PracticeSessionFunctions.wl
+++ b/spec/PracticeSessionFunctions.wl
@@ -119,14 +119,18 @@ scoreDetail[user_String, correct_String] :=
   Join[comparePhonemes[user, correct],
     <|"user" -> user, "target" -> correct, "alignment" -> alignPhonemes[user, correct]|>];
 
-(* --- evaluate[target, rec, lang] : the scoring of an attempt -----------
+(* --- evaluate[target, rec, tc] : the scoring of an attempt -------------
    PURE core (scoreDetail) composed with the ASR oracle. The recorded audio is
    recognised to phonemes (IO oracle, in the target language), both sides are
-   normalised, then aligned + scored (pure). lang is the BORROWED {source, target}
-   pair pulled from Helm at attempt_made; the ASR uses Last[lang] (the target code).
-   The result Association is what the agent wraps in scored[...] and the view
-   publishes. (The recognised TEXT/word is an oracle detail surfaced by the skin,
-   below the L1 boundary; L1 scores phonemes.) *)
+   normalised, then aligned + scored (pure). tc is the BORROWED target CODE
+   pulled from Helm at attempt_made via targetRead — the NARROW read: scoring
+   consumes only the target (practice identity), never the source, so the
+   borrow declares exactly that (ARCHITECTURE.md "The language pair is
+   asymmetric"). The lang_List form is kept below for the pre-narrowing
+   callers (round-trip law tests, ad-hoc use with a pair). The result
+   Association is what the agent wraps in scored[...] and the view publishes.
+   (The recognised TEXT/word is an oracle detail surfaced by the skin, below
+   the L1 boundary; L1 scores phonemes.) *)
 (* recognisedOf: held-until-concrete gate on the ORACLE's result. The old
    ToString here coerced an UNINTERPRETED recognisePhonemes[...] term into its
    printed form, which then got character-Levenshteined against the target IPA —
@@ -135,6 +139,11 @@ scoreDetail[user_String, correct_String] :=
    exists (the same discipline as vocabView[entries_List] / deleteFrom[id_Integer]). *)
 recognisedOf[r_String] := r;
 
+evaluate[target_, rec_, tc_String] :=
+  scoreDetail[
+    normalisePhonemes[recognisedOf[recognisePhonemes[audioOf[rec], tc]]],
+    normalisePhonemes[correctPhonemesOf[target]]];
+(* pair form: delegates to the code form on the target half (Last) *)
 evaluate[target_, rec_, lang_List] :=
   scoreDetail[
     normalisePhonemes[recognisedOf[recognisePhonemes[audioOf[rec], Last[lang]]]],

--- a/spec/PracticeSessionRecovered.wl
+++ b/spec/PracticeSessionRecovered.wl
@@ -110,18 +110,24 @@ defineAgent["PSActive", {phrases, pos, rec, res},
       choice[
         (* scoring PERSISTS: the app saves every scored attempt immediately
            (_persist_result -> save_practice, practice_tab.py:44), so the chain
-           is attempt_made · langRead(τ, borrow the language) · progressAppend(τ,
-           write the attempt to ProgressTable) — the write is part of scoring,
-           not a separate user action. Same mid-handoff NB as capture_vocab:
-           L3 must treat score-and-log as ATOMIC (no view flicker over the
-           two τ's). attemptRecord re-states the evaluate term (no let in
-           value-passing CCS); both occurrences compute identically. *)
+           is attempt_made · targetRead(τ, borrow the TARGET code) ·
+           progressAppend(τ, write the attempt to ProgressTable) — the write is
+           part of scoring, not a separate user action. The borrow is the
+           NARROW read (targetRead, not the langRead pair): practice identity
+           is the target — ASR and the attempt row consume only the code
+           (@src recognisePhonemes / save_practice's language_code) — so a
+           source switch provably cannot touch a practice record
+           (ARCHITECTURE.md "The language pair is asymmetric"). Same
+           mid-handoff NB as capture_vocab: L3 must treat score-and-log as
+           ATOMIC (no view flicker over the two τ's). attemptRecord re-states
+           the evaluate term (no let in value-passing CCS); both occurrences
+           compute identically. *)
         precede[coLabel["attempt_made"],
-          precede[coLabel["langRead", binding[lp]],
+          precede[coLabel["targetRead", binding[tc]],
             precede[label["progressAppend",
-                param[attemptRecord[targetOf[phrases, pos], rec, lp]]],
+                param[attemptRecord[targetOf[phrases, pos], rec, tc]]],
               call["PS", phrases, pos, rec,
-                scored[evaluate[targetOf[phrases, pos], rec, lp]]]]]],
+                scored[evaluate[targetOf[phrases, pos], rec, tc]]]]]],
         precede[coLabel["clear_recording"],
           call["PS", phrases, pos, none, none]]]],
     if[pos < Length[phrases] - 1,

--- a/spec/ProgressFunctions.wl
+++ b/spec/ProgressFunctions.wl
@@ -32,27 +32,28 @@
    ===================================================================== *)
 
 
-(* --- attemptRecord[target, rec, lp] : the row a scoring chain writes ------
+(* --- attemptRecord[target, rec, tc] : the row a scoring chain writes ------
    What _persist_result (practice_tab.py:44) passes to save_practice, built
    from the SAME evaluate the chain wraps in scored[…] (value-passing CCS has
    no let; the duplicated evaluate term is the idiom, and with bodies loaded
-   both occurrences compute identically). lp is the BORROWED (source, target)
-   pair the chain just pulled on langRead — the record carries its language
-   (language_code = the target code), which is what lets reads filter
+   both occurrences compute identically). tc is the BORROWED target CODE the
+   chain just pulled on targetRead (the NARROW read — scoring never consumes
+   the source; ARCHITECTURE.md "The language pair is asymmetric") — the
+   record carries it as language_code, which is what lets reads filter
    per-language WITHOUT borrowing at read time.
    NB the app's recognized_phrase is the ASR transcript TEXT — an oracle
    detail below the L1 boundary (function-recovery.md: L1 scores phonemes);
    the recognised PHONEME string stands in for it here. *)
-attemptRow[r_Association, target_Association, lp_List] := <|
-  "language_code"     -> Last[lp],
+attemptRow[r_Association, target_Association, tc_String] := <|
+  "language_code"     -> tc,
   "target_phrase"     -> Lookup[target, "text", ""],
   "recognized_phrase" -> Lookup[r, "user", ""],
   "similarity_score"  -> Lookup[r, "similarity", 0],
   "perfect_match"     -> Lookup[r, "exact_match", False],
   "target_phonemes"   -> Lookup[r, "target", ""],
   "user_phonemes"     -> Lookup[r, "user", ""]|>;
-attemptRecord[target_, rec_, lp_List] :=
-  attemptRow[evaluate[target, rec, lp], target, lp];
+attemptRecord[target_, rec_, tc_] :=
+  attemptRow[evaluate[target, rec, tc], target, tc];
 
 (* --- appendAttempt[records, r] : save_practice's INSERT (app_mysql.py:1628).
    Plain append — NO dedup/upsert (every attempt is a new row; contrast

--- a/spec/ProgressTableRecovered.wl
+++ b/spec/ProgressTableRecovered.wl
@@ -24,7 +24,7 @@
    PROJECTIONS on the store (statsView / historyView), not standalone
    interactive agents and not state held by PS. PS/StoryReader only WRITE,
    through the restricted append channel — completing the data flow
-     attempt_made · langRead(τ) · progressAppend(τ)  →  records
+     attempt_made · targetRead(τ) · progressAppend(τ)  →  records
      → statsView!(statsOf records) / historyView!(historyOf records).
 
    STATE: ProgressTable[records] — the persisted attempt log (list, in
@@ -61,7 +61,9 @@
    write time from the langRead borrow), so the projection can be filtered
    downstream without borrowing at read time. The day a filtered-at-source
    query port is wanted, it enters as a value-carrying read (a query
-   protocol) — the † rigging question, now concrete.
+   protocol) — the † rigging question, now concrete. (2026-07-06: the
+   write-time borrow NARROWED to targetRead — records carry exactly the
+   target code, the practice identity; see MioCore.wl.)
 
    LEAF agent (every branch loops back to ProgressTable) — no sub-agent
    expansion. Value-functions (appendAttempt/statsOf/historyOf/

--- a/spec/StoryReaderRecovered.wl
+++ b/spec/StoryReaderRecovered.wl
@@ -84,9 +84,10 @@ defineAgent["StoryBrowse", {scene, pos},
    (see PSActive's note + story-reader-recovery.md on why it isn't one shared
    definition). Value-functions ARE shared (targetOf, evaluate). Capture relays to
    VocabTable on vocabUpsert (the same store channel PS capture uses); scoring
-   borrows the language from Helm on langRead (a τ). Both stay UNPREFIXED — they are
-   the store / Helm channels, shared by design; only the user-facing inputs carry
-   story_. Successors return to StoryReader (practice mode), preserving (scene,pos). *)
+   borrows the TARGET code from Helm on targetRead (a τ — the narrow read; see
+   PSActive). All stay UNPREFIXED — they are the store / Helm channels, shared by
+   design; only the user-facing inputs carry story_. Successors return to
+   StoryReader (practice mode), preserving (scene,pos). *)
 defineAgent["StoryPractice", {scene, pos, rec, res},
   choice[
     precede[coLabel["story_select_item", binding[i]],
@@ -98,13 +99,15 @@ defineAgent["StoryPractice", {scene, pos, rec, res},
         (* scoring PERSISTS here too: story practice runs the SAME
            render_practice_interface (story_tab.py:279) whose _persist_result
            saves every attempt — so the SECOND writer on progressAppend (the
-           vocabUpsert two-writer precedent). Chain mirrors PSActive's. *)
+           vocabUpsert two-writer precedent). Chain mirrors PSActive's,
+           including the NARROW borrow: targetRead (the code), not the
+           langRead pair — see PSActive's note. *)
         precede[coLabel["story_attempt_made"],
-          precede[coLabel["langRead", binding[lp]],
+          precede[coLabel["targetRead", binding[tc]],
             precede[label["progressAppend",
-                param[attemptRecord[targetOf[sceneOf[scene], pos], rec, lp]]],
+                param[attemptRecord[targetOf[sceneOf[scene], pos], rec, tc]]],
               call["StoryReader", scene, pos, practice, rec,
-                scored[evaluate[targetOf[sceneOf[scene], pos], rec, lp]]]]]],
+                scored[evaluate[targetOf[sceneOf[scene], pos], rec, tc]]]]]],
         precede[coLabel["story_clear_recording"],
           call["StoryReader", scene, pos, practice, none, none]]]],
     if[pos < Length[sceneOf[scene]] - 1,

--- a/spec/docs/ARCHITECTURE.md
+++ b/spec/docs/ARCHITECTURE.md
@@ -102,7 +102,10 @@ upstream of the port.
 Today that oracle→`helmView` read is still **implicit** (test data carries
 pre-baked `ipa`/`translation` values, correct by fiat). Making it explicit — the
 oracle call reading `(source, target)` from `helmView` — is now a **decided**
-matter: see **Borrowed vs owned data** below. In short, the consuming action
+matter: see **Borrowed vs owned data** below, and note that Helm exposes **two**
+internal read ports matching the pair's asymmetric roles (`langRead` = the full
+pair, for enrichment; `targetRead` = the code only, for scoring — see *The
+language pair is asymmetric*). In short, the consuming action
 *pulls* the language fresh through an internal port at the point of use; it is
 **not** pushed into a Vocab/PS cache. The one place a setting already gates a port
 is `set_speed` (`if[tts === espeak, …]`) — a genuine **control** dependency, but
@@ -158,10 +161,39 @@ progress). Helm remains the **sole owner**; oracles stay boundary functions
 (decision-A) but are now called *with* the language the read delivered.
 `espeakG2P[word, voice]` already has this shape (`voice` = the target read).
 
-*Status:* implemented for **both** borrowers, by the identical prefix-read, with
-Helm's `langRead!` restricted in `mioCore`:
-- **Vocab `autofill`** → `autofillIn[entries, id, lang]` → `enrichOracle[word, source, target]`;
-- **PS scoring** (`attempt_made`) → `evaluate[target, rec, lang]` → `recognisePhonemes[audio, targetCode]`.
+*Status:* implemented for **both** borrowers by the identical prefix-read idiom,
+each through the read that matches **what it consumes** (see *The language pair
+is asymmetric*, below), with both of Helm's read ports restricted in `mioCore`:
+- **Vocab `autofill`** → `langRead` (the full pair) → `enrichOracle[word, source, target]`;
+- **PS / StoryReader scoring** (`attempt_made` / `story_attempt_made`) →
+  `targetRead` (the target code only) → `recognisePhonemes[audio, targetCode]`.
+
+### The language pair is asymmetric (principle, 2026-07-06)
+
+The `(source, target)` pair is not symmetric in role:
+
+> **Source (native) is an *authoring parameter*** — it determines how
+> translations are built and how words are recorded (vocab entries carry a
+> translation rendered *into* the source). **Target (learned) is the
+> *practice identity*** — it determines what is presented, what is saved,
+> and how practices are keyed (`user_progress.language_code` is the target,
+> and only the target).
+
+The port structure now *states* this: enrichment borrows the full pair on
+`langRead`; scoring borrows only the code on **`targetRead`** (recovered from
+`language_state.py`'s `read_target_code` — the app's own narrow read). The
+scoring chains are `attempt_made · targetRead(τ) · progressAppend(τ)`.
+
+Two consequences:
+- **Source-independence of practice records is a theorem of the ports, not a
+  convention**: a bilingual user switching the source mid-practice cannot
+  affect a score or a logged attempt — the borrowed value does not contain a
+  source for anything to depend on (pinned by `language_flow_test` §5).
+- **One attempt store, keyed by target.** Practices for the same target
+  belong together regardless of the source in play (matching the app schema);
+  a source-split store would be invented, not recovered. Vocab remains
+  source-sensitive by the same principle — its entries genuinely consume both
+  halves.
 
 **External store (VocabTable) — the persistence counterpart, now modelled.** The
 vocab collection is owned by the **VocabTable** agent (the DB), not held in Vocab.

--- a/spec/docs/progress-table-recovery.md
+++ b/spec/docs/progress-table-recovery.md
@@ -51,6 +51,15 @@ story_attempt_made  · langRead?(lp) · progressAppend!(attemptRecord …) · St
 
 ## Decisions a reviewer should check
 
+**Review verdicts (Matthew, 2026-07-06, PR #186):** 1 accepted · 2 **open**
+(recommendation on the table: restore `recognized_phrase` as a distinct
+uninterpreted `transcriptOf[audio, lang]` oracle term for schema parity —
+awaiting sign-off) · 3 resolved by the **targetRead narrowing** (scoring now
+borrows only the target code; the asymmetry is stated in ARCHITECTURE.md
+"The language pair is asymmetric"; records stay in ONE store keyed by
+target) · 4 accepted · 5 provisional — filling out tracked as bead
+`miolingo-99j`.
+
 1. **Naming.** `ProgressTable`, not `Ledger`/`AttemptTable`: the naming rule
    ("store agents are named after their table") post-dates the placeholder
    and wins. Rename is a one-file-set mechanical change if rejected.

--- a/spec/tests/grouping_test.wls
+++ b/spec/tests/grouping_test.wls
@@ -38,7 +38,7 @@ Print[hr]; Print["2. transGroup / inputsFirst"]; Print[hr];
 sV = Last[walkSteps[transVP, mioCore,
    {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
     vis["recording_made", "audio"], vis["attempt_made"],
-    tau["langRead"], tau["progressAppend"], vis["capture_vocab", "chat"]}]["states"]];
+    tau["targetRead"], tau["progressAppend"], vis["capture_vocab", "chat"]}]["states"]];
 tauTr = SelectFirst[readyTransitions[transVP, sV], isTauAct[First[#]] &];
 assert["a tau transition groups into internal (tau)",
   transGroup[pm, tauTr] === "internal (\[Tau])"];

--- a/spec/tests/helm_test.wls
+++ b/spec/tests/helm_test.wls
@@ -27,11 +27,11 @@ sG = call["Helm", "English", "fr", google, 250, system, base];   (* tts = google
 sE = call["Helm", "English", "fr", espeak, 250, system, base];    (* tts = espeak *)
 
 Print[hr]; Print["1. ports — set_speed is gated on tts === espeak"]; Print[hr];
-(* langRead is the internal READ port (a borrower pulls {source,target} from it);
-   STANDALONE it is unrestricted so it shows here — in mioCore it is restricted
-   to an internal tau and does NOT appear externally. *)
-assert["google: view + langRead + set_source/target/tts + set_asr, NO set_speed",
-  ports[sG] === {"langRead", "set_asr", "set_source", "set_target", "set_tts", "view"}];
+(* langRead/targetRead are the internal READ ports (a borrower pulls the pair /
+   the target code); STANDALONE they are unrestricted so they show here — in
+   mioCore they are restricted to internal taus and do NOT appear externally. *)
+assert["google: view + langRead + targetRead + set_source/target/tts + set_asr, NO set_speed",
+  ports[sG] === {"langRead", "set_asr", "set_source", "set_target", "set_tts", "targetRead", "view"}];
 assert["espeak: + set_speed appears",
   MemberQ[ports[sE], "set_speed"]];
 assert["set_speed absent unless espeak", !MemberQ[ports[sG], "set_speed"]];
@@ -39,10 +39,14 @@ assert["set_speed absent unless espeak", !MemberQ[ports[sG], "set_speed"]];
 assert["set_asr always present", MemberQ[ports[sG], "set_asr"]];
 assert["set_asr_model absent unless whisper", !MemberQ[ports[sG], "set_asr_model"]];
 
-(* langRead emits the (source, target) pair the borrowers pull *)
+(* langRead emits the (source, target) pair; targetRead is the NARROW read —
+   only the target code (the scoring borrow; the asymmetry principle) *)
 assert["langRead carries {source, target}",
   With[{t = SelectFirst[readyTransitions[transNamed, sG], portName[First[#]] === "langRead" &]},
     First[Cases[First[t], param[p_] :> p, Infinity], None] === {"English", "fr"}]];
+assert["targetRead carries ONLY the target code",
+  With[{t = SelectFirst[readyTransitions[transNamed, sG], portName[First[#]] === "targetRead" &]},
+    First[Cases[First[t], param[p_] :> p, Infinity], None] === "fr"]];
 
 Print[hr]; Print["2. helmView projection — the (source,target) pair others read"]; Print[hr];
 v = view[sG];

--- a/spec/tests/language_flow_test.wls
+++ b/spec/tests/language_flow_test.wls
@@ -4,28 +4,35 @@
    ---------------------------------------------------------------------
    THE LANGUAGE-CODE BORROW, made a CHECKED CONTRACT.
 
-   Helm OWNS the (source, target) pair; every oracle that needs a language
-   PULLS it fresh at point of use via the internal langRead τ (borrowed, not
-   cached — HelmRecovered.wl, ARCHITECTURE.md "Borrowed vs owned data"). The
-   pair already flows; what was missing was an assertion that it flows — so a
-   future re-derivation (or a new implementation) that HARDCODES a language,
-   or drops the langRead borrow, fails LOUDLY here instead of silently.
+   Helm OWNS the (source, target) pair, and the pair is ASYMMETRIC
+   (ARCHITECTURE.md "The language pair is asymmetric"): source is an
+   authoring parameter, target is the practice identity. Every consumer
+   PULLS its language fresh at point of use (borrowed, not cached), through
+   the read that matches WHAT it consumes: scoring borrows ONLY the target
+   code (targetRead); enrichment borrows the full pair (langRead). A future
+   re-derivation that HARDCODES a language, drops a borrow, or widens the
+   scoring borrow back to the pair fails LOUDLY here instead of silently.
 
    Origin: a bug-report trace where valid language codes were not visible at
    the points that consume them. The data was threaded but unchecked; this
    pins it as a regression gate AND demonstrates it is present in the trace.
 
    What it pins (mioCoreD, transNamed, AutoTau — the live composed system):
-     1. PS scoring   : attempt_made fires langRead τ carrying Helm's concrete
-                       {source, target}; the TARGET code reaches the recognise
-                       oracle call (recognisePhonemes[_, target]).
+     1. PS scoring   : attempt_made fires the targetRead τ carrying ONLY
+                       Helm's concrete target code, which reaches the
+                       recognise oracle call (recognisePhonemes[_, target]).
      2. FRESH PULL   : change the target (set_target) and the code reaching the
                        oracle CHANGES with it — the decisive "not hardcoded,
                        not cached" check. A constant-language impl fails this.
-     3. SOURCE half  : autofill pulls BOTH halves; set_source is reflected in
-                       the borrowed pair (enrich needs source AND target).
+     3. SOURCE half  : autofill pulls BOTH halves via langRead; set_source is
+                       reflected in the borrowed pair (enrich needs source AND
+                       target — it renders INTO the source).
      4. STORY path   : story_attempt_made borrows identically (its own loop).
-     5. VISIBILITY   : the borrowed pair is PRESENT in the rendered event log
+     5. SOURCE-INDEPENDENCE (the narrowing's theorem): switching the source
+                       right before an attempt changes NOTHING about the
+                       score or the logged attempt row — the borrowed value
+                       does not even CONTAIN the source.
+     6. VISIBILITY   : the borrowed code is PRESENT in the rendered event log
                        (eventLogForm) — the codes show up in the trace gadget.
 
    The oracles stay UNINTERPRETED: recognisePhonemes has no downvalue, so the
@@ -47,16 +54,20 @@ hr = StringRepeat["=", 70];
 run[plan_] := walkSteps[transNamed, mioCoreD, plan, "AutoTau" -> True];
 (* the (source,target) pairs the langRead τ delivered, in order *)
 langSubsts[w_] := Cases[w["actions"], tag[\[Tau], "langRead", s_] :> (lp /. s)];
+(* the target codes the targetRead τ delivered, in order (the scoring borrow) *)
+targetSubsts[w_] := Cases[w["actions"], tag[\[Tau], "targetRead", s_] :> (tc /. s)];
 (* the target CODES that reached the recognise oracle in a (symbolic) score *)
 oracleCodes[score_] := Cases[score, recognisePhonemes[_, c_] :> c, Infinity];
 
 ph = {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>};
 
-Print[hr]; Print["1. PS scoring borrows the language at attempt_made"]; Print[hr];
+Print[hr]; Print["1. PS scoring borrows ONLY the target code at attempt_made"]; Print[hr];
 w1 = run[{vis["load_material", ph], vis["recording_made", "a"], vis["attempt_made"]}];
 assert["walk completed", !w1["stuck"]];
-assert["langRead τ fired, carrying Helm's concrete pair {English, fr}",
-  langSubsts[w1] === {{"English", "fr"}}];
+assert["targetRead τ fired, carrying Helm's concrete code \"fr\" (not the pair)",
+  targetSubsts[w1] === {"fr"}];
+assert["scoring fired NO langRead (the pair borrow is enrichment's, not scoring's)",
+  langSubsts[w1] === {}];
 sc1 = viewProjections[transNamed, Last[w1["states"]]]["pSView"]["score"];
 assert["the recognise oracle was called with the TARGET code \"fr\"",
   oracleCodes[sc1] === {"fr"}];
@@ -64,8 +75,8 @@ assert["the recognise oracle was called with the TARGET code \"fr\"",
 Print[hr]; Print["2. FRESH PULL — change the target, the oracle's code changes"]; Print[hr];
 w2 = run[{vis["set_target", "pt"], vis["load_material", ph],
           vis["recording_made", "a"], vis["attempt_made"]}];
-assert["langRead now carries the NEW pair {English, pt}",
-  langSubsts[w2] === {{"English", "pt"}}];
+assert["targetRead now carries the NEW code \"pt\"",
+  targetSubsts[w2] === {"pt"}];
 codes2 = oracleCodes[viewProjections[transNamed, Last[w2["states"]]]["pSView"]["score"]];
 assert["the oracle is called with \"pt\" (the live setting)", codes2 === {"pt"}];
 assert["NOT the old default \"fr\" — the language is not hardcoded/cached",
@@ -80,14 +91,32 @@ assert["autofill's langRead carries the full pair, source first: {Italian, fr}",
 Print[hr]; Print["4. STORY path — story_attempt_made borrows identically"]; Print[hr];
 w4 = run[{vis["set_mode", practice], vis["story_recording_made", "a"],
           vis["story_attempt_made"]}];
-assert["langRead τ fired for the story score, pair {English, fr}",
-  langSubsts[w4] === {{"English", "fr"}}];
+assert["targetRead τ fired for the story score, code \"fr\"",
+  targetSubsts[w4] === {"fr"}];
 scS = viewProjections[transNamed, Last[w4["states"]]]["storyReaderView"]["score"];
 assert["story score's oracle was called with \"fr\"", oracleCodes[scS] === {"fr"}];
 
-Print[hr]; Print["5. VISIBILITY — the borrowed pair is present in the rendered trace"]; Print[hr];
+Print[hr]; Print["5. SOURCE-INDEPENDENCE — a source switch cannot touch a practice record"]; Print[hr];
+(* identical attempts, one with the source switched right before scoring: the
+   borrowed value, the score term, and the logged attempt row must be IDENTICAL
+   — the narrow borrow means the dependency does not exist to be violated. *)
+w5a = run[{vis["load_material", ph], vis["recording_made", "a"], vis["attempt_made"]}];
+w5b = run[{vis["load_material", ph], vis["recording_made", "a"],
+           vis["set_source", "Italian"], vis["attempt_made"]}];
+assert["borrowed value identical under the source switch",
+  targetSubsts[w5a] === targetSubsts[w5b]];
+assert["score term identical under the source switch",
+  viewProjections[transNamed, Last[w5a["states"]]]["pSView"]["score"] ===
+  viewProjections[transNamed, Last[w5b["states"]]]["pSView"]["score"]];
+assert["logged attempt row identical under the source switch",
+  Cases[w5a["actions"], tag[\[Tau], "progressAppend", s_] :> (r /. s)] ===
+  Cases[w5b["actions"], tag[\[Tau], "progressAppend", s_] :> (r /. s)]];
+assert["...and the borrowed value does not even CONTAIN a source",
+  FreeQ[targetSubsts[w5b], "English"] && FreeQ[targetSubsts[w5b], "Italian"]];
+
+Print[hr]; Print["6. VISIBILITY — the borrowed code is present in the rendered trace"]; Print[hr];
 log2 = eventLogForm[eventLog[w2]];
-assert["the condensed event log shows the langRead τ", StringContainsQ[log2, "langRead"]];
+assert["the condensed event log shows the targetRead τ", StringContainsQ[log2, "targetRead"]];
 assert["...with the borrowed code \"pt\" inline (codes ARE in the trace)",
   StringContainsQ[log2, "pt"]];
 

--- a/spec/tests/maxprog_test.wls
+++ b/spec/tests/maxprog_test.wls
@@ -33,12 +33,12 @@ readyTaus[tf_, s_] := Select[readyTransitions[tf, s], isTauAct[First[#]] &];
    its vocabRead prefix, so an internal tau is pending. Under the (i) store form the
    capture relay is a SEQUENCE of taus: vocabRead (Vocab reads) → vocabUpsert (PS→Vocab) → vocabUpsert
    (Vocab→store) → vocabRead — autoTau fires them to stability, landing the word in the
-   store. (Setup plan keeps the explicit langRead AND progressAppend — the scoring
-   chain is attempt_made · langRead · progressAppend since the ProgressTable
+   store. (Setup plan keeps the explicit targetRead AND progressAppend — the scoring
+   chain is attempt_made · targetRead · progressAppend since the ProgressTable
    recovery, and both are PS-side, no AutoTau.) *)
 plan = {vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "S"|>}],
         vis["recording_made", "audio"], vis["attempt_made"],
-        tau["langRead"], tau["progressAppend"], vis["capture_vocab", "chat"]};
+        tau["targetRead"], tau["progressAppend"], vis["capture_vocab", "chat"]};
 
 check[label_, tf_, s0_] := Module[{s, a, stable},
   Print[hr]; Print[label]; Print[hr];

--- a/spec/tests/progress_flow_test.wls
+++ b/spec/tests/progress_flow_test.wls
@@ -6,7 +6,7 @@
 
    ProgressTable OWNS the persisted attempt log (the app's user_progress
    table); every scored attempt is WRITTEN to it as part of scoring — the
-   chain attempt_made · langRead(τ) · progressAppend(τ) — and Statistics /
+   chain attempt_made · targetRead(τ) · progressAppend(τ) — and Statistics /
    History are the store's query projections (statsView / historyView),
    not state held by PS. This was the † Stats/History incompleteness
    (ARCHITECTURE.md); this test pins the recovered flow so a future

--- a/spec/walk-tests.wl
+++ b/spec/walk-tests.wl
@@ -8,7 +8,7 @@
    actions:
      vis["port"]          take a visible action by port name (no value)
      vis["port", value]   take a value-carrying input port, supplying value
-   The internal syncs (vocabUpsert / goPractice / langRead / vocabRead — the VocabTable reads
+   The internal syncs (vocabUpsert / goPractice / langRead / targetRead / vocabRead — the VocabTable reads
    and writes — and progressAppend, the attempt-log write after scoring) are fired
    AUTOMATICALLY between steps by walkSteps' maximal-progress
    mode ("AutoTau" -> True) — so plans stay readable and robust as new internal
@@ -96,7 +96,7 @@ walkTests = <|
     vis["recording_made", "audio-A"],
     vis["clear_recording"],
     vis["recording_made", "audio-B"],
-    vis["attempt_made"],                            (* langRead auto-fires for scoring *)
+    vis["attempt_made"],                            (* targetRead auto-fires for scoring *)
     vis["capture_vocab", "souris"]},                (* vocabUpsert auto-fires (relay to Vocab) *)
 
   (* --- USER-as-environment: the recording VALUE is the TTS oracle term
@@ -108,7 +108,7 @@ walkTests = <|
   "user-speaks-target" -> {
     vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
     vis["recording_made", synthAudio["chat", "fr"]],
-    vis["attempt_made"]},                           (* langRead auto-fires for scoring *)
+    vis["attempt_made"]},                           (* targetRead auto-fires for scoring *)
 
   (* --- sync: Vocab practise_vocab (FILTERED) -> PS pull (goPractice+vocabRead) ---
      a filter is set, so PS pulls then shapes with the filtered subset. *)
@@ -156,13 +156,13 @@ walkTests = <|
     vis["set_mode", browse]},
 
   (* --- Story Reader: practise a scene phrase end-to-end ---
-     enter practice mode, record, score (langRead τ from Helm), capture to the
+     enter practice mode, record, score (targetRead τ from Helm), capture to the
      store (vocabUpsert τ to VocabTable — the SAME channel Quick Practice uses),
      then advance. The practice loop is StoryReader's own (mirrors PSActive). *)
   "story-practice" -> {
     vis["set_mode", practice],
     vis["story_recording_made", "audio"],
-    vis["story_attempt_made"],                      (* langRead auto-fires (score) *)
+    vis["story_attempt_made"],                      (* targetRead auto-fires (score) *)
     vis["story_capture_vocab", "Bonjour"],          (* vocabUpsert -> VocabTable *)
     vis["story_next_item_requested"]},
 
@@ -179,7 +179,7 @@ walkTests = <|
   "sync-vadd" -> {
     vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>}],
     vis["recording_made", "audio"],
-    vis["attempt_made"],                            (* langRead auto-fires for scoring *)
+    vis["attempt_made"],                            (* targetRead auto-fires for scoring *)
     vis["capture_vocab", "chat"],                   (* vocabUpsert auto-fires -> VocabTable (direct) *)
     vis["open_vocab"]},                             (* now view the captured word in the tab *)
 
@@ -208,7 +208,7 @@ walkTests = <|
     vis["load_material", {<|"text" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>,
                           <|"text" -> "chien", "translation" -> "dog", "ipa" -> "ʃjɛ̃"|>}],
     vis["recording_made", "audio-A"],
-    vis["attempt_made"],                            (* langRead + progressAppend auto-fire *)
+    vis["attempt_made"],                            (* targetRead + progressAppend auto-fire *)
     vis["next_item_requested"],
     vis["recording_made", "audio-B"],
     vis["attempt_made"],                            (* second row appended *)
@@ -222,7 +222,7 @@ walkTests = <|
     vis["add", <|"word" -> "chat", "translation" -> "cat", "ipa" -> "ʃa"|>],
     vis["practise_vocab"],                          (* goPractice→vocabRead auto-fires *)
     vis["recording_made", "audio"],
-    vis["attempt_made"],                            (* langRead auto-fires for scoring *)
+    vis["attempt_made"],                            (* targetRead auto-fires for scoring *)
     vis["capture_vocab", "souris"]}                 (* vocabUpsert auto-fires (relay to Vocab) *)
 
 |>;

--- a/spec/walk.wl
+++ b/spec/walk.wl
@@ -410,7 +410,7 @@ $walkCloud = {
     "why" -> "Vocab.autofill's translation + IPA are produced OUTSIDE the model; only the (source,target) pull (langRead) is in it.",
     "ports" -> {"autofill"}|>,
   <|"item" -> "recognisePhonemes", "owner" -> "external ASR / acoustic model",
-    "why" -> "PS scoring recognises audio -> phonemes outside the model; only the target-language pull (langRead) is in it.",
+    "why" -> "PS scoring recognises audio -> phonemes outside the model; only the target-code pull (targetRead) is in it.",
     "ports" -> {"attempt_made"}|>,
   <|"item" -> "DB persistence", "owner" -> "the real MySQL tables",
     "why" -> "VocabTable + ProgressTable model the stores IN the system; the actual vocab_entries / user_progress tables (connections, SQL, durability) stay outside. Rigging the model stores to the real DB is the \[Dagger] rig concern.",


### PR DESCRIPTION
## What

Your review of #186 identified that the spec under-states the **asymmetry of the language pair** — and contained a trace of exactly that: scoring borrowed the full `(source, target)` pair on `langRead` but consumed only the target. This PR makes the asymmetry a stated principle and a checked property. Spec-only (`--skip-version-check`).

- **Principle** (ARCHITECTURE.md, *The language pair is asymmetric*): source = authoring parameter (translations render *into* it; vocab is source-sensitive); target = practice identity (what is presented, scored, and keyed in `user_progress`).
- **`Helm.targetRead!`** — a second restricted internal read beside `langRead`, recovered from the app's own narrow read (`language_state.py read_target_code`), carrying only the target code.
- **Both scoring chains narrowed**: `attempt_made · targetRead(τ) · progressAppend(τ)` in PS and StoryReader. `autofill` keeps the full-pair `langRead` — enrichment genuinely needs both halves.
- **The theorem** (your bilingual question, answered structurally): a source switch mid-practice cannot affect a score or a logged attempt row — the borrowed value doesn't contain a source for anything to depend on. `language_flow_test` §5 pins it: identical borrow, score term, and attempt row under a source switch, and the borrowed value is `FreeQ` of any source. One attempt store, keyed by target (matches the app schema).
- Value functions take the code (`evaluate` keeps a pair overload for the round-trip-law callers); `helm_test` pins both read ports and that `targetRead` carries *only* the code; manual-τ plans in maxprog/grouping updated.
- Review verdicts from #186 recorded in `progress-table-recovery.md` — **decision 2 (`transcriptOf` schema parity for `recognized_phrase`) remains open** for your sign-off.

## Testing

Full headless suite green on both compositions (the compiled engine makes this minutes, not tens of minutes); only the pre-existing `g2p_test` espeak failure (`miolingo-eff`) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)