### PR TITLE
feat(web): M7 Statistics + History from the Dexie log

### DIFF
--- a/web/app/src/domain/statsFunctions.ts
+++ b/web/app/src/domain/statsFunctions.ts
@@ -1,0 +1,125 @@
+// =====================================================================
+// Statistics/History aggregates — pure functions over practice-log rows,
+// matching the Streamlit statistics_tab.py/history_tab.py semantics:
+// accuracy trend (+ rolling-10 mean), attempts per day, score distribution,
+// weakest phrases (≥3 attempts, mean ascending), history grouped by date.
+// Framework-free: takes a minimal row shape, not the Dexie type.
+// =====================================================================
+
+export interface AttemptLike {
+  readonly date: string; // ISO
+  readonly target: string;
+  readonly similarity: number; // 0..1 primary-channel score
+  readonly recognized?: string;
+  readonly perfect?: boolean;
+}
+
+export interface TrendPoint {
+  readonly i: number;
+  readonly date: string;
+  readonly similarity: number;
+  /** Rolling mean over the last 10 attempts up to this point. */
+  readonly rolling: number;
+}
+
+export function trendPoints(rows: readonly AttemptLike[], window = 10): TrendPoint[] {
+  const sorted = [...rows].sort((a, b) => (a.date < b.date ? -1 : 1));
+  return sorted.map((r, i) => {
+    const from = Math.max(0, i - window + 1);
+    const slice = sorted.slice(from, i + 1);
+    const rolling = slice.reduce((s, x) => s + x.similarity, 0) / slice.length;
+    return { i, date: r.date, similarity: r.similarity, rolling };
+  });
+}
+
+export interface DayCount {
+  readonly day: string; // YYYY-MM-DD
+  readonly count: number;
+}
+
+export function volumeByDay(rows: readonly AttemptLike[]): DayCount[] {
+  const counts = new Map<string, number>();
+  for (const r of rows) {
+    const day = r.date.slice(0, 10);
+    counts.set(day, (counts.get(day) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([day, count]) => ({ day, count }))
+    .sort((a, b) => (a.day < b.day ? -1 : 1));
+}
+
+/** Similarity histogram over [0,1]; a perfect 1.0 lands in the top bin. */
+export function histogram(rows: readonly AttemptLike[], bins = 20): number[] {
+  const out = new Array<number>(bins).fill(0);
+  for (const r of rows) {
+    const idx = Math.min(bins - 1, Math.max(0, Math.floor(r.similarity * bins)));
+    out[idx] = out[idx]! + 1;
+  }
+  return out;
+}
+
+export interface WeakPhrase {
+  readonly target: string;
+  readonly attempts: number;
+  readonly mean: number;
+  readonly lastDate: string;
+}
+
+export function weakestPhrases(
+  rows: readonly AttemptLike[],
+  minAttempts = 3,
+  top = 10,
+): WeakPhrase[] {
+  const groups = new Map<string, AttemptLike[]>();
+  for (const r of rows) {
+    const g = groups.get(r.target);
+    if (g === undefined) groups.set(r.target, [r]);
+    else g.push(r);
+  }
+  const out: WeakPhrase[] = [];
+  for (const [target, g] of groups) {
+    if (g.length < minAttempts) continue;
+    out.push({
+      target,
+      attempts: g.length,
+      mean: g.reduce((s, x) => s + x.similarity, 0) / g.length,
+      lastDate: g.reduce((m, x) => (x.date > m ? x.date : m), g[0]!.date),
+    });
+  }
+  return out.sort((a, b) => a.mean - b.mean).slice(0, top);
+}
+
+export interface DayGroup<T extends AttemptLike> {
+  readonly day: string;
+  readonly attempts: T[];
+}
+
+/** Last `limit` attempts, grouped by day, newest day (and attempt) first. */
+export function historyByDate<T extends AttemptLike>(rows: readonly T[], limit = 100): DayGroup<T>[] {
+  const recent = [...rows].sort((a, b) => (a.date > b.date ? -1 : 1)).slice(0, limit);
+  const groups: DayGroup<T>[] = [];
+  for (const r of recent) {
+    const day = r.date.slice(0, 10);
+    const last = groups.at(-1);
+    if (last !== undefined && last.day === day) last.attempts.push(r);
+    else groups.push({ day, attempts: [r] });
+  }
+  return groups;
+}
+
+export interface Summary {
+  readonly attempts: number;
+  readonly meanSimilarity: number | null;
+  readonly perfectCount: number;
+  readonly distinctPhrases: number;
+}
+
+export function summarize(rows: readonly AttemptLike[]): Summary {
+  return {
+    attempts: rows.length,
+    meanSimilarity:
+      rows.length === 0 ? null : rows.reduce((s, x) => s + x.similarity, 0) / rows.length,
+    perfectCount: rows.filter((r) => r.perfect === true).length,
+    distinctPhrases: new Set(rows.map((r) => r.target)).size,
+  };
+}

--- a/web/app/src/ui/history/HistoryView.svelte
+++ b/web/app/src/ui/history/HistoryView.svelte
@@ -1,4 +1,90 @@
-<section class="card">
-  <h2>📜 History</h2>
-  <p class="muted">Past practice sessions arrive in M7.</p>
+<script lang="ts">
+  // Practice history: the last 100 attempts for the current language,
+  // grouped by day, newest first — straight from the Dexie log.
+  import { model } from '../../app/model.svelte.js';
+  import { db, type PracticeLogRow } from '../../store/db.js';
+  import { historyByDate } from '../../domain/statsFunctions.js';
+
+  let rows = $state<PracticeLogRow[]>([]);
+
+  $effect(() => {
+    void db.practiceLog
+      .where('lang')
+      .equals(model.helm.target)
+      .toArray()
+      .then((r) => (rows = r));
+  });
+
+  const groups = $derived(historyByDate(rows));
+  const pct = (x: number | null): string => (x === null ? '—' : `${Math.round(x * 100)}%`);
+</script>
+
+<section>
+  <h2>📜 History — {model.helm.target}</h2>
+  {#if groups.length === 0}
+    <p class="muted">No practice attempts logged for this language yet.</p>
+  {/if}
+  {#each groups as g (g.day)}
+    <div class="card day">
+      <h3>{g.day} <span class="muted">({g.attempts.length} attempts)</span></h3>
+      <table>
+        <tbody>
+          {#each g.attempts as a, i (i)}
+            <tr>
+              <td class="time muted">{a.date.slice(11, 16)}</td>
+              <td class="target">{a.target}</td>
+              <td class="muted">{a.recognized}</td>
+              <td class="num" class:good={a.similarity >= 0.8} class:bad={a.similarity < 0.5}>
+                {pct(a.similarity)}
+              </td>
+              <td>{a.perfect === true ? '✅' : ''}</td>
+              <td class="muted">{a.origin}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/each}
 </section>
+
+<style>
+  .day {
+    margin-bottom: 0.8rem;
+  }
+
+  .day h3 {
+    margin: 0 0 0.4rem;
+    font-size: 0.95rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+  }
+
+  td {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .time {
+    white-space: nowrap;
+  }
+
+  .target {
+    font-weight: 600;
+  }
+
+  .num {
+    text-align: right;
+  }
+
+  .num.good {
+    color: var(--ok);
+  }
+
+  .num.bad {
+    color: var(--err);
+  }
+</style>

--- a/web/app/src/ui/stats/BarChart.svelte
+++ b/web/app/src/ui/stats/BarChart.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  // Generic bar chart (volume per day, score histogram) — hand-rolled SVG.
+  const {
+    values,
+    labels,
+    ariaLabel,
+  }: { values: number[]; labels: string[]; ariaLabel: string } = $props();
+
+  const W = 640;
+  const H = 140;
+  const PAD = 6;
+
+  const max = $derived(Math.max(1, ...values));
+  const bw = $derived((W - 2 * PAD) / Math.max(1, values.length));
+</script>
+
+<svg viewBox="0 0 {W} {H}" role="img" aria-label={ariaLabel}>
+  {#each values as v, i (i)}
+    <rect
+      x={PAD + i * bw + 1}
+      y={H - PAD - (v / max) * (H - 2 * PAD)}
+      width={Math.max(1, bw - 2)}
+      height={(v / max) * (H - 2 * PAD)}
+      class="bar"
+    >
+      <title>{labels[i]}: {v}</title>
+    </rect>
+  {/each}
+</svg>
+
+<style>
+  svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .bar {
+    fill: var(--accent);
+    opacity: 0.8;
+  }
+
+  .bar:hover {
+    opacity: 1;
+  }
+</style>

--- a/web/app/src/ui/stats/StatsView.svelte
+++ b/web/app/src/ui/stats/StatsView.svelte
@@ -1,4 +1,141 @@
-<section class="card">
-  <h2>📊 Statistics</h2>
-  <p class="muted">Accuracy trend, volume, distribution, and weakest phrases arrive in M7.</p>
+<script lang="ts">
+  // Statistics over the Dexie practice log for the current language —
+  // computed client-side by pure domain functions (the SQL queries the
+  // Streamlit app ran server-side, replaced).
+  import { model } from '../../app/model.svelte.js';
+  import { db, type PracticeLogRow } from '../../store/db.js';
+  import {
+    histogram,
+    summarize,
+    trendPoints,
+    volumeByDay,
+    weakestPhrases,
+  } from '../../domain/statsFunctions.js';
+  import TrendChart from './TrendChart.svelte';
+  import BarChart from './BarChart.svelte';
+
+  let rows = $state<PracticeLogRow[]>([]);
+
+  $effect(() => {
+    void db.practiceLog
+      .where('lang')
+      .equals(model.helm.target)
+      .toArray()
+      .then((r) => (rows = r));
+  });
+
+  const summary = $derived(summarize(rows));
+  const trend = $derived(trendPoints(rows));
+  const volume = $derived(volumeByDay(rows));
+  const hist = $derived(histogram(rows));
+  const weakest = $derived(weakestPhrases(rows));
+  const histLabels = $derived(hist.map((_, i) => `${i * 5}–${(i + 1) * 5}%`));
+
+  const pct = (x: number | null): string => (x === null ? '—' : `${Math.round(x * 100)}%`);
+</script>
+
+<section>
+  <h2>📊 Statistics — {model.helm.target}</h2>
+  {#if rows.length === 0}
+    <p class="muted">No practice attempts logged for this language yet.</p>
+  {:else}
+    <div class="tiles">
+      <div class="card tile"><strong>{summary.attempts}</strong><span>attempts</span></div>
+      <div class="card tile"><strong>{pct(summary.meanSimilarity)}</strong><span>mean score</span></div>
+      <div class="card tile"><strong>{summary.perfectCount}</strong><span>perfect</span></div>
+      <div class="card tile"><strong>{summary.distinctPhrases}</strong><span>phrases</span></div>
+    </div>
+
+    <div class="card chart">
+      <h3>Accuracy trend <span class="muted">(dots = attempts, line = rolling 10)</span></h3>
+      <TrendChart points={trend} />
+    </div>
+
+    <div class="card chart">
+      <h3>Practice volume <span class="muted">(attempts per day)</span></h3>
+      <BarChart
+        values={volume.map((v) => v.count)}
+        labels={volume.map((v) => v.day)}
+        ariaLabel="attempts per day"
+      />
+    </div>
+
+    <div class="card chart">
+      <h3>Score distribution</h3>
+      <BarChart values={hist} labels={histLabels} ariaLabel="score distribution" />
+    </div>
+
+    {#if weakest.length > 0}
+      <div class="card">
+        <h3>Weakest phrases <span class="muted">(≥3 attempts)</span></h3>
+        <table>
+          <thead><tr><th>phrase</th><th>attempts</th><th>mean</th><th>last tried</th></tr></thead>
+          <tbody>
+            {#each weakest as w (w.target)}
+              <tr>
+                <td>{w.target}</td>
+                <td class="num">{w.attempts}</td>
+                <td class="num">{pct(w.mean)}</td>
+                <td class="muted">{w.lastDate.slice(0, 10)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  {/if}
 </section>
+
+<style>
+  .tiles {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.8rem;
+  }
+
+  .tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 6.5rem;
+    padding: 0.6rem 1rem;
+  }
+
+  .tile strong {
+    font-size: 1.4rem;
+    color: var(--accent);
+  }
+
+  .tile span {
+    font-size: 0.8rem;
+    color: var(--fg-muted);
+  }
+
+  .chart {
+    margin-bottom: 0.8rem;
+  }
+
+  .chart h3,
+  .card h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.95rem;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .num {
+    text-align: right;
+  }
+</style>

--- a/web/app/src/ui/stats/TrendChart.svelte
+++ b/web/app/src/ui/stats/TrendChart.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  // Accuracy trend: one dot per attempt + rolling-10 mean line. Hand-rolled
+  // SVG (astro render/ style) — CSS-var theming, viewBox scaling.
+  import type { TrendPoint } from '../../domain/statsFunctions.js';
+
+  const { points }: { points: TrendPoint[] } = $props();
+
+  const W = 640;
+  const H = 160;
+  const PAD = 8;
+
+  const x = (i: number): number =>
+    points.length <= 1 ? W / 2 : PAD + (i / (points.length - 1)) * (W - 2 * PAD);
+  const y = (v: number): number => H - PAD - v * (H - 2 * PAD);
+
+  const line = $derived(points.map((p) => `${x(p.i).toFixed(1)},${y(p.rolling).toFixed(1)}`).join(' '));
+</script>
+
+<svg viewBox="0 0 {W} {H}" role="img" aria-label="accuracy trend">
+  {#each [0.5, 1.0] as g (g)}
+    <line x1={PAD} x2={W - PAD} y1={y(g)} y2={y(g)} class="grid" />
+    <text x={PAD} y={y(g) - 3} class="tick">{Math.round(g * 100)}%</text>
+  {/each}
+  {#each points as p (p.i)}
+    <circle cx={x(p.i)} cy={y(p.similarity)} r="2.4" class="dot">
+      <title>{p.date.slice(0, 16).replace('T', ' ')} — {Math.round(p.similarity * 100)}%</title>
+    </circle>
+  {/each}
+  {#if points.length > 1}
+    <polyline points={line} class="rolling" />
+  {/if}
+</svg>
+
+<style>
+  svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .grid {
+    stroke: var(--border);
+    stroke-dasharray: 3 4;
+  }
+
+  .tick {
+    fill: var(--fg-muted);
+    font-size: 9px;
+  }
+
+  .dot {
+    fill: var(--accent);
+    opacity: 0.55;
+  }
+
+  .rolling {
+    fill: none;
+    stroke: var(--ok);
+    stroke-width: 2;
+  }
+</style>

--- a/web/app/test/stats.spec.ts
+++ b/web/app/test/stats.spec.ts
@@ -1,0 +1,76 @@
+// Pure statistics aggregates (statistics_tab.py / history_tab.py semantics).
+
+import { describe, expect, it } from 'vitest';
+import {
+  histogram,
+  historyByDate,
+  summarize,
+  trendPoints,
+  volumeByDay,
+  weakestPhrases,
+} from '../src/domain/statsFunctions.js';
+
+const at = (day: string, target: string, similarity: number) => ({
+  date: `${day}T10:00:00Z`,
+  target,
+  similarity,
+});
+
+describe('statsFunctions', () => {
+  it('trendPoints sorts by date and rolls a 10-mean', () => {
+    const rows = [at('2026-07-02', 'b', 1.0), at('2026-07-01', 'a', 0.5)];
+    const t = trendPoints(rows);
+    expect(t.map((p) => p.similarity)).toEqual([0.5, 1.0]); // date order
+    expect(t[1]!.rolling).toBeCloseTo(0.75, 9);
+  });
+
+  it('volumeByDay counts per calendar day, ascending', () => {
+    const rows = [at('2026-07-02', 'a', 1), at('2026-07-01', 'a', 1), at('2026-07-02', 'b', 1)];
+    expect(volumeByDay(rows)).toEqual([
+      { day: '2026-07-01', count: 1 },
+      { day: '2026-07-02', count: 2 },
+    ]);
+  });
+
+  it('histogram bins [0,1] with 1.0 in the top bin', () => {
+    const h = histogram([at('d', 'a', 0), at('d', 'b', 0.5), at('d', 'c', 1.0)], 20);
+    expect(h[0]).toBe(1);
+    expect(h[10]).toBe(1);
+    expect(h[19]).toBe(1);
+    expect(h.reduce((s, x) => s + x, 0)).toBe(3);
+  });
+
+  it('weakestPhrases needs ≥3 attempts, ranks ascending by mean', () => {
+    const rows = [
+      ...[0.2, 0.4, 0.6].map((s) => at('2026-07-01', 'hard', s)),
+      ...[0.9, 1.0, 0.95].map((s) => at('2026-07-02', 'easy', s)),
+      at('2026-07-03', 'rare', 0.1), // only 1 attempt — excluded
+    ];
+    const w = weakestPhrases(rows);
+    expect(w.map((x) => x.target)).toEqual(['hard', 'easy']);
+    expect(w[0]!.mean).toBeCloseTo(0.4, 9);
+    expect(w[0]!.attempts).toBe(3);
+  });
+
+  it('historyByDate groups newest-first and honours the limit', () => {
+    const rows = [at('2026-07-01', 'a', 1), at('2026-07-02', 'b', 1), at('2026-07-02', 'c', 1)];
+    const g = historyByDate(rows, 2);
+    expect(g).toHaveLength(1); // limit 2 → only the newest day's two
+    expect(g[0]!.day).toBe('2026-07-02');
+    expect(g[0]!.attempts).toHaveLength(2);
+  });
+
+  it('summarize', () => {
+    const s = summarize([
+      { ...at('d', 'a', 1.0), perfect: true },
+      { ...at('d', 'a', 0.5), perfect: false },
+    ]);
+    expect(s).toEqual({
+      attempts: 2,
+      meanSimilarity: 0.75,
+      perfectCount: 1,
+      distinctPhrases: 1,
+    });
+    expect(summarize([]).meanSimilarity).toBeNull();
+  });
+});


### PR DESCRIPTION
Seventh milestone (bead `miolingo-5t8`), **stacked on #195**. Statistics and History computed client-side by pure domain functions over the Dexie practice log — trend + rolling-10 mean, volume/day, score distribution, weakest phrases (≥3 attempts), day-grouped history — rendered as hand-rolled SVG (astro convention, no chart dependency).

Gates: vitest **65/65** · tsc ✓ · build 66 kB gzip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)