### PR TITLE
feat(web): M6 StoryReader — 3 modes over ONE preserved position

### DIFF
--- a/web/app/src/app/model.svelte.ts
+++ b/web/app/src/app/model.svelte.ts
@@ -9,6 +9,7 @@
 // =====================================================================
 
 import * as ps from '../domain/practiceSession.js';
+import * as story from '../domain/storyReader.js';
 import * as helmFns from '../domain/helm.js';
 import * as vocabFns from '../domain/vocabFunctions.js';
 import * as vocabTab from '../domain/vocab.js';
@@ -22,7 +23,7 @@ import type {
   Score,
   VocabEntry,
 } from '../domain/types.js';
-import { attempt, fetchMaterial, tts } from '../oracle/client.js';
+import { attempt, fetchMaterial, materialsIndex, tts } from '../oracle/client.js';
 import type { AttemptChannel, AttemptResponse } from '../oracle/types.js';
 import { db, loadHelm, saveHelm, type VocabRow } from '../store/db.js';
 
@@ -70,6 +71,22 @@ export class AppModel {
   scoring = $state(false);
   error = $state<string | null>(null);
 
+  // --- StoryReader slice (ONE narrative position; modes are affordances) --
+  storyReader = $state<story.StoryReader>(story.initialStoryReader);
+  /** Scenes for the current language, from unified stories (one file each). */
+  storyScenes = $state<Phrase[][]>([]);
+  storyLoading = $state(false);
+  lastStoryAttempt = $state<AttemptResponse | null>(null);
+
+  /** The story-content boundary: a StoryLibrary over the fetched scenes. */
+  get storyLib(): story.StoryLibrary {
+    const scenes = this.storyScenes;
+    return {
+      sceneCount: scenes.length,
+      scene: (i: number) => scenes[i] ?? [],
+    };
+  }
+
   async hydrate(): Promise<void> {
     this.helm = await loadHelm(helmFns.defaultHelm);
     await this.reloadEntries();
@@ -96,6 +113,8 @@ export class AppModel {
     await saveHelm($state.snapshot(this.helm) as helmFns.Helm);
     if (langChanged) {
       this.#sync(ps.clearMaterial(this.ps)); // stale-language queue is meaningless
+      this.storyScenes = []; // story content is per language too
+      this.#syncStory(story.initialStoryReader);
       await this.reloadEntries();
     }
   }
@@ -267,6 +286,112 @@ export class AppModel {
       });
     } catch {
       /* logging must never break the practice loop */
+    }
+  }
+
+  // --- StoryReader channels ------------------------------------------------
+  async loadStory(): Promise<void> {
+    this.storyLoading = true;
+    try {
+      const idx = await materialsIndex();
+      const sceneFiles = idx.files
+        .filter((f) => f.kind === 'stories')
+        .sort((a, b) => (a.path < b.path ? -1 : 1));
+      const source = helmFns.codeOfName(this.helm.source); // langRead
+      const docs = await Promise.all(
+        sceneFiles.map((f) => fetchMaterial<UnifiedDoc>(f.path)),
+      );
+      this.storyScenes = docs
+        .map((d) => phrasesFor(d, this.helm.target, source))
+        .filter((scene) => scene.length > 0);
+      this.#syncStory(story.initialStoryReader); // fresh narrative position
+    } catch {
+      this.storyScenes = [];
+    } finally {
+      this.storyLoading = false;
+    }
+  }
+
+  #syncStory(next: story.StoryReader): void {
+    this.storyReader = next;
+    if (next.res === null) this.lastStoryAttempt = null;
+  }
+
+  setStoryMode(m: story.StoryReader['mode']): void {
+    this.#syncStory(story.setMode(this.storyReader, m)); // preserves (scene,pos)
+  }
+
+  selectScene(s: number): void {
+    this.#syncStory(story.selectScene(this.storyReader, s)); // resets pos
+  }
+
+  storySelectItem(i: number): void {
+    this.#syncStory(story.selectItem(this.storyReader, this.storyLib, i));
+  }
+
+  storyNext(): void {
+    this.#syncStory(story.next(this.storyReader, this.storyLib));
+  }
+
+  storyPrev(): void {
+    this.#syncStory(story.prev(this.storyReader));
+  }
+
+  storyClearRecording(): void {
+    this.#syncStory(story.clearRecording(this.storyReader));
+  }
+
+  /** Story practice: the SAME loop as PSActive, over the scene's phrases,
+   * logging origin 'story' and capturing to the same VocabTable store. */
+  async storyRecordingMade(audio: Blob): Promise<void> {
+    const lib = this.storyLib;
+    const held = story.recordingMade(this.storyReader, audio);
+    if (held === this.storyReader) return; // guarded (mode/dup)
+    this.#syncStory(held);
+    this.scoring = true;
+    this.error = null;
+    try {
+      const target = story.phrasesOf(held, lib)[held.pos];
+      const res = await attempt({
+        audio,
+        target: target?.text ?? '',
+        lang: this.helm.target, // langRead
+        algorithm: 'weighted_phone',
+        whisperModel: this.helm.asrModel,
+      });
+      this.lastStoryAttempt = res;
+      this.storyReader = story.attemptMade(
+        this.storyReader,
+        channelToScore(res, res.comprehensibility),
+      );
+      await this.#logAttempt(res, 'story');
+      if (res.comprehensibility.exact && isSingleWord(res.target)) {
+        this.captureVocab({
+          word: res.target,
+          translation: target?.translation ?? null,
+          ipa: res.target_ipa,
+          sourceName: 'story',
+        });
+      }
+    } catch (e: unknown) {
+      this.error = String(e);
+      this.#syncStory(story.clearRecording(this.storyReader));
+    } finally {
+      this.scoring = false;
+    }
+  }
+
+  /** story_capture_vocab — gated on a score by the domain. */
+  storyCapture(): void {
+    const w = story.captureWord(this.storyReader, this.storyLib);
+    if (w !== null) {
+      const item = story.phrasesOf(this.storyReader, this.storyLib)[this.storyReader.pos];
+      this.captureVocab({
+        word: w,
+        translation: item?.translation ?? null,
+        ipa: item?.ipa ?? null,
+        sourceName: 'story',
+      });
     }
   }
 

--- a/web/app/src/ui/practice/PracticeView.svelte
+++ b/web/app/src/ui/practice/PracticeView.svelte
@@ -3,10 +3,11 @@
   import * as ps from '../../domain/practiceSession.js';
   import MaterialPicker from './MaterialPicker.svelte';
   import PhraseCard from './PhraseCard.svelte';
-  import Recorder from './Recorder.svelte';
-  import ScorePanel from './ScorePanel.svelte';
+  import Recorder from '../shared/Recorder.svelte';
+  import ScorePanel from '../shared/ScorePanel.svelte';
 
   const view = $derived(ps.psView(model.ps));
+  const ready = $derived(ps.psReady(model.ps));
 </script>
 
 <section>
@@ -15,7 +16,13 @@
     <p class="muted">Load a material set above, then record yourself saying each phrase.</p>
   {:else}
     <PhraseCard />
-    <Recorder />
-    <ScorePanel />
+    <Recorder
+      canRecord={ready.canRecord}
+      canClear={ready.canClearRecording}
+      busy={model.scoring}
+      onBlob={(b) => void model.recordingMade(b)}
+      onClear={() => model.clearRecording()}
+    />
+    <ScorePanel res={view.score !== null ? model.lastAttempt : null} error={model.error} />
   {/if}
 </section>

--- a/web/app/src/ui/shared/Recorder.svelte
+++ b/web/app/src/ui/shared/Recorder.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
-  // MediaRecorder → one Blob per take, sent as-is (the oracle ffmpeg-
-  // normalizes any container — webm/opus on Chrome/Firefox, mp4 on Safari).
-  // Enablement comes ONLY from the ready-set props (spec invariant).
-  import { model } from '../../app/model.svelte.js';
-  import * as ps from '../../domain/practiceSession.js';
-
-  const ready = $derived(ps.psReady(model.ps));
+  // MediaRecorder → one Blob per take (webm/opus on Chrome/Firefox, mp4 on
+  // Safari; the oracle ffmpeg-normalizes). Prop-driven so Quick Practice and
+  // Story Practice share it; enablement comes ONLY from ready-set props.
+  const {
+    canRecord,
+    canClear,
+    busy,
+    onBlob,
+    onClear,
+  }: {
+    canRecord: boolean;
+    canClear: boolean;
+    busy: boolean;
+    onBlob: (blob: Blob) => void;
+    onClear: () => void;
+  } = $props();
 
   let recording = $state(false);
   let recorder: MediaRecorder | null = null;
@@ -32,7 +41,7 @@
         const blob = new Blob(chunks, { type: recorder?.mimeType ?? 'audio/webm' });
         if (replayUrl !== null) URL.revokeObjectURL(replayUrl);
         replayUrl = URL.createObjectURL(blob);
-        void model.recordingMade(blob); // recording_made → attempt_made
+        onBlob(blob); // recording_made → attempt_made (wired by the caller)
       };
       recorder.start();
       recording = true;
@@ -47,7 +56,7 @@
   }
 
   function clear(): void {
-    model.clearRecording(); // the clear-then-record re-record idiom
+    onClear(); // the clear-then-record re-record idiom
     if (replayUrl !== null) {
       URL.revokeObjectURL(replayUrl);
       replayUrl = null;
@@ -59,17 +68,13 @@
   {#if recording}
     <button class="rec live" onclick={stop}>⏹ Stop</button>
   {:else}
-    <button class="rec" onclick={start} disabled={!ready.canRecord || model.scoring}>
-      🎙️ Record
-    </button>
+    <button class="rec" onclick={start} disabled={!canRecord || busy}>🎙️ Record</button>
   {/if}
-  <button onclick={clear} disabled={!ready.canClearRecording || model.scoring}>
-    ↺ Re-record
-  </button>
-  {#if replayUrl !== null && ready.canClearRecording}
+  <button onclick={clear} disabled={!canClear || busy}>↺ Re-record</button>
+  {#if replayUrl !== null && canClear}
     <audio src={replayUrl} controls></audio>
   {/if}
-  {#if model.scoring}
+  {#if busy}
     <span class="muted">scoring…</span>
   {/if}
   {#if micError !== null}

--- a/web/app/src/ui/shared/ScorePanel.svelte
+++ b/web/app/src/ui/shared/ScorePanel.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  // Dual-channel results: comprehensibility (what a listener understood) vs
-  // accuracy (what the mouth produced) — the GAP is the diagnostic. All
-  // numbers/diffs verbatim from the oracle's last attempt; rendering is gated
-  // on the PS view's score presence (single gating source).
-  import { model } from '../../app/model.svelte.js';
-  import * as ps from '../../domain/practiceSession.js';
-  import IpaDiff from './IpaDiff.svelte';
+  // Dual-channel results — the GAP between comprehensibility and accuracy is
+  // the diagnostic. Prop-driven (Quick Practice and Story Practice share it);
+  // everything shown comes verbatim from the oracle response.
+  import type { AttemptResponse } from '../../oracle/types.js';
+  import IpaDiff from '../practice/IpaDiff.svelte';
 
-  const view = $derived(ps.psView(model.ps));
-  const res = $derived(model.lastAttempt);
+  const {
+    res,
+    error,
+  }: { res: AttemptResponse | null; error: string | null } = $props();
 
   const pct = (x: number | null): string => (x === null ? '—' : `${Math.round(x * 100)}%`);
 </script>
 
-{#if view.score !== null && res !== null}
+{#if res !== null}
   <div class="card score">
     <p class="heard muted">
       Heard: <em>{res.recognized_text || '(nothing)'}</em>
@@ -37,9 +37,9 @@
       {/if}
     </div>
   </div>
-{:else if model.error !== null}
+{:else if error !== null}
   <div class="card">
-    <p class="errline">⚠️ {model.error}</p>
+    <p class="errline">⚠️ {error}</p>
     <p class="muted">Is the oracle running? Re-record to try again.</p>
   </div>
 {/if}

--- a/web/app/src/ui/story/StoryView.svelte
+++ b/web/app/src/ui/story/StoryView.svelte
@@ -1,7 +1,196 @@
-<section class="card">
-  <h2>📖 Story Reader</h2>
-  <p class="muted">
-    Full / scene / practice modes over one preserved narrative position arrive
-    in M6.
-  </p>
+<script lang="ts">
+  // StoryReader: ONE narrative position (scene, pos); the three modes are
+  // affordances over it — switching modes PRESERVES your place (the spec's
+  // deliberate fix over the Streamlit app's two independent loops).
+  import { model } from '../../app/model.svelte.js';
+  import * as story from '../../domain/storyReader.js';
+  import type { ReadingMode } from '../../domain/types.js';
+  import Recorder from '../shared/Recorder.svelte';
+  import ScorePanel from '../shared/ScorePanel.svelte';
+
+  const view = $derived(story.storyView(model.storyReader, model.storyLib));
+  const canCapture = $derived(story.captureWord(model.storyReader, model.storyLib) !== null);
+
+  const MODES: { value: ReadingMode; label: string }[] = [
+    { value: 'full', label: '📜 Full scene' },
+    { value: 'browse', label: '🔎 Phrase by phrase' },
+    { value: 'practice', label: '🎯 Practice' },
+  ];
+
+  $effect(() => {
+    if (model.storyScenes.length === 0 && !model.storyLoading) void model.loadStory();
+  });
+
+  let playing = $state(false);
+  async function speak(text: string): Promise<void> {
+    if (playing) return;
+    playing = true;
+    try {
+      const url = URL.createObjectURL(await model.speak(text));
+      const audio = new Audio(url);
+      audio.onended = () => {
+        URL.revokeObjectURL(url);
+        playing = false;
+      };
+      await audio.play();
+    } catch {
+      playing = false;
+    }
+  }
+</script>
+
+<section>
+  {#if model.storyLoading}
+    <p class="muted">Loading story scenes…</p>
+  {:else if model.storyScenes.length === 0}
+    <p class="muted">
+      No story scenes available for “{model.helm.target}” (or the oracle is offline).
+    </p>
+  {:else}
+    <div class="bar">
+      <label
+        >Scene
+        <select
+          value={view.scene}
+          onchange={(e) => model.selectScene(Number(e.currentTarget.value))}
+        >
+          {#each model.storyScenes as _, i (i)}
+            <option value={i}>Scene {i + 1}</option>
+          {/each}
+        </select>
+      </label>
+      <nav class="modes">
+        {#each MODES as m (m.value)}
+          <button class:active={view.mode === m.value} onclick={() => model.setStoryMode(m.value)}>
+            {m.label}
+          </button>
+        {/each}
+      </nav>
+    </div>
+
+    {#if view.mode === 'full'}
+      <div class="card prose">
+        {#each view.phrases as p, i (i)}
+          <button
+            class="inline"
+            class:current={i === view.pos}
+            onclick={() => model.storySelectItem(i)}
+            title={p.translation}>{p.text}</button
+          >
+        {/each}
+      </div>
+      <p class="muted">Click a sentence to set your place — it follows you across modes.</p>
+    {:else if view.item !== null}
+      <div class="card">
+        <div class="nav">
+          <button onclick={() => model.storyPrev()} disabled={view.pos <= 0}>←</button>
+          <span class="muted">{view.pos + 1} / {view.count}</span>
+          <button onclick={() => model.storyNext()} disabled={view.pos >= view.count - 1}>→</button>
+        </div>
+        <p class="target">{view.item.text}</p>
+        {#if view.item.ipa !== ''}<p class="ipa">[{view.item.ipa}]</p>{/if}
+        {#if view.item.translation !== ''}<p class="muted">{view.item.translation}</p>{/if}
+        <button onclick={() => view.item !== null && speak(view.item.text)} disabled={playing}>
+          🔊 Listen
+        </button>
+        {#if view.mode === 'practice'}
+          <div class="practice">
+            <Recorder
+              canRecord={!view.hasRecording}
+              canClear={view.hasRecording}
+              busy={model.scoring}
+              onBlob={(b) => void model.storyRecordingMade(b)}
+              onClear={() => model.storyClearRecording()}
+            />
+            <ScorePanel
+              res={view.score !== null ? model.lastStoryAttempt : null}
+              error={model.error}
+            />
+            {#if canCapture}
+              <button onclick={() => model.storyCapture()}>📚 Capture to vocabulary</button>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {/if}
 </section>
+
+<style>
+  .bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.9rem;
+  }
+
+  .modes {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  .modes button.active {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  select {
+    font: inherit;
+    color: inherit;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.3rem;
+  }
+
+  .prose {
+    line-height: 2;
+  }
+
+  .prose .inline {
+    border: none;
+    background: none;
+    padding: 0 0.15rem;
+    font-size: 1.05rem;
+    line-height: inherit;
+  }
+
+  .prose .inline.current {
+    background: color-mix(in srgb, var(--accent) 22%, transparent);
+    border-radius: 4px;
+  }
+
+  .nav {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .target {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0.25rem 0;
+  }
+
+  .ipa {
+    color: var(--accent);
+    margin: 0.1rem 0 0.4rem;
+  }
+
+  .practice {
+    margin-top: 0.9rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    align-items: flex-start;
+  }
+</style>

--- a/web/app/test/model.spec.ts
+++ b/web/app/test/model.spec.ts
@@ -12,7 +12,7 @@ vi.mock('../src/oracle/client.js', () => ({
   health: vi.fn(),
 }));
 
-import { attempt } from '../src/oracle/client.js';
+import { attempt, fetchMaterial, materialsIndex } from '../src/oracle/client.js';
 import { AppModel, channelToScore } from '../src/app/model.svelte.js';
 import { db } from '../src/store/db.js';
 import { phrase } from '../src/domain/types.js';
@@ -51,6 +51,7 @@ describe('AppModel wiring (stubbed oracle)', () => {
     await db.vocab.clear();
     await db.practiceLog.clear();
     await db.settings.clear();
+    vi.clearAllMocks();
     vi.mocked(attempt).mockResolvedValue(fakeResponse());
     model = new AppModel();
   });
@@ -150,6 +151,56 @@ describe('AppModel wiring (stubbed oracle)', () => {
     const ok = model.importBulk('(fr,en)\nsouris|mouse|[suʁi]');
     expect(ok).toEqual({ kind: 'ok', added: 1 });
     expect(model.entries.map((e) => e.word)).toContain('souris');
+  });
+
+  it('story: loads scenes, practises with origin=story, mode-switch preserves position', async () => {
+    vi.mocked(materialsIndex).mockResolvedValue({
+      files: [
+        { path: 'unified/stories/scene-01.json', kind: 'stories', meta: {} },
+        { path: 'unified/stories/scene-02.json', kind: 'stories', meta: {} },
+      ],
+    });
+    vi.mocked(fetchMaterial).mockImplementation((path: string) =>
+      Promise.resolve({
+        meta: { languages: ['fr', 'en'] },
+        phrases: [
+          { id: `${path}-1`, text: { fr: 'Bonjour', en: 'Hello' }, ipa: { fr: '[bɔ̃ʒuʁ]' } },
+          { id: `${path}-2`, text: { fr: 'Merci', en: 'Thanks' }, ipa: { fr: '[mɛʁsi]' } },
+        ],
+      }),
+    );
+    await model.loadStory();
+    expect(model.storyScenes).toHaveLength(2);
+
+    model.storyNext(); // pos 1
+    model.setStoryMode('practice'); // PRESERVES (scene, pos)
+    expect(model.storyReader.pos).toBe(1);
+    expect(model.storyReader.mode).toBe('practice');
+
+    vi.mocked(attempt).mockResolvedValue(fakeResponse({ target: 'Merci', target_ipa: 'mɛʁsi' }));
+    await model.storyRecordingMade(take());
+    expect(model.storyReader.res?.exactMatch).toBe(true);
+    expect(model.lastStoryAttempt).not.toBeNull();
+    expect(vi.mocked(attempt).mock.calls.at(-1)![0].target).toBe('Merci');
+
+    const log = await db.practiceLog.toArray();
+    expect(log.at(-1)!).toMatchObject({ origin: 'story', target: 'Merci' });
+
+    model.storyCapture(); // story_capture_vocab → the SAME VocabTable store
+    expect(model.entries.some((e) => e.word === 'merci')).toBe(true);
+    expect(model.storyReader.pos).toBe(1); // capture does not move the position
+
+    model.selectScene(1); // new scene → pos resets
+    expect(model.storyReader.pos).toBe(0);
+    expect(model.lastStoryAttempt).toBeNull(); // lifecycle slaved to story res
+  });
+
+  it('story recording is guarded outside practice mode', async () => {
+    model.storyScenes = [[phrase('Bonjour', 'Hello', 'bɔ̃ʒuʁ')]];
+    expect(model.storyReader.mode).toBe('browse');
+    await model.storyRecordingMade(take());
+    expect(model.storyReader.rec).toBeNull(); // guard: browse mode holds nothing
+    expect(vi.mocked(attempt)).not.toHaveBeenCalled();
   });
 
   it('channelToScore maps oracle ops onto the spec alignment shape', () => {


### PR DESCRIPTION
Sixth milestone (bead `miolingo-cb9`), **stacked on #194**. The StoryReader with the spec's signature behaviour: one narrative position, three modes as affordances, mode-switch preserves your place. Story content = the unified story scenes, per language. Practice mode is the same loop as Quick Practice (shared prop-driven Recorder/ScorePanel, origin `story` in the log, captures to the same VocabTable).

Gates: vitest **59/59** (story wiring incl. position preservation + browse-mode guard) · tsc ✓ · build 63 kB gzip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)