### PR TITLE
feat(web): M5 Vocab tab — CRUD, import/export, MySQL migration

### DIFF
--- a/web/app/src/app/model.svelte.ts
+++ b/web/app/src/app/model.svelte.ts
@@ -11,8 +11,17 @@
 import * as ps from '../domain/practiceSession.js';
 import * as helmFns from '../domain/helm.js';
 import * as vocabFns from '../domain/vocabFunctions.js';
+import * as vocabTab from '../domain/vocab.js';
+import { exportCsv, importOutcome } from '../domain/vocabImportExport.js';
 import { phrasesFor, type UnifiedDoc } from '../domain/materials.js';
-import type { AlignOp, Capture, Phrase, Score, VocabEntry } from '../domain/types.js';
+import type {
+  AlignOp,
+  Capture,
+  ImportResult,
+  Phrase,
+  Score,
+  VocabEntry,
+} from '../domain/types.js';
 import { attempt, fetchMaterial, tts } from '../oracle/client.js';
 import type { AttemptChannel, AttemptResponse } from '../oracle/types.js';
 import { db, loadHelm, saveHelm, type VocabRow } from '../store/db.js';
@@ -52,6 +61,9 @@ export class AppModel {
   /** VocabTable's owned store for the CURRENT target language (vocabRead
    * reads this fresh; rows carry lang + wall-clock beyond the domain entry). */
   entries = $state<VocabRow[]>([]);
+  /** The Vocab TAB's UI params (sort/filter/editing) — the spec's Vocab
+   * agent; the collection itself lives in `entries` (VocabTable). */
+  vocab = $state<vocabTab.Vocab>(vocabTab.initialVocab);
   /** The full dual-channel result of the last scored attempt (display only;
    * lifecycle slaved to ps.res — see #sync). */
   lastAttempt = $state<AttemptResponse | null>(null);
@@ -157,27 +169,83 @@ export class AppModel {
     }
   }
 
-  /** capture_vocab · vocabUpsert — ATOMIC: one synchronous state write, then
-   * write-through persistence. The PS slice is untouched (no view flicker). */
-  captureVocab(w: Capture | string): void {
-    const before = this.entries;
-    const after = vocabFns.addEntry(before, w) as VocabEntry[];
+  /** Decorate domain entries with the row fields (lang, wall-clock), then
+   * write the current language's table through to Dexie. Persisted rows drop
+   * the in-memory domain ids (identity is [lang+word]; Dexie auto-assigns). */
+  #setEntries(after: readonly VocabEntry[], touchedKey: string | null): void {
     const now = nowIso();
-    const key = typeof w === 'string' ? w : w.word;
-    const norm = vocabFns.validateWord(key);
     this.entries = after.map((e) => {
       const row = e as VocabRow;
-      const touched = norm !== null && e.word === norm.key;
       return {
         ...row,
         lang: row.lang ?? this.helm.target,
         firstSeenAt: row.firstSeenAt ?? now,
-        lastSeenAt: touched ? now : (row.lastSeenAt ?? now),
+        lastSeenAt: touchedKey !== null && e.word === touchedKey ? now : (row.lastSeenAt ?? now),
       };
     });
-    void db.vocab.bulkPut($state.snapshot(this.entries) as VocabRow[]).catch(() => {
-      /* persistence is write-through best-effort; the in-memory table rules */
+    const rows = ($state.snapshot(this.entries) as VocabRow[]).map(
+      ({ id: _id, ...rest }) => rest,
+    );
+    void db
+      .transaction('rw', db.vocab, async () => {
+        await db.vocab.where('lang').equals(this.helm.target).delete();
+        await db.vocab.bulkAdd(rows as VocabRow[]);
+      })
+      .catch(() => {
+        /* persistence is write-through best-effort; the in-memory table rules */
+      });
+  }
+
+  /** capture_vocab · vocabUpsert — ATOMIC: one synchronous state write, then
+   * write-through persistence. The PS slice is untouched (no view flicker). */
+  captureVocab(w: Capture | string): void {
+    const key = typeof w === 'string' ? w : w.word;
+    const norm = vocabFns.validateWord(key);
+    this.#setEntries(vocabFns.addEntry(this.entries, w), norm?.key ?? null);
+  }
+
+  // --- Vocab tab (external channels + table write-throughs) --------------
+  setVocabSort(s: vocabTab.Vocab['sort']): void {
+    this.vocab = vocabTab.setSort(this.vocab, s);
+  }
+
+  setVocabFilter(q: string | null): void {
+    this.vocab = vocabTab.setFilter(this.vocab, q);
+  }
+
+  beginEdit(id: number): void {
+    this.vocab = vocabTab.beginEdit(this.vocab, id);
+  }
+
+  cancelEdit(): void {
+    this.vocab = vocabTab.cancelEdit(this.vocab);
+  }
+
+  removeEntry(id: number): void {
+    this.#setEntries(vocabFns.deleteFrom(this.entries, id), null);
+  }
+
+  amendEntry(id: number, fields: Readonly<Record<string, string>>): void {
+    this.#setEntries(vocabFns.updateEntry(this.entries, id, fields), null);
+    this.vocab = vocabTab.endEdit(this.vocab);
+  }
+
+  amendNotes(id: number, notes: string | null): void {
+    this.#setEntries(vocabFns.updateNotesIn(this.entries, id, notes), null);
+  }
+
+  /** import_bulk — header target-guarded against the borrowed language. */
+  importBulk(contents: string): ImportResult {
+    const { entries, result } = importOutcome(this.entries, {
+      contents,
+      expectedTarget: this.helm.target,
     });
+    if (result.kind === 'ok') this.#setEntries(entries, null);
+    return result;
+  }
+
+  exportCsvString(): string {
+    return exportCsv(this.entries);
   }
 
   async #logAttempt(res: AttemptResponse, origin: 'quick' | 'story' | 'vocab'): Promise<void> {

--- a/web/app/src/store/exportImport.ts
+++ b/web/app/src/store/exportImport.ts
@@ -1,0 +1,107 @@
+// JSON export/import — the portability story for browser-owned data (and the
+// landing pad for the one-off MySQL export, web/oracle/scripts/export_mysql.py,
+// which emits exactly this shape). Ids are never exported or imported: vocab
+// identity is [lang+word]; log rows are append-only.
+
+import { db, type PracticeLogRow, type VocabRow } from './db.js';
+
+type PortableVocab = Omit<VocabRow, 'id'>;
+type PortableLog = Omit<PracticeLogRow, 'id'>;
+
+export interface ExportFile {
+  miolingo_export: 1;
+  exportedAt: string;
+  vocab: PortableVocab[];
+  practiceLog: PortableLog[];
+  settings: Record<string, unknown>;
+}
+
+const stripId = <T extends { id?: unknown }>(row: T): Omit<T, 'id'> => {
+  const { id: _id, ...rest } = row;
+  return rest;
+};
+
+export async function exportAll(): Promise<ExportFile> {
+  const [vocab, practiceLog, settings] = await Promise.all([
+    db.vocab.toArray(),
+    db.practiceLog.toArray(),
+    db.settings.toArray(),
+  ]);
+  return {
+    miolingo_export: 1,
+    exportedAt: new Date().toISOString(),
+    vocab: vocab.map(stripId),
+    practiceLog: practiceLog.map(stripId),
+    settings: Object.fromEntries(settings.map((s) => [s.key, s.value])),
+  };
+}
+
+/** Merge one incoming vocab row into an existing one: fill-never-overwrite
+ * (addEntry semantics), sum timesSeen, widen the seen window. */
+function mergeVocab(existing: VocabRow, incoming: PortableVocab): VocabRow {
+  const fill = (old: string | null, next: string | null): string | null =>
+    old == null || old === '' ? next : old;
+  return {
+    ...existing,
+    translation: fill(existing.translation, incoming.translation),
+    ipa: fill(existing.ipa, incoming.ipa),
+    sourceName: fill(existing.sourceName, incoming.sourceName),
+    url: fill(existing.url, incoming.url),
+    contextBefore: fill(existing.contextBefore, incoming.contextBefore),
+    contextLine: fill(existing.contextLine, incoming.contextLine),
+    contextAfter: fill(existing.contextAfter, incoming.contextAfter),
+    notes: fill(existing.notes, incoming.notes),
+    timesSeen: existing.timesSeen + incoming.timesSeen,
+    firstSeenAt:
+      incoming.firstSeenAt < existing.firstSeenAt ? incoming.firstSeenAt : existing.firstSeenAt,
+    lastSeenAt:
+      incoming.lastSeenAt > existing.lastSeenAt ? incoming.lastSeenAt : existing.lastSeenAt,
+  };
+}
+
+export interface ImportSummary {
+  vocabAdded: number;
+  vocabMerged: number;
+  logAdded: number;
+  settingsApplied: boolean;
+}
+
+/** Import an export file: vocab deduped on [lang+word], log rows appended,
+ * settings applied only where absent (never clobber the local Helm). */
+export async function importAll(
+  data: ExportFile,
+  opts: { applySettings?: boolean } = {},
+): Promise<ImportSummary> {
+  if (data.miolingo_export !== 1) throw new Error('not a miolingo export file');
+  let vocabAdded = 0;
+  let vocabMerged = 0;
+
+  await db.transaction('rw', db.vocab, db.practiceLog, db.settings, async () => {
+    for (const row of data.vocab) {
+      const existing = await db.vocab.where('[lang+word]').equals([row.lang, row.word]).first();
+      if (existing === undefined) {
+        // clone: Dexie writes the assigned id back INTO the object it is
+        // given, which would silently mutate the caller's import data
+        await db.vocab.add({ ...row } as VocabRow);
+        vocabAdded++;
+      } else {
+        await db.vocab.put(mergeVocab(existing, row));
+        vocabMerged++;
+      }
+    }
+    await db.practiceLog.bulkAdd(data.practiceLog.map((r) => ({ ...r }) as PracticeLogRow));
+    if (opts.applySettings === true) {
+      for (const [key, value] of Object.entries(data.settings)) {
+        const existing = await db.settings.get(key);
+        if (existing === undefined) await db.settings.put({ key, value });
+      }
+    }
+  });
+
+  return {
+    vocabAdded,
+    vocabMerged,
+    logAdded: data.practiceLog.length,
+    settingsApplied: opts.applySettings === true,
+  };
+}

--- a/web/app/src/ui/vocab/ImportExportBar.svelte
+++ b/web/app/src/ui/vocab/ImportExportBar.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  // CSV export (the spec's exportCsv), bulk text import (header-guarded),
+  // and whole-store JSON export/import (incl. the MySQL migration file).
+  import { model } from '../../app/model.svelte.js';
+  import { exportAll, importAll, type ExportFile } from '../../store/exportImport.js';
+
+  let note = $state<string | null>(null);
+
+  function download(name: string, text: string, type: string): void {
+    const url = URL.createObjectURL(new Blob([text], { type }));
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function exportCsvFile(): void {
+    download(`miolingo-vocab-${model.helm.target}.csv`, model.exportCsvString(), 'text/csv');
+  }
+
+  async function exportJsonFile(): Promise<void> {
+    const data = await exportAll();
+    download('miolingo-export.json', JSON.stringify(data, null, 1), 'application/json');
+  }
+
+  async function onBulkFile(e: Event): Promise<void> {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file === undefined) return;
+    const result = model.importBulk(await file.text());
+    note =
+      result.kind === 'ok'
+        ? `imported ${result.added} new entries`
+        : result.kind === 'noHeader'
+          ? 'no (target,source) header line — nothing imported'
+          : result.kind === 'targetMismatch'
+            ? `file is for “${result.fileTarget}”, current target is “${result.expected}”`
+            : `too many lines (${result.count} > 250)`;
+    input.value = '';
+  }
+
+  async function onJsonFile(e: Event): Promise<void> {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file === undefined) return;
+    try {
+      const data = JSON.parse(await file.text()) as ExportFile;
+      const s = await importAll(data);
+      await model.reloadEntries();
+      note = `imported: ${s.vocabAdded} new + ${s.vocabMerged} merged vocab, ${s.logAdded} log rows`;
+    } catch (err: unknown) {
+      note = `import failed: ${String(err)}`;
+    }
+    input.value = '';
+  }
+</script>
+
+<div class="row">
+  <button onclick={exportCsvFile} disabled={model.entries.length === 0}>⬇ CSV</button>
+  <button onclick={exportJsonFile}>⬇ Export JSON</button>
+  <label class="filebtn">
+    ⬆ Import JSON<input type="file" accept=".json" onchange={onJsonFile} />
+  </label>
+  <label class="filebtn">
+    ⬆ Bulk text<input type="file" accept=".txt,.text" onchange={onBulkFile} />
+  </label>
+  {#if note !== null}<span class="muted">{note}</span>{/if}
+</div>
+
+<style>
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .filebtn {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.4rem 0.9rem;
+    cursor: pointer;
+  }
+
+  .filebtn input {
+    display: none;
+  }
+</style>

--- a/web/app/src/ui/vocab/VocabEditForm.svelte
+++ b/web/app/src/ui/vocab/VocabEditForm.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  // Inline row editor — writes go through vocabAmend (updateEntry), which
+  // rejects unknown fields and display words that would change the key.
+  import type { VocabEntry } from '../../domain/types.js';
+  import { model } from '../../app/model.svelte.js';
+
+  const { entry }: { entry: VocabEntry } = $props();
+
+  let displayWord = $state(entry.displayWord);
+  let translation = $state(entry.translation ?? '');
+  let ipa = $state(entry.ipa ?? '');
+  let notes = $state(entry.notes ?? '');
+
+  function save(): void {
+    model.amendEntry(entry.id, {
+      display_word: displayWord,
+      translation,
+      ipa,
+    });
+    model.amendNotes(entry.id, notes === '' ? null : notes);
+  }
+</script>
+
+<div class="edit">
+  <label>word <input bind:value={displayWord} title="case only — the key cannot change" /></label>
+  <label>translation <input bind:value={translation} /></label>
+  <label>IPA <input bind:value={ipa} /></label>
+  <label>notes <input bind:value={notes} /></label>
+  <div class="buttons">
+    <button onclick={save}>💾 Save</button>
+    <button onclick={() => model.cancelEdit()}>Cancel</button>
+  </div>
+</div>
+
+<style>
+  .edit {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: end;
+    padding: 0.3rem 0;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.8rem;
+    color: var(--fg-muted);
+  }
+
+  input {
+    font: inherit;
+    color: var(--fg);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.3rem 0.45rem;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 0.4rem;
+  }
+</style>

--- a/web/app/src/ui/vocab/VocabTableView.svelte
+++ b/web/app/src/ui/vocab/VocabTableView.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  // The filtered+sorted collection (already projected by vocabView).
+  import type { VocabEntry } from '../../domain/types.js';
+  import { model } from '../../app/model.svelte.js';
+  import VocabEditForm from './VocabEditForm.svelte';
+
+  const {
+    entries,
+    editing,
+  }: { entries: readonly VocabEntry[]; editing: number | null } = $props();
+</script>
+
+{#if entries.length === 0}
+  <p class="muted">No entries yet — capture words by practising, add them above, or import.</p>
+{:else}
+  <div class="tablewrap card">
+    <table>
+      <thead>
+        <tr><th>word</th><th>translation</th><th>IPA</th><th>seen</th><th>notes</th><th></th></tr>
+      </thead>
+      <tbody>
+        {#each entries as e (e.id)}
+          {#if editing === e.id}
+            <tr><td colspan="6"><VocabEditForm entry={e} /></td></tr>
+          {:else}
+            <tr>
+              <td class="word">{e.displayWord}</td>
+              <td>{e.translation ?? ''}</td>
+              <td class="ipa">{e.ipa !== null ? `[${e.ipa}]` : ''}</td>
+              <td class="num">{e.timesSeen}</td>
+              <td class="notes">{e.notes ?? ''}</td>
+              <td class="actions">
+                <button title="edit" onclick={() => model.beginEdit(e.id)}>✏️</button>
+                <button title="delete" onclick={() => model.removeEntry(e.id)}>🗑</button>
+              </td>
+            </tr>
+          {/if}
+        {/each}
+      </tbody>
+    </table>
+  </div>
+{/if}
+
+<style>
+  .tablewrap {
+    overflow-x: auto;
+    padding: 0.4rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.35rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .word {
+    font-weight: 600;
+  }
+
+  .ipa {
+    color: var(--accent);
+  }
+
+  .num {
+    text-align: right;
+  }
+
+  .notes {
+    color: var(--fg-muted);
+    max-width: 14rem;
+  }
+
+  .actions button {
+    padding: 0.1rem 0.35rem;
+    margin-left: 0.2rem;
+  }
+</style>

--- a/web/app/src/ui/vocab/VocabView.svelte
+++ b/web/app/src/ui/vocab/VocabView.svelte
@@ -1,6 +1,100 @@
-<section class="card">
-  <h2>📚 Vocabulary</h2>
-  <p class="muted">
-    Vocab table, capture, import/export, and the MySQL migration arrive in M5.
-  </p>
+<script lang="ts">
+  // The Vocab TAB (spec Vocab agent): sort/filter/add/import/export chrome.
+  // Renders ONLY vocabView(model.vocab, model.entries) — the collection is
+  // read fresh from the table at view time (borrow, never cache).
+  import { model } from '../../app/model.svelte.js';
+  import { vocabView } from '../../domain/vocab.js';
+  import type { VocabSort } from '../../domain/types.js';
+  import VocabTableView from './VocabTableView.svelte';
+  import ImportExportBar from './ImportExportBar.svelte';
+  import { setTab } from '../../store/prefs.svelte.js';
+
+  const view = $derived(vocabView(model.vocab, model.entries));
+
+  let newWord = $state('');
+  let addNote = $state<string | null>(null);
+
+  function add(): void {
+    const word = newWord.trim();
+    if (word === '') return;
+    const before = model.entries.length;
+    model.captureVocab({ word, sourceName: 'manual' });
+    addNote =
+      model.entries.length > before
+        ? `added “${word}”`
+        : model.entries.some((e) => e.word === word.toLowerCase())
+          ? `bumped “${word}” (already known)`
+          : `“${word}” is not a single word`;
+    newWord = '';
+  }
+
+  function practise(): void {
+    model.practiseVocab(view.filter); // goPractice carries only the filter
+    setTab('practice');
+  }
+</script>
+
+<section>
+  <div class="card controls">
+    <h2>📚 Vocabulary — {model.helm.target} ({view.count})</h2>
+    <div class="row">
+      <input
+        placeholder="add a word…"
+        bind:value={newWord}
+        onkeydown={(e) => e.key === 'Enter' && add()}
+      />
+      <button onclick={add}>＋ Add</button>
+      {#if addNote !== null}<span class="muted">{addNote}</span>{/if}
+    </div>
+    <div class="row">
+      <label
+        >Sort
+        <select
+          value={view.sort}
+          onchange={(e) => model.setVocabSort(e.currentTarget.value as VocabSort)}
+        >
+          <option value="alpha">A→Z</option>
+          <option value="recent">recently seen</option>
+          <option value="oldest">first captured</option>
+        </select>
+      </label>
+      <input
+        placeholder="filter…"
+        value={view.filter ?? ''}
+        oninput={(e) => model.setVocabFilter(e.currentTarget.value)}
+      />
+      <button onclick={practise} disabled={view.entries.length === 0}>
+        🎯 Practise these ({view.entries.length})
+      </button>
+    </div>
+    <ImportExportBar />
+  </div>
+
+  <VocabTableView entries={view.entries} editing={view.editing} />
 </section>
+
+<style>
+  .controls .row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin: 0.5rem 0;
+  }
+
+  input,
+  select {
+    font: inherit;
+    color: inherit;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.35rem 0.5rem;
+  }
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+</style>

--- a/web/app/test/exportImport.spec.ts
+++ b/web/app/test/exportImport.spec.ts
@@ -1,0 +1,107 @@
+// Export → wipe → import identity, merge semantics, and the MySQL-export
+// shape (the script emits exactly this format).
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { db, type VocabRow } from '../src/store/db.js';
+import { exportAll, importAll, type ExportFile } from '../src/store/exportImport.js';
+
+const row = (over: Partial<VocabRow> = {}): Omit<VocabRow, 'id'> => ({
+  lang: 'fr',
+  word: 'chat',
+  displayWord: 'chat',
+  translation: 'cat',
+  ipa: 'ʃa',
+  sourceName: null,
+  url: null,
+  contextBefore: null,
+  contextLine: null,
+  contextAfter: null,
+  timesSeen: 2,
+  firstSeq: 1,
+  lastSeq: 1,
+  notes: null,
+  firstSeenAt: '2026-01-01T00:00:00Z',
+  lastSeenAt: '2026-06-01T00:00:00Z',
+  ...over,
+});
+
+describe('JSON export/import', () => {
+  beforeEach(async () => {
+    await db.vocab.clear();
+    await db.practiceLog.clear();
+    await db.settings.clear();
+  });
+
+  it('export → wipe → import is identity (minus ids)', async () => {
+    await db.vocab.bulkAdd([row(), row({ word: 'chien', displayWord: 'chien' })] as VocabRow[]);
+    await db.practiceLog.add({
+      lang: 'fr',
+      date: '2026-07-12T10:00:00Z',
+      target: 'chat',
+      recognized: 'chat',
+      targetIpa: 'ʃa',
+      algorithm: 'weighted_phone',
+      compIpa: 'ʃa',
+      compSimilarity: 1,
+      accIpa: '',
+      accSimilarity: null,
+      perfect: true,
+      similarity: 1,
+      origin: 'quick',
+    });
+
+    const exported = await exportAll();
+    expect(exported.vocab).toHaveLength(2);
+    expect(exported.vocab[0]).not.toHaveProperty('id');
+
+    await db.vocab.clear();
+    await db.practiceLog.clear();
+    const summary = await importAll(exported);
+    expect(summary).toMatchObject({ vocabAdded: 2, vocabMerged: 0, logAdded: 1 });
+
+    const back = await exportAll();
+    expect(back.vocab).toEqual(exported.vocab);
+    expect(back.practiceLog).toEqual(exported.practiceLog);
+  });
+
+  it('merges duplicates: fill-never-overwrite, timesSeen summed, window widened', async () => {
+    await db.vocab.add(row({ translation: 'cat', ipa: null, timesSeen: 2 }) as VocabRow);
+    const incoming: ExportFile = {
+      miolingo_export: 1,
+      exportedAt: 'x',
+      vocab: [
+        row({
+          translation: 'feline',
+          ipa: 'ʃa',
+          timesSeen: 3,
+          firstSeenAt: '2025-01-01T00:00:00Z',
+          lastSeenAt: '2026-07-01T00:00:00Z',
+        }),
+      ],
+      practiceLog: [],
+      settings: {},
+    };
+    const s = await importAll(incoming);
+    expect(s).toMatchObject({ vocabAdded: 0, vocabMerged: 1 });
+    const merged = (await db.vocab.toArray())[0]!;
+    expect(merged.translation).toBe('cat'); // never overwritten
+    expect(merged.ipa).toBe('ʃa'); // filled
+    expect(merged.timesSeen).toBe(5); // summed
+    expect(merged.firstSeenAt).toBe('2025-01-01T00:00:00Z'); // widened
+    expect(merged.lastSeenAt).toBe('2026-07-01T00:00:00Z');
+  });
+
+  it('rejects non-export files and leaves local settings alone by default', async () => {
+    await expect(importAll({ nope: true } as unknown as ExportFile)).rejects.toThrow();
+    await db.settings.put({ key: 'helm', value: { target: 'fr' } });
+    await importAll({
+      miolingo_export: 1,
+      exportedAt: 'x',
+      vocab: [],
+      practiceLog: [],
+      settings: { helm: { target: 'ru' } },
+    });
+    const helm = await db.settings.get('helm');
+    expect((helm?.value as { target: string }).target).toBe('fr'); // untouched
+  });
+});

--- a/web/app/test/model.spec.ts
+++ b/web/app/test/model.spec.ts
@@ -129,6 +129,29 @@ describe('AppModel wiring (stubbed oracle)', () => {
     expect(model.ps.phrases).toEqual([phrase('chat', 'cat', 'ʃa')]);
   });
 
+  it('vocab table ops write through to Dexie (ids re-assigned, identity [lang+word])', async () => {
+    model.captureVocab({ word: 'chat', translation: 'cat' });
+    model.captureVocab('chien');
+    await vi.waitFor(async () => expect(await db.vocab.count()).toBe(2));
+
+    model.removeEntry(model.entries.find((e) => e.word === 'chat')!.id);
+    await vi.waitFor(async () => expect(await db.vocab.count()).toBe(1));
+    expect((await db.vocab.toArray())[0]!.word).toBe('chien');
+
+    model.amendEntry(model.entries[0]!.id, { translation: 'dog' });
+    await vi.waitFor(async () =>
+      expect((await db.vocab.toArray())[0]!.translation).toBe('dog'),
+    );
+  });
+
+  it('importBulk guards on the borrowed target language', () => {
+    const bad = model.importBulk('(en,fr)\nx|y');
+    expect(bad.kind).toBe('targetMismatch'); // helm.target is fr
+    const ok = model.importBulk('(fr,en)\nsouris|mouse|[suʁi]');
+    expect(ok).toEqual({ kind: 'ok', added: 1 });
+    expect(model.entries.map((e) => e.word)).toContain('souris');
+  });
+
   it('channelToScore maps oracle ops onto the spec alignment shape', () => {
     const res = fakeResponse({
       comprehensibility: {

--- a/web/oracle/scripts/export_mysql.py
+++ b/web/oracle/scripts/export_mysql.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""One-off MySQL → miolingo-export.json (the web app's import format).
+
+Exports a user's vocab_entries + user_progress so the browser app can import
+them (Vocabulary tab → Import JSON). Runs against the local mirror by default
+(same connection pattern as scripts/apply_sql.py); use --target remote to go
+through the SSH tunnel.
+
+Usage:
+    venv/bin/python web/oracle/scripts/export_mysql.py --email matthew@... \
+        [--target local|remote] [--lang pt] [-o miolingo-export.json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "scripts"))
+
+
+def _load_secrets() -> dict:
+    import tomllib
+
+    path = REPO / ".streamlit" / "secrets.toml"
+    if not path.exists():
+        raise SystemExit(f"secrets not found: {path}")
+    return tomllib.loads(path.read_text())
+
+
+def _connect(target: str, secrets: dict):
+    import mysql.connector
+
+    if target == "remote":
+        from sync_db import open_remote_connection
+
+        tunnel, conn = open_remote_connection(secrets)
+        return tunnel, conn
+    db = secrets.get("local_db") or secrets["mysql_local"]
+    kwargs = dict(user=db["user"], password=db["password"],
+                  database=db["database"])
+    if db.get("unix_socket"):
+        kwargs["unix_socket"] = db["unix_socket"]
+    else:
+        kwargs.update(host=db.get("host", "127.0.0.1"), port=int(db.get("port", 3306)))
+    return None, mysql.connector.connect(**kwargs)
+
+
+def _iso(x) -> str:
+    if isinstance(x, datetime):
+        return x.isoformat()
+    return str(x) if x else "1970-01-01T00:00:00"
+
+
+def export_user(conn, email: str, lang: str | None) -> dict:
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT id FROM users WHERE email=%s OR username=%s", (email, email))
+    user = cur.fetchone()
+    if user is None:
+        raise SystemExit(f"no user found for {email!r}")
+    uid = user["id"]
+
+    lang_clause = " AND language_code=%s" if lang else ""
+    lang_args = (lang,) if lang else ()
+
+    cur.execute(
+        f"SELECT * FROM vocab_entries WHERE user_id=%s{lang_clause}", (uid, *lang_args)
+    )
+    vocab = []
+    for seq, r in enumerate(cur.fetchall(), start=1):
+        word = (r.get("word") or "").lower()
+        if not word:
+            continue
+        vocab.append({
+            "lang": r["language_code"],
+            "word": word,
+            "displayWord": r.get("display_word") or r.get("word") or word,
+            "translation": r.get("translation"),
+            "ipa": r.get("ipa"),
+            "sourceName": r.get("source"),
+            "url": r.get("url"),
+            "contextBefore": r.get("context_before"),
+            "contextLine": r.get("context_line"),
+            "contextAfter": r.get("context_after"),
+            "timesSeen": int(r.get("times_seen") or 1),
+            "firstSeq": seq,  # logical clock synthesized from row order
+            "lastSeq": seq,
+            "notes": r.get("notes"),
+            "firstSeenAt": _iso(r.get("first_seen_at")),
+            "lastSeenAt": _iso(r.get("last_seen_at")),
+        })
+
+    cur.execute(
+        f"SELECT * FROM user_progress WHERE user_id=%s{lang_clause} ORDER BY practice_date",
+        (uid, *lang_args),
+    )
+    log = []
+    for r in cur.fetchall():
+        sim = float(r.get("similarity_score") or 0)
+        if sim > 1.5:  # stored as percent in MySQL; the web app uses 0..1
+            sim /= 100.0
+        log.append({
+            "lang": r["language_code"],
+            "date": _iso(r.get("practice_date")),
+            "target": r.get("target_phrase") or "",
+            "recognized": r.get("recognized_phrase") or "",
+            "targetIpa": r.get("target_phonemes") or "",
+            "algorithm": "edit_distance",  # legacy rows predate weighted_phone
+            "compIpa": r.get("user_phonemes") or "",
+            "compSimilarity": sim,
+            "accIpa": "",
+            "accSimilarity": None,
+            "perfect": bool(r.get("perfect_match")),
+            "similarity": sim,
+            "origin": "quick",
+        })
+
+    return {
+        "miolingo_export": 1,
+        "exportedAt": datetime.now().astimezone().isoformat(),
+        "vocab": vocab,
+        "practiceLog": log,
+        "settings": {},
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--email", required=True, help="user email or username")
+    ap.add_argument("--target", choices=("local", "remote"), default="local")
+    ap.add_argument("--lang", help="restrict to one language_code")
+    ap.add_argument("-o", "--out", type=Path, default=Path("miolingo-export.json"))
+    args = ap.parse_args()
+
+    tunnel, conn = _connect(args.target, _load_secrets())
+    try:
+        data = export_user(conn, args.email, args.lang)
+    finally:
+        conn.close()
+        if tunnel is not None:
+            tunnel.stop()
+
+    args.out.write_text(json.dumps(data, ensure_ascii=False, indent=1), "utf-8")
+    print(f"wrote {args.out}: {len(data['vocab'])} vocab, "
+          f"{len(data['practiceLog'])} log rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fifth milestone (bead `miolingo-opn`). The Vocabulary tab is live: add/edit/delete/sort/filter, practise-these (goPractice), CSV export, header-guarded bulk import with reasons, whole-store JSON export/import, and the one-off `export_mysql.py` for migrating the real MySQL data (`--email … [--target remote] [--lang …]`, emits the app's import format).

Notable: persisted vocab rows drop in-memory domain ids (identity = `[lang+word]`) so per-language id sequences can't collide on Dexie's global PK; and a real bug caught by the identity test — Dexie `add()` mutates its argument (writes the id back), which was polluting import data. Cloned before insert.

Gates: vitest **57/57** · tsc ✓ · build 61 kB gzip.

To migrate your data after merge: `venv/bin/python web/oracle/scripts/export_mysql.py --email <you> --target remote` then Vocabulary → ⬆ Import JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)