### PR TITLE
feat(phonetics): A2P lifecycle + flyout selector + Russian specialist (s06/3ym/dky)

### DIFF
--- a/docs/research/phonetics/phone_recognizer_survey_2026-07.md
+++ b/docs/research/phonetics/phone_recognizer_survey_2026-07.md
@@ -205,6 +205,7 @@ paper PERs mispredicted Spanish** — always bench:
 | **de** | CP-de | 0.1141 | **0.0426** | hk-de **1.0** (empty output) | **fallback** — hk-de unusable |
 | **pt-br** | FLEURS | 0.1542 | **0.1143** | caiocrocha 0.1156 | **fallback** — specialist ties, no gain |
 | **nl** | FLEURS | 0.1447 | 0.1116 | **clementapa 0.086** | **clementapa specialist** |
+| **ru** | CP-ru | 0.1333 | 0.1400 | **pklumpp 0.0733** | **pklumpp specialist** |
 | fr *(prior)* | CP-fr | 0.0719 | — | **cnam 0.0126** | cnam specialist |
 
 **`fb-xlsr` beat the old `lv-60` fb on all 5 benched languages** (es/it/de/pt-br/nl;
@@ -225,9 +226,22 @@ for everything else**, `lv-60` retained as a selectable backstop.
 | es/de/pt/pt-br/ru/en/… | **facebook/wav2vec2-xlsr-53-espeak-cv-ft** | fallback beat every specialist tested for these + beat lv-60 everywhere |
 | *(backstop)* | facebook/wav2vec2-lv-60-espeak-cv-ft | previous default, kept selectable (miolingo-3ym) |
 
-Not yet benched: **ru** (pklumpp CC0, best-lang 6.6% PER — needs dky processor build),
-**pt-pt** (no specialist exists), **en**. ZIPA (all-lang frontier) still needs the
-ONNX runtime path.
+**ru now benched + wired (miolingo-dky closed):** pklumpp's HF repo is weights-only
+with a custom class, so it's reconstructed in `src/audio/pklumpp_ctc.py` (vendored
+class + the exact 101-symbol vocab from github.com/PKlumpp/phd_model; state dict
+loaded directly, audio standardized, greedy CTC). It won ru **0.073 vs fb-xlsr 0.140**
+and is wired as the `ru` default. Note ru is the *only* language where xlsr-53 did
+not beat lv-60 (0.140 vs 0.133) — both fallbacks lose to pklumpp regardless.
+
+Still open: **pt-pt** (no specialist exists), **en** (unbenched). ZIPA (all-lang
+frontier) still needs the ONNX runtime path. The flyout model-selector (miolingo-3ym)
+and load-on-demand/unload-on-switch lifecycle (miolingo-s06) are now implemented.
+
+### Final wiring (all specialists benched on real audio)
+
+`fr→cnam · it→cnam-it · nl→clementapa · ru→pklumpp · es/de/pt/pt-br/en→xlsr-53
+fallback · lv-60 backstop`. The sidebar "🗣️ A2P Recognizer" expander lets a tester
+override any language's model live and unload the large models.
 
 **Two decisive outcomes:**
 1. **`fb-xlsr` (xlsr-53-espeak) beats the old `lv-60` fb on both es and it** (and same

--- a/research/phonetics/phone_poc/cp_eval.py
+++ b/research/phonetics/phone_poc/cp_eval.py
@@ -65,20 +65,21 @@ MODELS = {
     # 42-symbol IPA inventory (not espeak convention) -- scoring still runs on
     # panphon feature distance, but a symbol map may sharpen it.
     "caiocrocha-pt": "caiocrocha/wav2vec2-large-xlsr-53-phoneme-portuguese",
-    # pklumpp ships WEIGHTS ONLY (no processor/tokenizer/vocab in the HF repo), so
-    # AutoProcessor.from_pretrained fails. Decoding its CTC output needs the
-    # author's exact 101-IPA-symbol vocab + a hand-built Wav2Vec2Processor -- see
-    # follow-up bead. Left registered so the harness records the blocker.
+    # pklumpp ships WEIGHTS ONLY + a custom class; loaded via audio/pklumpp_ctc.py
+    # (Russian specialist, 0.073 err). pr._load returns (None, model) for it.
     "pklumpp": "pklumpp/Wav2Vec2_CommonPhone",
 }
 
 
 def recognize(model_id: str, wav_path: str) -> str:
-    """Audio -> space-separated IPA via the app's loader + CTC argmax decode."""
+    """Audio -> space-separated IPA via the app's cached loader + CTC decode."""
     import torch
 
-    processor, model = pr._load(model_id)
+    processor, model = pr._load(model_id)   # cached; (None, model) for pklumpp
     audio = pr._load_audio_16k(wav_path)
+    if processor is None:                   # pklumpp custom decode
+        from audio import pklumpp_ctc
+        return pklumpp_ctc.decode(model, audio)
     inputs = processor(audio, sampling_rate=16000, return_tensors="pt").input_values
     with torch.no_grad():
         logits = model(inputs).logits

--- a/research/phonetics/phone_poc/results/cp_eval_ru.json
+++ b/research/phonetics/phone_poc/results/cp_eval_ru.json
@@ -1,0 +1,32 @@
+{
+  "corpus": "common_phone",
+  "lang": "ru",
+  "split": "test",
+  "n_requested": 150,
+  "n_items": 150,
+  "reference": "espeak-G2P of transcript (weighted_phone metric)",
+  "metric": "mean 1 - phone_distance.similarity",
+  "results": {
+    "fb": {
+      "model_id": "facebook/wav2vec2-lv-60-espeak-cv-ft",
+      "n_scored": 150,
+      "n_failed": 0,
+      "mean_weighted_error": 0.1333,
+      "load_and_run_s": 42.2
+    },
+    "fb-xlsr": {
+      "model_id": "facebook/wav2vec2-xlsr-53-espeak-cv-ft",
+      "n_scored": 150,
+      "n_failed": 0,
+      "mean_weighted_error": 0.14,
+      "load_and_run_s": 39.9
+    },
+    "pklumpp": {
+      "model_id": "pklumpp/Wav2Vec2_CommonPhone",
+      "n_scored": 150,
+      "n_failed": 0,
+      "mean_weighted_error": 0.0733,
+      "load_and_run_s": 37.0
+    }
+  }
+}

--- a/src/audio/phone_recognizer.py
+++ b/src/audio/phone_recognizer.py
@@ -11,6 +11,8 @@ bake-off, cp_eval.py, miolingo-0x9):
   - French  -> Cnam-LMSSC/wav2vec2-french-phonemizer    (specialist, ~0.013 err)
   - Italian -> Cnam-LMSSC/wav2vec2-italian-phonemizer   (specialist, 0.046 err)
   - Dutch   -> Clementapa/wav2vec2-base-960h-phoneme-reco-dutch (specialist, 0.086)
+  - Russian -> pklumpp/Wav2Vec2_CommonPhone          (specialist, 0.073; custom
+               weights-only class loaded via audio/pklumpp_ctc.py, not AutoModelForCTC)
   - other   -> facebook/wav2vec2-xlsr-53-espeak-cv-ft   (multilingual fallback)
 No specialist wired for Spanish/German/pt-BR: each benched WORSE than or equal to
 the xlsr-53 fallback (es cnam-es 0.071>0.036 truncates; de hk-de emits empty; pt-BR
@@ -28,7 +30,7 @@ comprehensibility-only path never pays for them.
 
 from __future__ import annotations
 
-import functools
+from collections import OrderedDict
 from typing import Callable, Optional
 
 # espeak voice code (or its language prefix) -> HuggingFace phoneme-CTC model id.
@@ -46,6 +48,10 @@ _ITALIAN_MODEL = "Cnam-LMSSC/wav2vec2-italian-phonemizer"
 # 0.112 vs lv-60 0.145). Licence undeclared -> clear before ship (miolingo-0x9
 # reframe: test-only for now). nl-be/Flemish rides this via the prefix fallback.
 _DUTCH_MODEL = "Clementapa/wav2vec2-base-960h-phoneme-reco-dutch"
+# Russian specialist: pklumpp CommonPhone beat both fallbacks on Common Phone ru
+# (0.073 vs 0.133) -- ~1.9x. Weights-only repo + custom class, so it loads via
+# audio/pklumpp_ctc.py (not AutoModelForCTC). CC0 licence. (miolingo-dky)
+_RUSSIAN_MODEL = "pklumpp/Wav2Vec2_CommonPhone"
 
 # Multilingual fallback. xlsr-53 beat the old lv-60 on BOTH benched langs
 # (es 0.036<0.060, it 0.065<0.085), same espeak-IPA output + loader -> new default.
@@ -60,11 +66,42 @@ _VOICE_TO_MODEL = {
     "fr-ch": _FRENCH_MODEL,
     "it": _ITALIAN_MODEL,
     "nl": _DUTCH_MODEL,
+    "ru": _RUSSIAN_MODEL,
 }
 
 
-def model_for_voice(voice: str) -> str:
-    """Pick the phoneme-CTC model id for an espeak voice code."""
+# --- Model lifecycle & selection (miolingo-s06 load-on-demand/unload; miolingo-3ym
+# --- flyout selector) -----------------------------------------------------------
+#
+# Models are 0.3-1.2 GB each, so we (a) load lazily on first use, (b) keep at most
+# _MAX_LOADED resident and LRU-evict beyond that, and (c) expose explicit unload +
+# an evict-on-language-switch hook so the app can bound memory when the learner
+# changes target language. A manual OrderedDict cache (not lru_cache) is used so we
+# can introspect what's loaded, evict a single model, and free torch memory.
+
+_MODEL_CACHE: "OrderedDict[str, tuple]" = OrderedDict()  # model_id -> (proc, model)
+_MAX_LOADED = 2                    # soft cap; evict LRU beyond this
+_MODEL_OVERRIDE: dict[str, str] = {}  # espeak voice (lc) -> forced model id (UI)
+
+# Candidate recognizers for the flyout selector (miolingo-3ym): the wired defaults,
+# both multilingual options, and benched-but-not-default specialists a tester may
+# want to A/B. label -> HuggingFace model id.
+KNOWN_MODELS: "OrderedDict[str, str]" = OrderedDict([
+    ("Auto (per-language default)", ""),  # "" => resolve via _VOICE_TO_MODEL
+    ("fr · Cnam french (default)", _FRENCH_MODEL),
+    ("it · Cnam italian (default)", _ITALIAN_MODEL),
+    ("nl · Clementapa dutch (default)", _DUTCH_MODEL),
+    ("ru · pklumpp CommonPhone (default)", _RUSSIAN_MODEL),
+    ("es · Cnam spanish (benched: loses)", "Cnam-LMSSC/wav2vec2-spanish-phonemizer"),
+    ("pt-br · caiocrocha (benched: ties)",
+     "caiocrocha/wav2vec2-large-xlsr-53-phoneme-portuguese"),
+    ("fallback · xlsr-53-espeak (default)", _MULTILINGUAL_MODEL),
+    ("backstop · lv-60-espeak (legacy)", _MULTILINGUAL_MODEL_LV60),
+])
+
+
+def default_model_for_voice(voice: str) -> str:
+    """The wired per-language default, ignoring any UI override."""
     if not voice:
         return _MULTILINGUAL_MODEL
     v = voice.lower()
@@ -73,14 +110,95 @@ def model_for_voice(voice: str) -> str:
     return _VOICE_TO_MODEL.get(v.split("-")[0], _MULTILINGUAL_MODEL)
 
 
-@functools.lru_cache(maxsize=2)
-def _load(model_id: str):
-    """Lazily load (processor, model) for a phoneme-CTC model, cached per id."""
-    from transformers import AutoProcessor, AutoModelForCTC
+def model_for_voice(voice: str) -> str:
+    """Pick the model id for a voice, honoring a UI override if one is set."""
+    v = (voice or "").lower()
+    if v in _MODEL_OVERRIDE:
+        return _MODEL_OVERRIDE[v]
+    if v and v.split("-")[0] in _MODEL_OVERRIDE:
+        return _MODEL_OVERRIDE[v.split("-")[0]]
+    return default_model_for_voice(voice)
 
-    processor = AutoProcessor.from_pretrained(model_id)
-    model = AutoModelForCTC.from_pretrained(model_id)
-    model.eval()
+
+def set_model_override(voice: str, model_id: str) -> None:
+    """Force a specific recognizer for a voice (flyout selector). Empty model_id or
+    None clears the override (revert to the per-language default)."""
+    v = (voice or "").lower()
+    if not v:
+        return
+    if model_id:
+        _MODEL_OVERRIDE[v] = model_id
+    else:
+        _MODEL_OVERRIDE.pop(v, None)
+
+
+def loaded_model_ids() -> list[str]:
+    """Model ids currently resident in memory (for the flyout status display)."""
+    return list(_MODEL_CACHE.keys())
+
+
+def unload(model_id: Optional[str] = None) -> None:
+    """Free one model (by id) or all models, releasing torch memory."""
+    ids = [model_id] if model_id else list(_MODEL_CACHE.keys())
+    for mid in ids:
+        _MODEL_CACHE.pop(mid, None)
+    _free_torch_memory()
+
+
+def unload_all_except_voice(voice: str) -> None:
+    """Evict every resident model except the one the given voice resolves to.
+
+    The app calls this when the learner switches target language, so we don't pin
+    the previous language's large model alongside the new one."""
+    keep = model_for_voice(voice)
+    for mid in list(_MODEL_CACHE.keys()):
+        if mid != keep:
+            _MODEL_CACHE.pop(mid, None)
+    _free_torch_memory()
+
+
+def _free_torch_memory() -> None:
+    """Best-effort release of freed model memory back to the allocator. Never
+    IMPORTS torch -- only touches it if a model already pulled it in, so an
+    unload call on the comprehensibility-only path stays cheap."""
+    import gc
+    import sys
+
+    gc.collect()
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return
+    try:
+        if torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+        elif torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001 - memory reclaim is advisory
+        pass
+
+
+def _load(model_id: str):
+    """Lazily load (processor, model), cached per id with an LRU soft cap."""
+    cached = _MODEL_CACHE.get(model_id)
+    if cached is not None:
+        _MODEL_CACHE.move_to_end(model_id)  # mark most-recently-used
+        return cached
+
+    if model_id == _RUSSIAN_MODEL:
+        # Weights-only custom-class model: no processor, decoded specially below.
+        from audio import pklumpp_ctc
+        processor, model = None, pklumpp_ctc.load_model()
+    else:
+        from transformers import AutoProcessor, AutoModelForCTC
+
+        processor = AutoProcessor.from_pretrained(model_id)
+        model = AutoModelForCTC.from_pretrained(model_id)
+        model.eval()
+    _MODEL_CACHE[model_id] = (processor, model)
+    _MODEL_CACHE.move_to_end(model_id)
+    while len(_MODEL_CACHE) > _MAX_LOADED:      # evict least-recently-used
+        _MODEL_CACHE.popitem(last=False)
+        _free_torch_memory()
     return processor, model
 
 
@@ -132,16 +250,20 @@ def phones_from_audio(
         return ""
 
     try:
-        import torch
-
         audio = _load_audio_16k(audio_file)
-        inputs = processor(
-            audio, sampling_rate=16000, return_tensors="pt"
-        ).input_values
-        with torch.no_grad():
-            logits = model(inputs).logits
-        ids = torch.argmax(logits, dim=-1)
-        text = processor.batch_decode(ids)[0]
+        if processor is None:                       # pklumpp custom class (ru)
+            from audio import pklumpp_ctc
+            text = pklumpp_ctc.decode(model, audio)
+        else:
+            import torch
+
+            inputs = processor(
+                audio, sampling_rate=16000, return_tensors="pt"
+            ).input_values
+            with torch.no_grad():
+                logits = model(inputs).logits
+            ids = torch.argmax(logits, dim=-1)
+            text = processor.batch_decode(ids)[0]
     except Exception as e:
         if warn_fn is not None:
             warn_fn(f"Phone recognition failed: {e}")

--- a/src/audio/pklumpp_ctc.py
+++ b/src/audio/pklumpp_ctc.py
@@ -1,0 +1,102 @@
+"""
+Loader/decoder for pklumpp/Wav2Vec2_CommonPhone — the Russian A2P specialist
+(miolingo-dky; benched 0.073 weighted err vs the fallback's 0.133 on Common Phone
+Russian, ~1.9x better).
+
+The HF repo ships WEIGHTS ONLY (no processor/tokenizer/vocab) and is NOT a
+Wav2Vec2ForCTC, so it can't load via AutoModelForCTC like the other recognizers.
+It is the author's custom class (github.com/PKlumpp/phd_model): a HF Wav2Vec2Model
+(xlsr-53) + Linear(1024, 102) CTC head, blank index 0, over 101 IPA symbols. We
+vendor the tiny class + the exact vocab so it runs with no extra deps.
+
+Two requirements from the author's example.py:
+  - input audio must be STANDARDIZED (zero mean, unit std), NOT run through a
+    Wav2Vec2 feature extractor;
+  - CTC blank is index 0; decode is greedy argmax + collapse repeats + drop blank.
+The "(...)" placeholder (id 49) is dropped as a non-phone token.
+
+Licence: model is CC0-1.0; vocab + class transcribed from the author's CC0 repo.
+"""
+from __future__ import annotations
+
+HF_ID = "pklumpp/Wav2Vec2_CommonPhone"
+
+# id -> IPA symbol (blank = 0). From phd_model/phonetics/ipa.py SYMBOLS, inverted.
+_SYMBOLS = {
+    "r": 1, "ʝ": 2, "ã": 3, "gː": 4, "t": 5, "n": 6, "w": 7, "u": 8, "l": 9,
+    "yː": 10, "ʎ": 11, "bʲ": 12, "ə": 13, "ʃʲ": 14, "sː": 15, "zʲ": 16, "kː": 17,
+    "y": 18, "ɒ": 19, "fʲ": 20, "ɑ": 21, "ʏ": 22, "ɣ": 23, "s": 24, "m": 25,
+    "tː": 26, "xʲ": 27, "vː": 28, "ø": 29, "h": 30, "ɨ": 31, "dʲ": 32, "dː": 33,
+    "bː": 34, "ɲː": 35, "ɑː": 36, "ɪ": 37, "ɛ": 38, "i": 39, "ʔ": 40, "g": 41,
+    "ʃ": 42, "ɜː": 43, "mː": 44, "øː": 45, "fː": 46, "p": 47, "iː": 48, "(...)": 49,
+    "v": 50, "ʌ": 51, "b": 52, "k": 53, "x": 54, "ɲ": 55, "ʒ": 56, "rː": 57,
+    "eː": 58, "ç": 59, "ŋ": 60, "ɔː": 61, "œ": 62, "ẽ": 63, "θ": 64, "a": 65,
+    "rʲ": 66, "vʲ": 67, "ʃː": 68, "æ": 69, "ɶ̃": 70, "pː": 71, "nː": 72, "lʲ": 73,
+    "õ": 74, "pʲ": 75, "ɱ": 76, "ð": 77, "f": 78, "j": 79, "o": 80, "nʲ": 81,
+    "sʲ": 82, "lː": 83, "e": 84, "d": 85, "ʊ": 86, "gʲ": 87, "z": 88, "ɛː": 89,
+    "tʲ": 90, "β": 91, "mʲ": 92, "uː": 93, "ɥ": 94, "ʀ": 95, "aː": 96, "ɐ": 97,
+    "ɔ": 98, "oː": 99, "ʎː": 100, "kʲ": 101,
+}
+_ID_TO_SYMBOL = {i: s for s, i in _SYMBOLS.items()}
+_SKIP = {0, 49}  # blank + "(...)" placeholder
+
+
+def load_model():
+    """Instantiate the vendored class and load the safetensors weights directly.
+
+    from_pretrained() breaks on newer transformers (the class predates
+    `all_tied_weights_keys`), so we load the state dict by hand -- keys are
+    `wav2vec.*` / `linear.*`, matching the class attributes.
+    """
+    import torch.nn as nn
+    from transformers import (Wav2Vec2Model, Wav2Vec2Config, PreTrainedModel,
+                              PretrainedConfig)
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    class _Config(PretrainedConfig):
+        model_type = "wav2vec2"
+
+        def __init__(self, n_classes: int = 102, **kwargs):
+            self.n_classes = n_classes
+            super().__init__(**kwargs)
+
+    class _Wav2Vec2(PreTrainedModel):
+        config_class = _Config
+
+        def __init__(self, config):
+            super().__init__(config)
+            self.wav2vec = Wav2Vec2Model(
+                Wav2Vec2Config.from_pretrained("facebook/wav2vec2-large-xlsr-53"))
+            self.linear = nn.Linear(in_features=1024, out_features=config.n_classes)
+
+        def forward(self, x):
+            x = self.wav2vec(x)
+            return self.linear(x.last_hidden_state)
+
+    model = _Wav2Vec2(_Config(n_classes=102))
+    sd = load_file(hf_hub_download(HF_ID, "model.safetensors"))
+    missing, _ = model.load_state_dict(sd, strict=False)
+    if [k for k in missing if k.startswith("linear.")]:
+        raise RuntimeError("pklumpp head weights missing")
+    model.eval()
+    return model
+
+
+def decode(model, audio_16k) -> str:
+    """Standardized-audio -> space-separated IPA via greedy CTC (blank=0)."""
+    import numpy as np
+    import torch
+
+    a = np.asarray(audio_16k, dtype="float32")
+    a = (a - a.mean()) / (a.std() + 1e-9)                # standardize (required)
+    x = torch.tensor(a, dtype=torch.float).unsqueeze(0)  # (1, T)
+    with torch.no_grad():
+        logits = model(x)                                # (1, T, 102)
+    ids = torch.argmax(logits[0], dim=-1).tolist()
+    out, prev = [], None
+    for i in ids:                                        # collapse + drop skips
+        if i != prev and i not in _SKIP:
+            out.append(_ID_TO_SYMBOL.get(i, ""))
+        prev = i
+    return " ".join(s for s in out if s)

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -303,6 +303,12 @@ def render_settings_panel():
                     "date": datetime.now().isoformat(),
                     "practices": []
                 }
+            # Target language changed: evict the previous language's A2P model so we
+            # don't pin two large recognizers in memory (miolingo-s06). Cheap no-op
+            # if nothing is loaded (comprehensibility-only path never imported torch).
+            from audio import phone_recognizer as _pr
+            if _pr.loaded_model_ids():
+                _pr.unload_all_except_voice(st.session_state.material_language)
 
         # Safety: ensure session exists for current language
         if st.session_state.language not in st.session_state.current_sessions:
@@ -410,6 +416,12 @@ def render_settings_panel():
         # selector is gone. Default the setting to 'comprehensibility' for the
         # primary saved score; the result view shows both regardless.
         st.session_state.settings.setdefault('realization_source', 'comprehensibility')
+
+        # ── A2P Recognizer (accuracy channel, miolingo-3ym) ──────────────────
+        # Testing aid: show which acoustic phone-recognizer model is active for the
+        # current target language, let it be overridden per language, keep the fb
+        # backstop selectable, and surface / free what's loaded in memory (s06).
+        _render_a2p_recognizer_selector()
 
         # ── Audio Processing ─────────────────────────────────────────────────
         st.markdown("**🎚️ Audio Processing**")
@@ -538,6 +550,59 @@ def _render_story_link(lang_code: str):
     if lang_code in stories:
         url, label = stories[lang_code]
         st.markdown(f"- [{label}]({url})")
+
+
+def _render_a2p_recognizer_selector():
+    """Sidebar panel (miolingo-3ym): show / override the acoustic phone-recognizer
+    model for the CURRENT target language, keep the fb backstop selectable, and
+    surface + free the large models loaded in memory (miolingo-s06).
+
+    A testing aid — it reminds the tester which model produced a given accuracy
+    score and lets them A/B models per language. The override is remembered per
+    language in settings and re-applied to the recognizer module each render.
+    """
+    from audio import phone_recognizer as pr
+
+    voice = st.session_state.get('material_language') or 'fr'
+    overrides = st.session_state.settings.setdefault('a2p_overrides', {})
+    # Re-apply persisted per-language overrides to the (module-global) recognizer.
+    for _v, _mid in overrides.items():
+        pr.set_model_override(_v, _mid)
+
+    with st.expander("🗣️ A2P Recognizer (accuracy channel)", expanded=False):
+        labels = list(pr.KNOWN_MODELS)
+        cur_mid = overrides.get(voice, "")
+        cur_label = next((l for l, m in pr.KNOWN_MODELS.items() if m == cur_mid),
+                         labels[0])
+        sel = st.selectbox(
+            f"Model for '{voice}'",
+            labels,
+            index=labels.index(cur_label),
+            help="Override the audio→IPA recognizer for THIS language. 'Auto' uses "
+                 "the benched default; the fb entries are the multilingual "
+                 "backstop. Remembered per language.",
+        )
+        sel_mid = pr.KNOWN_MODELS[sel]
+        if sel_mid != cur_mid:
+            if sel_mid:
+                overrides[voice] = sel_mid
+            else:
+                overrides.pop(voice, None)
+            pr.set_model_override(voice, sel_mid)
+            _save_settings(st.session_state.settings)
+
+        active = pr.model_for_voice(voice)
+        default = pr.default_model_for_voice(voice)
+        st.caption(f"Active: `{active.split('/')[-1]}`")
+        if active != default:
+            st.caption(f"↳ default for '{voice}' is `{default.split('/')[-1]}`")
+
+        loaded = pr.loaded_model_ids()
+        st.caption("In memory: " +
+                   (", ".join(f"`{m.split('/')[-1]}`" for m in loaded) or "none"))
+        if loaded and st.button("♻️ Unload A2P models", key="a2p_unload"):
+            pr.unload()
+            st.rerun()
 
 
 def _save_settings(settings: dict):


### PR DESCRIPTION
Three pieces of the acoustic phone-recognizer work, building on #188.

## miolingo-s06 — model lifecycle (load-on-demand + unload-on-switch)
- Manual `OrderedDict` LRU cache (replaces `lru_cache`) with `unload(id|all)`,
  `loaded_model_ids()`, `unload_all_except_voice()`.
- The unload hook is wired into the sidebar's **target-language switch**, so the
  previous language's 0.3–1.2 GB model is evicted rather than pinned.
- `_free_torch_memory()` never *imports* torch unless a model already did →
  idle switches / comprehensibility-only path stay cheap.

## miolingo-3ym — flyout model selector + backstop
- Sidebar **🗣️ A2P Recognizer** expander: active model for the current language,
  a per-language override selectbox (specialists + fb/lv-60 backstop), the
  in-memory model list, and an **Unload** button.
- Override persisted per voice in settings; a testing aid so you always see which
  model produced an accuracy score and can A/B live.

## miolingo-dky — Russian specialist (pklumpp), reconstructed + wired
pklumpp/Wav2Vec2_CommonPhone is weights-only with a custom class, so it's rebuilt
in `src/audio/pklumpp_ctc.py`: vendored class + the exact 101-symbol IPA vocab
from github.com/PKlumpp/phd_model, state dict loaded directly (`from_pretrained`
breaks on newer transformers), audio standardized, greedy CTC.

| model | ru weighted err |
|-------|----------------:|
| **pklumpp** | **0.0733** |
| fb (lv-60) | 0.1333 |
| fb-xlsr | 0.1400 |

Wired as the `ru` default, integrated into the same cache/unload path (`pr._load`
returns `(None, model)` for it). ru is the one language where xlsr-53 didn't beat
lv-60 — but both fallbacks lose to pklumpp.

## Verification
- `py_compile` clean on all edited files; `tests/test_phone_distance.py` green.
- End-to-end: `phones_from_audio(ru_wav, 'ru')` → correct Russian phones; model
  loads into the shared cache; language switch evicts it.
- The sidebar selector is straightforward Streamlit but hasn't had eyes-on-browser
  yet — worth a glance in the running app.

Final wiring: `fr/it/nl/ru` specialists + xlsr-53 fallback (`es/de/pt/pt-br/en`) +
lv-60 backstop. Licences deferred to pre-ship per the 0x9 reframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)